### PR TITLE
dev: memory optimisation

### DIFF
--- a/src/memory.cairo
+++ b/src/memory.cairo
@@ -9,7 +9,7 @@ use integer::{
     u32_safe_divmod, u32_as_non_zero, u128_safe_divmod, u128_as_non_zero, u256_safe_div_rem,
     u256_as_non_zero
 };
-use helpers::{max};
+use cmp::{max};
 use traits::{TryInto, Into};
 use kakarot::{utils, utils::helpers};
 use option::OptionTrait;
@@ -120,7 +120,7 @@ impl MemoryImpl of MemoryTrait {
     fn store(ref self: Memory, element: u256, offset: usize) {
         let new_min_bytes_len = helpers::ceil_bytes_len_to_next_32_bytes_word(offset + 32);
 
-        self.bytes_len = helpers::max(new_min_bytes_len, self.bytes_len);
+        self.bytes_len = cmp::max(new_min_bytes_len, self.bytes_len);
 
         // Check alignment of offset to bytes16 chunks
         let (chunk_index, offset_in_chunk) = u32_safe_divmod(offset, u32_as_non_zero(16));
@@ -185,7 +185,7 @@ impl MemoryImpl of MemoryTrait {
         let new_min_bytes_len = helpers::ceil_bytes_len_to_next_32_bytes_word(
             offset + elements.len()
         );
-        let new_bytes_len = helpers::max(new_min_bytes_len, self.bytes_len);
+        let new_bytes_len = cmp::max(new_min_bytes_len, self.bytes_len);
         self.bytes_len = new_bytes_len;
 
         // Check alignment of offset to bytes16 chunks.
@@ -216,15 +216,15 @@ impl MemoryImpl of MemoryTrait {
         self.items.insert(chunk_index_i.into(), w1);
 
         // Write blocks
-        let sliced_elements = elements
+        let next_elements = elements
             .slice(16 - offset_in_chunk_i, elements.len() - 16 - offset_in_chunk_i, );
-        self.store_aligned_words(chunk_index_i + 1, chunk_index_f, sliced_elements);
+        self.store_aligned_words(chunk_index_i + 1, chunk_index_f, next_elements);
 
         // Fill last word
         let w_f = self.items.get(chunk_index_f.into());
         let w_f_l = (w_f.into() % mask_f);
-        let slice = elements.slice(elements.len() - offset_in_chunk_f, offset_in_chunk_f);
-        let x_f = helpers::load_word(offset_in_chunk_f, slice);
+        let next_elements = elements.slice(elements.len() - offset_in_chunk_f, offset_in_chunk_f);
+        let x_f = helpers::load_word(offset_in_chunk_f, next_elements);
         let w2: u128 = (x_f.into() * mask_f + w_f_l).try_into().unwrap();
         self.items.insert(chunk_index_f.into(), w2);
     }

--- a/src/memory.cairo
+++ b/src/memory.cairo
@@ -199,7 +199,7 @@ impl MemoryImpl of MemoryTrait {
 
         // Special case: within the same word.
         if chunk_index_i == chunk_index_f {
-            let w: u128 = self.items.get(offset_in_chunk_i.into());
+            let w: u128 = self.items.get(chunk_index_i.into());
             let (w_h, w_l) = u256_safe_div_rem(u256 { low: w, high: 0 }, u256_as_non_zero(mask_i));
             let (_, w_ll) = u256_safe_div_rem(w_l, u256_as_non_zero(mask_f));
             let x = helpers::load_word(elements.len(), elements);

--- a/src/memory.cairo
+++ b/src/memory.cairo
@@ -9,9 +9,9 @@ use integer::{
     u32_safe_divmod, u32_as_non_zero, u128_safe_divmod, u128_as_non_zero, u256_safe_div_rem,
     u256_as_non_zero
 };
+use helpers::{max};
 use traits::{TryInto, Into};
 use kakarot::{utils, utils::helpers};
-use helpers::{SpanExtensionTrait};
 use option::OptionTrait;
 use debug::PrintTrait;
 
@@ -120,12 +120,7 @@ impl MemoryImpl of MemoryTrait {
     fn store(ref self: Memory, element: u256, offset: usize) {
         let new_min_bytes_len = helpers::ceil_bytes_len_to_next_32_bytes_word(offset + 32);
 
-        let new_bytes_len = if new_min_bytes_len > self.bytes_len {
-            new_min_bytes_len
-        } else {
-            self.bytes_len
-        };
-        self.bytes_len = new_bytes_len;
+        self.bytes_len = helpers::max(new_min_bytes_len, self.bytes_len);
 
         // Check alignment of offset to bytes16 chunks
         let (chunk_index, offset_in_chunk) = u32_safe_divmod(offset, u32_as_non_zero(16));
@@ -190,11 +185,7 @@ impl MemoryImpl of MemoryTrait {
         let new_min_bytes_len = helpers::ceil_bytes_len_to_next_32_bytes_word(
             offset + elements.len()
         );
-        let new_bytes_len = if new_min_bytes_len > self.bytes_len {
-            new_min_bytes_len
-        } else {
-            self.bytes_len
-        };
+        let new_bytes_len = helpers::max(new_min_bytes_len, self.bytes_len);
         self.bytes_len = new_bytes_len;
 
         // Check alignment of offset to bytes16 chunks.
@@ -225,16 +216,15 @@ impl MemoryImpl of MemoryTrait {
         self.items.insert(chunk_index_i.into(), w1);
 
         // Write blocks
-        let mut elements_clone = elements.clone();
-        elements_clone.pop_front_n(elements.len() + 15 - offset_in_chunk_i);
-        self.store_aligned_words(chunk_index_i + 1, chunk_index_f, elements_clone);
+        let sliced_elements = elements
+            .slice(16 - offset_in_chunk_i, elements.len() - 16 - offset_in_chunk_i, );
+        self.store_aligned_words(chunk_index_i + 1, chunk_index_f, sliced_elements);
 
         // Fill last word
         let w_f = self.items.get(chunk_index_f.into());
         let w_f_l = (w_f.into() % mask_f);
-        let mut elements_clone = elements.clone();
-        elements_clone.pop_front_n(elements.len() - offset_in_chunk_f);
-        let x_f = helpers::load_word(offset_in_chunk_f, elements_clone);
+        let mut slice = elements.slice(0, elements.len() - offset_in_chunk_f);
+        let x_f = helpers::load_word(offset_in_chunk_f, slice);
         let w2: u128 = (x_f.into() * mask_f + w_f_l).try_into().unwrap();
         self.items.insert(chunk_index_f.into(), w2);
     }
@@ -275,7 +265,7 @@ impl MemoryImpl of MemoryTrait {
 
             self.items.insert(chunk_index.into(), current.try_into().unwrap());
             chunk_index += 1;
-            elements.pop_front_n(16);
+            elements = elements.slice(0, 16);
         }
     }
 

--- a/src/memory.cairo
+++ b/src/memory.cairo
@@ -223,7 +223,7 @@ impl MemoryImpl of MemoryTrait {
         // Fill last word
         let w_f = self.items.get(chunk_index_f.into());
         let w_f_l = (w_f.into() % mask_f);
-        let mut slice = elements.slice(0, elements.len() - offset_in_chunk_f);
+        let slice = elements.slice(elements.len() - offset_in_chunk_f, offset_in_chunk_f);
         let x_f = helpers::load_word(offset_in_chunk_f, slice);
         let w2: u128 = (x_f.into() * mask_f + w_f_l).try_into().unwrap();
         self.items.insert(chunk_index_f.into(), w2);

--- a/src/utils/helpers.cairo
+++ b/src/utils/helpers.cairo
@@ -199,12 +199,3 @@ fn reverse_array<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>>(src: Span<T>) -> A
     };
     dst
 }
-
-#[inline(always)]
-fn max(a: usize, b: usize) -> usize {
-    return if a > b {
-        a
-    } else {
-        b
-    };
-}

--- a/src/utils/helpers.cairo
+++ b/src/utils/helpers.cairo
@@ -75,19 +75,19 @@ fn split_word(mut value: u256, mut len: usize, ref dst: Array<u8>) {
 /// Splits a u256 into `len` bytes, little-endian, and returns the bytes array.
 fn split_word_little(mut value: u256, mut len: usize) -> Array<u8> {
     let mut dst: Array<u8> = ArrayTrait::new();
+    let base = 256;
+    let bound = 256;
     loop {
         if len == 0 {
             assert(value == 0, 'split_words:value not 0');
             break ();
         }
 
-        let base = 256;
-        let bound = 256;
         let low_part = (value % constants::FELT252_PRIME) % base;
         dst.append(low_part.try_into().unwrap());
 
-        len = len - 1;
         value = (value - low_part) / 256;
+        len -= 1;
     };
     dst
 }
@@ -137,13 +137,13 @@ fn load_word(mut len: usize, words: Span<u8>) -> u256 {
 /// The bytes array representation of the value.
 fn u256_to_bytes_array(mut value: u256) -> Array<u8> {
     let mut counter = 0;
-    let mut bytes_vec: Array<u8> = ArrayTrait::new();
+    let mut bytes_arr: Array<u8> = ArrayTrait::new();
     // low part
     loop {
         if counter == 16 {
             break ();
         }
-        bytes_vec.append((value.low % 256).try_into().unwrap());
+        bytes_arr.append((value.low % 256).try_into().unwrap());
         value.low /= 256;
         counter += 1;
     };
@@ -154,22 +154,22 @@ fn u256_to_bytes_array(mut value: u256) -> Array<u8> {
         if counter == 16 {
             break ();
         }
-        bytes_vec.append((value.high % 256).try_into().unwrap());
+        bytes_arr.append((value.high % 256).try_into().unwrap());
         value.high /= 256;
         counter += 1;
     };
 
     // Reverse the array as memory is arranged in big endian order.
-    let mut counter = bytes_vec.len();
-    let mut bytes_vec_reversed: Array<u8> = ArrayTrait::new();
+    let mut counter = bytes_arr.len();
+    let mut bytes_arr_reversed: Array<u8> = ArrayTrait::new();
     loop {
         if counter == 0 {
             break ();
         }
-        bytes_vec_reversed.append(*bytes_vec[counter - 1]);
+        bytes_arr_reversed.append(*bytes_arr[counter - 1]);
         counter -= 1;
     };
-    bytes_vec_reversed
+    bytes_arr_reversed
 }
 
 
@@ -200,43 +200,11 @@ fn reverse_array<T, impl TCopy: Copy<T>, impl TDrop: Drop<T>>(src: Span<T>) -> A
     dst
 }
 
-
-//TODO(eni) make PR and add this in corelib
-
-trait SpanExtensionTrait<T> {
-    fn pop_front_n(ref self: Span<T>, n: usize);
-}
-
-impl SpanExtensionImpl<T> of SpanExtensionTrait<T> {
-    /// Removes the first `n` elements from the Span.
-    fn pop_front_n(ref self: Span<T>, mut n: usize) {
-        loop {
-            if n == 0 {
-                break ();
-            }
-            self.pop_front();
-            n = n - 1;
-        };
-    }
-}
-
-impl U128IntoU256 of Into<u128, u256> {
-    fn into(self: u128) -> u256 {
-        u256 { low: self, high: 0 }
-    }
-}
-
-impl U32IntoU256 of Into<u32, u256> {
-    fn into(self: u32) -> u256 {
-        u256 { low: self.into(), high: 0 }
-    }
-}
-
-impl U256TryIntoU128 of TryInto<u256, u128> {
-    fn try_into(self: u256) -> Option<u128> {
-        if self.high != 0 {
-            return Option::None(());
-        }
-        Option::Some(self.low)
-    }
+#[inline(always)]
+fn max(a: usize, b: usize) -> usize {
+    return if a > b {
+        a
+    } else {
+        b
+    };
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Optimised `store_n` memory function by getting rid of useless array cloning and using newly introduced Span `slice` methods.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Gas usage results:


Before change
```shell
❯ scarb test -f test_store_should_add_n_elements_to_the_memory
testing kakarot ...
running 1 tests
[DEBUG]	                               	(raw: 0x1eb2e8

test kakarot::tests::test_memory::test_store_should_add_n_elements_to_the_memory ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 37 filtered out;
```

```shell

After change
❯ scarb test -f test_store_should_add_n_elements_to_the_memory
testing kakarot ...
running 1 tests
[DEBUG]	-V                            	(raw: 0x182d56

test kakarot::tests::test_memory::test_store_should_add_n_elements_to_the_memory ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 37 filtered out;
```

Which is a 21% decrease
<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
