### PR TITLE
feat: 0x09-MULMOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ and this project adheres to
 
 ### Added
 
+- opcodes: add 0x09-MULMOD opcode
 - ci: add `CHANGELOG.md` and enforce it is edited for each PR on `main`

--- a/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -283,6 +283,72 @@ fn test_exec_addmod_overflow() {
 
 #[test]
 #[available_gas(20000000)]
+fn test_mulmod_basic() {
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(10);
+    ctx.stack.push(7);
+    ctx.stack.push(5);
+
+    // When
+    let x = testing::get_available_gas();
+    gas::withdraw_gas().unwrap();
+    ctx.exec_mulmod();
+    (x - testing::get_available_gas()).print();
+
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 5, 'stack top should be 5'); // 5 * 7 % 10 = 5
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_mulmod_zero_modulus() {
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(0);
+    ctx.stack.push(7);
+    ctx.stack.push(5);
+
+    ctx.exec_mulmod();
+
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 0'); // modulus is 0
+}
+
+use debug::PrintTrait;
+#[test]
+#[available_gas(20000000)]
+fn test_mulmod_overflow() {
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(12);
+    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(BoundedInt::<u256>::max());
+
+    let x = testing::get_available_gas();
+    gas::withdraw_gas().unwrap();
+    ctx.exec_mulmod();
+    (x - testing::get_available_gas()).print();
+
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(
+        ctx.stack.peek().unwrap() == 9, 'stack top should be 1'
+    ); // (MAX_U256 * MAX_U256) % 12 = 9
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_mulmod_zero() {
+    let mut ctx = setup_execution_context();
+    ctx.stack.push(10);
+    ctx.stack.push(7);
+    ctx.stack.push(0);
+
+    ctx.exec_mulmod();
+
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 0'); // 0 * 7 % 10 = 0
+}
+
+#[test]
+#[available_gas(20000000)]
 fn test_exec_exp() {
     // Given
     let mut ctx = setup_execution_context();

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,4 +1,4 @@
-use integer::u256_overflow_mul;
+use integer::{u256_overflow_mul};
 
 trait Exponentiation<T> {
     // Raise a number to a power.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #4 Closes #63

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Implements the MULMOD opcode
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

I tried two different implementations for this MULMOD opcode, leveraging the fact that `// (x * y) mod N <=> (x mod N) * (y mod N) mod N` 

The first try was using u256_wide_mul to avoid overflowing on the a*b multiplication, and then dividing it by N and returning the remainder.

```rust
 fn exec_mulmod(ref self: ExecutionContext) {
        let popped = self.stack.pop_n(3);

        let n: u256 = *popped[2];
        let mut result = 0;
        if n != 0 {
            result = u256_mul_mod(*popped[0], *popped[1], n.try_into().unwrap())
        }
        self.stack.push(result);
    }  fn u256_mul_mod(a: u256, b: u256, n: NonZero<u256>) -> u256 {
    let wide_product = u256_wide_mul(a, b);
    let (_, r) = u512_safe_div_rem_by_u256(wide_product, n);
    r
} 
```

Here is the test output 
```shell
Running tests for package: kakarot
testing kakarot ...
running 1 tests
[DEBUG]	                               	(raw: 0x417b2

test kakarot::tests::test_instructions::test_stop_and_arithmetic_operations::test_mulmod_overflow ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 75 filtered out;
```


The other implementation is the one that I kept for the PR

```rust
 fn exec_mulmod(ref self: ExecutionContext) {
        let popped = self.stack.pop_n(3);

        let n: u256 = *popped[2];
        let mut result = 0;
        if n != 0 {
            // (x * y) mod N <=> (x mod N) * (y mod N) mod N
            // It is more gas-efficient than to use u256_wide_mul
            result = (*popped[0] % n) * (*popped[1] % n) % n;
        }
        self.stack.push(result);
    }
 ```
 
 Here is the test output
 ```shell
 ❯ scarb test -f test_mulmod_overflow
Running tests for package: kakarot
testing kakarot ...
running 1 tests
[DEBUG]	                               	(raw: 0x40dd0

test kakarot::tests::test_instructions::test_stop_and_arithmetic_operations::test_mulmod_overflow ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 75 filtered out;
```

That second version is a bit less gas-consuming than the first one and is the one implemented in this PR.
    
