### PR TITLE
feat: Opcode 0x0A - EXP

### DIFF
--- a/src/memory.cairo
+++ b/src/memory.cairo
@@ -120,7 +120,7 @@ impl MemoryImpl of MemoryTrait {
         // Store aligned bytes in [initial_chunk + 1, final_chunk - 1].
         let aligned_bytes = elements
             .slice(
-                16 - offset_in_chunk_i, elements.len() - 16 - offset_in_chunk_i - offset_in_chunk_f,
+                16 - offset_in_chunk_i, elements.len() - 16 - offset_in_chunk_i - offset_in_chunk_f, 
             );
         self._store_aligned_words(initial_chunk + 1, aligned_bytes);
 

--- a/src/memory.cairo
+++ b/src/memory.cairo
@@ -10,7 +10,7 @@ use integer::{
 };
 use cmp::{max};
 use traits::{TryInto, Into};
-use kakarot::{utils, utils::helpers};
+use kakarot::{utils, utils::helpers, utils::math::Exponentiation};
 use option::OptionTrait;
 use debug::PrintTrait;
 
@@ -120,7 +120,7 @@ impl MemoryImpl of MemoryTrait {
         // Store aligned bytes in [initial_chunk + 1, final_chunk - 1].
         let aligned_bytes = elements
             .slice(
-                16 - offset_in_chunk_i, elements.len() - 16 - offset_in_chunk_i - offset_in_chunk_f, 
+                16 - offset_in_chunk_i, elements.len() - 16 - offset_in_chunk_i - offset_in_chunk_f,
             );
         self._store_aligned_words(initial_chunk + 1, aligned_bytes);
 
@@ -196,7 +196,7 @@ impl InternalMemoryMethods of InternalMemoryTrait {
     /// * `offset_in_chunk` - The offset within the memory chunk to store the element at.
     fn _store_element(ref self: Memory, element: u256, chunk_index: usize, offset_in_chunk: u32) {
         let mask: u256 = helpers::pow256_rev(offset_in_chunk);
-        let mask_c: u256 = helpers::pow(256, 16).into() / mask;
+        let mask_c: u256 = 256.pow(16).into() / mask;
 
         // Split the 2 input bytes16 chunks at offset_in_chunk.
         let (el_hh, el_hl) = u256_safe_div_rem(element.high.into(), u256_as_non_zero(mask_c));
@@ -264,22 +264,22 @@ impl InternalMemoryMethods of InternalMemoryTrait {
                 break ();
             }
 
-            let current: felt252 = ((*elements[0]).into() * helpers::pow(256, 15)
-                + (*elements[1]).into() * helpers::pow(256, 14)
-                + (*elements[2]).into() * helpers::pow(256, 13)
-                + (*elements[3]).into() * helpers::pow(256, 12)
-                + (*elements[4]).into() * helpers::pow(256, 11)
-                + (*elements[5]).into() * helpers::pow(256, 10)
-                + (*elements[6]).into() * helpers::pow(256, 9)
-                + (*elements[7]).into() * helpers::pow(256, 8)
-                + (*elements[8]).into() * helpers::pow(256, 7)
-                + (*elements[9]).into() * helpers::pow(256, 6)
-                + (*elements[10]).into() * helpers::pow(256, 5)
-                + (*elements[11]).into() * helpers::pow(256, 4)
-                + (*elements[12]).into() * helpers::pow(256, 3)
-                + (*elements[13]).into() * helpers::pow(256, 2)
-                + (*elements[14]).into() * helpers::pow(256, 1)
-                + (*elements[15]).into() * helpers::pow(256, 0));
+            let current: felt252 = ((*elements[0]).into() * 256.pow(15)
+                + (*elements[1]).into() * 256.pow(14)
+                + (*elements[2]).into() * 256.pow(13)
+                + (*elements[3]).into() * 256.pow(12)
+                + (*elements[4]).into() * 256.pow(11)
+                + (*elements[5]).into() * 256.pow(10)
+                + (*elements[6]).into() * 256.pow(9)
+                + (*elements[7]).into() * 256.pow(8)
+                + (*elements[8]).into() * 256.pow(7)
+                + (*elements[9]).into() * 256.pow(6)
+                + (*elements[10]).into() * 256.pow(5)
+                + (*elements[11]).into() * 256.pow(4)
+                + (*elements[12]).into() * 256.pow(3)
+                + (*elements[13]).into() * 256.pow(2)
+                + (*elements[14]).into() * 256.pow(1)
+                + (*elements[15]).into() * 256.pow(0));
 
             self.items.insert(chunk_index.into(), current.try_into().unwrap());
             chunk_index += 1;
@@ -349,7 +349,7 @@ impl InternalMemoryMethods of InternalMemoryTrait {
         // Compute mask.
 
         let mask: u256 = helpers::pow256_rev(offset_in_chunk);
-        let mask_c: u256 = helpers::pow(2, 128).into() / mask;
+        let mask_c: u256 = 2.pow(128).into() / mask;
 
         // Read the words at chunk_index, +1, +2.
         let w0: u128 = self.items.get(chunk_index.into());

--- a/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -3,10 +3,11 @@ use kakarot::instructions::StopAndArithmeticOperationsTrait;
 use kakarot::stack::StackTrait;
 use option::OptionTrait;
 use integer::BoundedInt;
+use traits::{TryInto, Into};
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_stop() {
+fn test_exec_stop() {
     // Given
     let mut ctx = setup_execution_context();
 
@@ -19,7 +20,7 @@ fn test__exec_stop() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_add() {
+fn test_exec_add() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(1);
@@ -37,7 +38,7 @@ fn test__exec_add() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_add_overflow() {
+fn test_exec_add_overflow() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(BoundedInt::<u256>::max());
@@ -53,7 +54,7 @@ fn test__exec_add_overflow() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_mul() {
+fn test_exec_mul() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(4);
@@ -69,7 +70,7 @@ fn test__exec_mul() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_mul_overflow() {
+fn test_exec_mul_overflow() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(BoundedInt::<u256>::max());
@@ -85,7 +86,7 @@ fn test__exec_mul_overflow() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_sub() {
+fn test_exec_sub() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(7);
@@ -101,7 +102,7 @@ fn test__exec_sub() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_sub_underflow() {
+fn test_exec_sub_underflow() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(1);
@@ -118,7 +119,7 @@ fn test__exec_sub_underflow() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_div() {
+fn test_exec_div() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(4);
@@ -134,7 +135,7 @@ fn test__exec_div() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_div_by_zero() {
+fn test_exec_div_by_zero() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(0);
@@ -147,57 +148,6 @@ fn test__exec_div_by_zero() {
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 0');
 }
-
-#[test]
-#[available_gas(20000000)]
-fn test__exec_mod() {
-    // Given
-    let mut ctx = setup_execution_context();
-    ctx.stack.push(6);
-    ctx.stack.push(100);
-
-    // When
-    ctx.exec_mod();
-
-    // Then
-    assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.peek().unwrap() == 4, 'stack top should be 100%6');
-}
-
-#[test]
-#[available_gas(20000000)]
-fn test__exec_addmod() {
-    // Given
-    let mut ctx = setup_execution_context();
-    ctx.stack.push(7);
-    ctx.stack.push(10);
-    ctx.stack.push(20);
-
-    // When
-    ctx.exec_addmod();
-
-    // Then
-    assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.peek().unwrap() == 2, 'stack top should be (10+20)%7');
-}
-
-#[test]
-#[available_gas(20000000)]
-fn test__exec_addmod_overflow() {
-    // Given
-    let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::<u256>::max());
-    ctx.stack.push(101);
-    ctx.stack.push(BoundedInt::<u256>::max());
-
-    // When
-    ctx.exec_addmod();
-
-    // Then
-    assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.peek().unwrap() == 100, 'stack top should be 100');
-}
-
 
 #[test]
 #[available_gas(20000000)]
@@ -233,7 +183,7 @@ fn test__exec_sdiv_neg() {
 
 #[test]
 #[available_gas(20000000)]
-fn test__exec_sdiv_by_0() {
+fn test_exec_sdiv_by_0() {
     // Given
     let mut ctx = setup_execution_context();
     ctx.stack.push(0);
@@ -247,3 +197,120 @@ fn test__exec_sdiv_by_0() {
     assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 0');
 }
 
+#[test]
+#[available_gas(20000000)]
+fn test_exec_mod() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(6);
+    ctx.stack.push(100);
+
+    // When
+    ctx.exec_mod();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 4, 'stack top should be 100%6');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_exec_mod_by_zero() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(0);
+    ctx.stack.push(100);
+
+    // When
+    ctx.exec_mod();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 100%6');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_exec_addmod() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(7);
+    ctx.stack.push(10);
+    ctx.stack.push(20);
+
+    // When
+    ctx.exec_addmod();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 2, 'stack top should be (10+20)%7');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_exec_addmod_by_zero() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(0);
+    ctx.stack.push(10);
+    ctx.stack.push(20);
+
+    // When
+    ctx.exec_addmod();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 0');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+fn test_exec_addmod_overflow() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(101);
+    ctx.stack.push(BoundedInt::<u256>::max());
+
+    // When
+    ctx.exec_addmod();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 100, 'stack top should be 100');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_exec_exp() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(2);
+    ctx.stack.push(10);
+
+    // When
+    ctx.exec_exp();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 100, 'stack top should be 100');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_exec_exp_overflow() {
+    // Given
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(2);
+    ctx.stack.push(BoundedInt::<u128>::max().into() + 1);
+
+    // When
+    ctx.exec_exp();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(
+        ctx.stack.peek().unwrap() == 0, 'stack top should be 0'
+    ); // (2^128)^2 = 2^256 = 0 % 2^256
+}

--- a/src/tests/test_memory.cairo
+++ b/src/tests/test_memory.cairo
@@ -86,12 +86,9 @@ fn test__load__should_load_an_element_from_the_memory() {
     let second_value = u256 { low: 4, high: 3 };
     let first_bytes_array = helpers::u256_to_bytes_array(first_value);
     let second_bytes_array = helpers::u256_to_bytes_array(second_value);
-    let x = testing::get_available_gas();
-    gas::withdraw_gas().unwrap();
     memory.store_n(first_bytes_array.span(), 0);
 
     memory.store_n(second_bytes_array.span(), 32);
-    (x - testing::get_available_gas()).print();
 
     // When
     let result: u256 = memory._load(0);

--- a/src/tests/test_memory.cairo
+++ b/src/tests/test_memory.cairo
@@ -1,7 +1,8 @@
 use core::dict::Felt252DictTrait;
 use core::debug::PrintTrait;
 use kakarot::memory::{MemoryTrait, InternalMemoryTrait, MemoryPrintTrait};
-use kakarot::{utils, utils::helpers};
+use kakarot::utils::{math::Exponentiation, helpers};
+use kakarot::utils;
 use array::{ArrayTrait, SpanTrait};
 use traits::{Into, TryInto};
 use option::OptionTrait;
@@ -85,10 +86,12 @@ fn test__load__should_load_an_element_from_the_memory() {
     let second_value = u256 { low: 4, high: 3 };
     let first_bytes_array = helpers::u256_to_bytes_array(first_value);
     let second_bytes_array = helpers::u256_to_bytes_array(second_value);
-
+    let x = testing::get_available_gas();
+    gas::withdraw_gas().unwrap();
     memory.store_n(first_bytes_array.span(), 0);
 
     memory.store_n(second_bytes_array.span(), 32);
+    (x - testing::get_available_gas()).print();
 
     // When
     let result: u256 = memory._load(0);
@@ -133,23 +136,21 @@ fn _load_should_load_an_element_from_the_memory_with_offset(offset: usize, low: 
 #[available_gas(200000000)]
 fn test__load__should_load_an_element_from_the_memory_with_offset_1() {
     _load_should_load_an_element_from_the_memory_with_offset(
-        8, 2 * helpers::pow(256, 8).try_into().unwrap(), helpers::pow(256, 8).try_into().unwrap()
+        8, 2 * 256.pow(8).try_into().unwrap(), 256.pow(8).try_into().unwrap()
     );
 }
 #[test]
 #[available_gas(200000000)]
 fn test__load__should_load_an_element_from_the_memory_with_offset_2() {
     _load_should_load_an_element_from_the_memory_with_offset(
-        7, 2 * helpers::pow(256, 7).try_into().unwrap(), helpers::pow(256, 7).try_into().unwrap()
+        7, 2 * 256.pow(7).try_into().unwrap(), 256.pow(7).try_into().unwrap()
     );
 }
 #[test]
 #[available_gas(200000000)]
 fn test__load__should_load_an_element_from_the_memory_with_offset_3() {
     _load_should_load_an_element_from_the_memory_with_offset(
-        23,
-        3 * helpers::pow(256, 7).try_into().unwrap(),
-        2 * helpers::pow(256, 7).try_into().unwrap()
+        23, 3 * 256.pow(7).try_into().unwrap(), 2 * 256.pow(7).try_into().unwrap()
     );
 }
 
@@ -157,16 +158,14 @@ fn test__load__should_load_an_element_from_the_memory_with_offset_3() {
 #[available_gas(200000000)]
 fn test__load__should_load_an_element_from_the_memory_with_offset_4() {
     _load_should_load_an_element_from_the_memory_with_offset(
-        33,
-        4 * helpers::pow(256, 1).try_into().unwrap(),
-        3 * helpers::pow(256, 1).try_into().unwrap()
+        33, 4 * 256.pow(1).try_into().unwrap(), 3 * 256.pow(1).try_into().unwrap()
     );
 }
 #[test]
 #[available_gas(200000000)]
 fn test__load__should_load_an_element_from_the_memory_with_offset_5() {
     _load_should_load_an_element_from_the_memory_with_offset(
-        63, 0, 4 * helpers::pow(256, 15).try_into().unwrap()
+        63, 0, 4 * 256.pow(15).try_into().unwrap()
     );
 }
 

--- a/src/tests/test_utils.cairo
+++ b/src/tests/test_utils.cairo
@@ -7,6 +7,7 @@ use kakarot::context::{CallContext, CallContextTrait, ExecutionContext, Executio
 
 mod test_helpers;
 mod test_u256_signed_math;
+mod test_math;
 
 fn starknet_address() -> ContractAddress {
     'starknet_address'.try_into().unwrap()

--- a/src/tests/test_utils/test_math.cairo
+++ b/src/tests/test_utils/test_math.cairo
@@ -1,0 +1,25 @@
+use kakarot::utils::math::{Exponentiation, ExponentiationModulo};
+
+#[test]
+#[available_gas(20000000)]
+fn test_pow_mod() {
+    assert(5_u256.pow_mod(10) == 9765625, '5^10 should be 9765625');
+    assert(2_u256.pow_mod(256) == 0, 'should wrap to 0');
+    assert(123456_u256.pow_mod(0) == 1, 'n^0 should be 1');
+    assert(0_u256.pow_mod(123456) == 0, '0^n should be 0');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_pow() {
+    assert(5_u256.pow(10) == 9765625, '5^10 should be 9765625');
+    assert(123456_u256.pow(0) == 1, 'n^0 should be 1');
+    assert(0_u256.pow(123456) == 0, '0^n should be 0');
+}
+
+#[test]
+#[should_panic]
+#[available_gas(2000000)]
+fn test_pow_should_overflow() {
+    assert(2_u256.pow(256) == 0, 'should overflow');
+}

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -5,4 +5,5 @@ use option::OptionTrait;
 mod helpers;
 mod constants;
 mod u256_signed_math;
+mod math;
 

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,3 +1,5 @@
+use integer::u256_overflow_mul;
+
 trait Exponentiation<T> {
     // Raise a number to a power.
     /// * `base` - The number to raise.
@@ -9,6 +11,9 @@ trait Exponentiation<T> {
 
 impl U256ExpImpl of Exponentiation<u256> {
     fn pow(self: u256, exp: u256) -> u256 {
+        if self == 0 {
+            return 0;
+        }
         if exp == 0 {
             return 1;
         } else {
@@ -19,10 +24,43 @@ impl U256ExpImpl of Exponentiation<u256> {
 
 impl Felt252ExpImpl of Exponentiation<felt252> {
     fn pow(self: felt252, exp: felt252) -> felt252 {
+        if self == 0 {
+            return 0;
+        }
         if exp == 0 {
             return 1;
         } else {
             return self * Exponentiation::pow(self, exp - 1);
         }
+    }
+}
+
+
+trait ExponentiationModulo<T> {
+    // Raise a number to a power modulo MAX<T> (max value of type T).
+    // Instead of explicitly providing a modulo, we use overflowing functions
+    // from the core library, which wrap around when overflowing.
+    /// * `base` - The number to raise.
+    /// * `exp` - The exponent.
+    /// # Returns
+    /// * `T` - The result of base raised to the power of exp modulo MAX<T>.
+    fn pow_mod(self: T, exponent: T) -> T;
+}
+
+impl U256ExpModImpl of ExponentiationModulo<u256> {
+    fn pow_mod(self: u256, mut exponent: u256) -> u256 {
+        if self == 0 {
+            return 0;
+        }
+        let mut result = 1;
+        loop {
+            if exponent == 0 {
+                break;
+            }
+            let (new_result, _) = u256_overflow_mul(result, self);
+            result = new_result;
+            exponent -= 1;
+        };
+        result
     }
 }

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,0 +1,28 @@
+trait Exponentiation<T> {
+    // Raise a number to a power.
+    /// * `base` - The number to raise.
+    /// * `exp` - The exponent.
+    /// # Returns
+    /// * `T` - The result of base raised to the power of exp.
+    fn pow(self: T, exp: T) -> T;
+}
+
+impl U256ExpImpl of Exponentiation<u256> {
+    fn pow(self: u256, exp: u256) -> u256 {
+        if exp == 0 {
+            return 1;
+        } else {
+            return self * Exponentiation::pow(self, exp - 1);
+        }
+    }
+}
+
+impl Felt252ExpImpl of Exponentiation<felt252> {
+    fn pow(self: felt252, exp: felt252) -> felt252 {
+        if exp == 0 {
+            return 1;
+        } else {
+            return self * Exponentiation::pow(self, exp - 1);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #72, Closes #73 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- mod-related opcodes are now wrapping back to 0 instead of overflowing
- implements the 0x0A-EXP opcode (modulo 256 exponentiation)
- Re-ordered test functions so that they match the opcode numbers and implementation order 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
