### PR TITLE
fix: addmod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ and this project adheres to
 
 ### Added
 
+- fix: ADDMOD opcode
 - opcodes: add 0x09-MULMOD opcode
 - ci: add `CHANGELOG.md` and enforce it is edited for each PR on `main`

--- a/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/instructions/stop_and_arithmetic_operations.cairo
@@ -130,6 +130,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         let n: u256 = *popped[2];
         let mut result = 0;
         if n != 0 {
+            // This is more gas efficient than computing (a mod N) + (b mod N) mod N
             let add_res = u256_wide_add(*popped[0], *popped[1]);
             let (_, r) = u512_safe_div_rem_by_u256(add_res, n.try_into().unwrap());
             result = r;

--- a/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/instructions/stop_and_arithmetic_operations.cairo
@@ -132,6 +132,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         if n != 0 {
             // This is more gas efficient than computing (a mod N) + (b mod N) mod N
             let add_res = u256_wide_add(*popped[0], *popped[1]);
+            // Won't panic since 0 case is handled manually
             let (_, r) = u512_safe_div_rem_by_u256(add_res, n.try_into().unwrap());
             result = r;
         }

--- a/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -280,7 +280,7 @@ fn test_exec_addmod_overflow() {
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(
         ctx.stack.peek().unwrap() == 2, 'stack top should be 2'
-    ); // (MAX_U256 + 2) % 3 = 2^256 + 1 % 3 = 2
+    ); // (MAX_U256 + 2) % 3 = (2^256 + 1) % 3 = 2
 }
 
 #[test]

--- a/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -295,7 +295,7 @@ fn test_mulmod_basic() {
     ctx.exec_mulmod();
 
     assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.peek().unwrap() == 5, 'stack top should be 5'); // 5 * 7 % 10 = 5
+    assert(ctx.stack.peek().unwrap() == 5, 'stack top should be 5'); // (5 * 7) % 10 = 5
 }
 
 #[test]

--- a/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -269,16 +269,19 @@ fn test_exec_addmod_by_zero() {
 fn test_exec_addmod_overflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::<u256>::max());
-    ctx.stack.push(101);
+    ctx.stack.push(2);
+    ctx.stack.push(2);
     ctx.stack.push(BoundedInt::<u256>::max());
 
     // When
+    let x = testing::get_available_gas();
+    gas::withdraw_gas().unwrap();
     ctx.exec_addmod();
+    (x - testing::get_available_gas()).print();
 
     // Then
     assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.peek().unwrap() == 100, 'stack top should be 100');
+    assert(ctx.stack.peek().unwrap() == 1, 'stack top should be 1');
 }
 
 #[test]

--- a/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -269,19 +269,18 @@ fn test_exec_addmod_by_zero() {
 fn test_exec_addmod_overflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(2);
+    ctx.stack.push(3);
     ctx.stack.push(2);
     ctx.stack.push(BoundedInt::<u256>::max());
 
     // When
-    let x = testing::get_available_gas();
-    gas::withdraw_gas().unwrap();
     ctx.exec_addmod();
-    (x - testing::get_available_gas()).print();
 
     // Then
     assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.peek().unwrap() == 1, 'stack top should be 1');
+    assert(
+        ctx.stack.peek().unwrap() == 2, 'stack top should be 2'
+    ); // (MAX_U256 + 2) % 3 = 2^256 + 1 % 3 = 2
 }
 
 #[test]
@@ -293,10 +292,7 @@ fn test_mulmod_basic() {
     ctx.stack.push(5);
 
     // When
-    let x = testing::get_available_gas();
-    gas::withdraw_gas().unwrap();
     ctx.exec_mulmod();
-    (x - testing::get_available_gas()).print();
 
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(ctx.stack.peek().unwrap() == 5, 'stack top should be 5'); // 5 * 7 % 10 = 5
@@ -316,7 +312,6 @@ fn test_mulmod_zero_modulus() {
     assert(ctx.stack.peek().unwrap() == 0, 'stack top should be 0'); // modulus is 0
 }
 
-use debug::PrintTrait;
 #[test]
 #[available_gas(20000000)]
 fn test_mulmod_overflow() {
@@ -325,10 +320,7 @@ fn test_mulmod_overflow() {
     ctx.stack.push(BoundedInt::<u256>::max());
     ctx.stack.push(BoundedInt::<u256>::max());
 
-    let x = testing::get_available_gas();
-    gas::withdraw_gas().unwrap();
     ctx.exec_mulmod();
-    (x - testing::get_available_gas()).print();
 
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(

--- a/src/tests/test_utils/test_math.cairo
+++ b/src/tests/test_utils/test_math.cairo
@@ -1,4 +1,5 @@
-use kakarot::utils::math::{Exponentiation, ExponentiationModulo};
+use integer::{u256_overflowing_add, BoundedInt, u512};
+use kakarot::utils::math::{Exponentiation, ExponentiationModulo, u256_wide_add};
 
 #[test]
 #[available_gas(20000000)]
@@ -22,4 +23,55 @@ fn test_pow() {
 #[available_gas(2000000)]
 fn test_pow_should_overflow() {
     assert(2_u256.pow(256) == 0, 'should overflow');
+}
+
+
+#[test]
+#[available_gas(2000000)]
+fn test_wide_add_basic() {
+    let a = 1000;
+    let b = 500;
+
+    let (sum, overflow) = u256_overflowing_add(a, b);
+
+    let expected = u512 { limb0: 1500, limb1: 0, limb2: 0, limb3: 0,  };
+
+    let result = u256_wide_add(a, b);
+
+    assert(!overflow, 'shouldnt overflow');
+    assert(result == expected, 'wrong result');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_wide_add_overflow() {
+    let a = BoundedInt::<u256>::max();
+    let b = 1;
+
+    let (sum, overflow) = u256_overflowing_add(a, b);
+
+    let expected = u512 { limb0: 0, limb1: 0, limb2: 1, limb3: 0,  };
+
+    let result = u256_wide_add(a, b);
+
+    assert(overflow, 'should overflow');
+    assert(result == expected, 'wrong result');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_wide_add_max_values() {
+    let a = BoundedInt::<u256>::max();
+    let b = BoundedInt::<u256>::max();
+
+    let expected = u512 {
+        limb0: 0xfffffffffffffffffffffffffffffffe,
+        limb1: 0xffffffffffffffffffffffffffffffff,
+        limb2: 1,
+        limb3: 0,
+    };
+
+    let result = u256_wide_add(a, b);
+
+    assert(result == expected, 'wrong result');
 }

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -65,6 +65,10 @@ impl U256ExpModImpl of ExponentiationModulo<u256> {
     }
 }
 
+/// Adds two 256-bit unsigned integers, returning a 512-bit unsigned integer result.
+///
+/// limb3 will always be 0, because the maximum sum of two 256-bit numbers is at most
+/// 2**257 - 2 which fits in 257 bits.
 fn u256_wide_add(a: u256, b: u256) -> u512 {
     let (sum, overflow) = u256_overflowing_add(a, b);
 
@@ -81,55 +85,3 @@ fn u256_wide_add(a: u256, b: u256) -> u512 {
 
     u512 { limb0, limb1, limb2, limb3 }
 }
-
-#[test]
-fn test_abc_basic() {
-    let a = 1000;
-    let b = 500;
-
-    let (sum, overflow) = u256_overflowing_add(a, b);
-
-    let expected = u512 { limb0: 1500, limb1: 0, limb2: 0, limb3: 0,  };
-
-    let result = u256_wide_add(a, b);
-
-    assert(!overflow, 'shouldnt overflow');
-    assert(result == expected, 'wrong result');
-}
-
-#[test]
-fn test_abc_overflow() {
-    let a = BoundedInt::<u256>::max();
-    let b = 1;
-
-    let (sum, overflow) = u256_overflowing_add(a, b);
-
-    let expected = u512 { limb0: 0, limb1: 0, limb2: 1, limb3: 0,  };
-
-    let result = u256_wide_add(a, b);
-
-    assert(overflow, 'should overflow');
-    assert(result == expected, 'wrong result');
-}
-#[test]
-fn test_abc_max_values() {
-    let a = BoundedInt::<u256>::max();
-    let b = BoundedInt::<u256>::max();
-
-    let (sum, overflow) = u256_overflowing_add(a, b);
-
-    let expected = u512 {
-        limb0: 0xfffffffffffffffffffffffffffffffe,
-        limb1: 0xffffffffffffffffffffffffffffffff,
-        limb2: 1,
-        limb3: 0,
-    };
-
-    let result = u256_wide_add(a, b);
-
-    assert(overflow, 'should overflow');
-    assert(result == expected, 'wrong result');
-}
-
-use debug::PrintTrait;
-

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,4 +1,4 @@
-use integer::{u256_overflow_mul};
+use integer::{u256_overflow_mul, u256_overflowing_add, u512, BoundedInt};
 
 trait Exponentiation<T> {
     // Raise a number to a power.
@@ -64,3 +64,72 @@ impl U256ExpModImpl of ExponentiationModulo<u256> {
         result
     }
 }
+
+fn u256_wide_add(a: u256, b: u256) -> u512 {
+    let (sum, overflow) = u256_overflowing_add(a, b);
+
+    let limb0 = sum.low;
+    let limb1 = sum.high;
+
+    let limb2 = if overflow {
+        1
+    } else {
+        0
+    };
+
+    let limb3 = 0;
+
+    u512 { limb0, limb1, limb2, limb3 }
+}
+
+#[test]
+fn test_abc_basic() {
+    let a = 1000;
+    let b = 500;
+
+    let (sum, overflow) = u256_overflowing_add(a, b);
+
+    let expected = u512 { limb0: 1500, limb1: 0, limb2: 0, limb3: 0,  };
+
+    let result = u256_wide_add(a, b);
+
+    assert(!overflow, 'shouldnt overflow');
+    assert(result == expected, 'wrong result');
+}
+
+#[test]
+fn test_abc_overflow() {
+    let a = BoundedInt::<u256>::max();
+    let b = 1;
+
+    let (sum, overflow) = u256_overflowing_add(a, b);
+
+    let expected = u512 { limb0: 0, limb1: 0, limb2: 1, limb3: 0,  };
+
+    let result = u256_wide_add(a, b);
+
+    assert(overflow, 'should overflow');
+    assert(result == expected, 'wrong result');
+}
+#[test]
+fn test_abc_max_values() {
+    let a = BoundedInt::<u256>::max();
+    let b = BoundedInt::<u256>::max();
+
+    let (sum, overflow) = u256_overflowing_add(a, b);
+
+    let expected = u512 {
+        limb0: 0xfffffffffffffffffffffffffffffffe,
+        limb1: 0xffffffffffffffffffffffffffffffff,
+        limb2: 1,
+        limb3: 0,
+    };
+
+    let result = u256_wide_add(a, b);
+
+    assert(overflow, 'should overflow');
+    assert(result == expected, 'wrong result');
+}
+
+use debug::PrintTrait;
+


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #83 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes ADDMOD behavior
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

ADDMOD

I tried two different implementations for this ADDMOD opcode, leveraging the fact that `(x + y) mod N <=> (x mod N) + (y mod N) mod N` 

The first try was using u256_wide_add, a function that I created that adds two u256s and returns a u512 to avoid overflowing on the a+b addition, and then dividing it by N and returning the remainder.

```rust
     fn exec_addmod(ref self: ExecutionContext) {
        let popped = self.stack.pop_n(3);

        let n: u256 = *popped[2];
        let mut result = 0;
        if n != 0 {
            let add_res = u256_wide_add(*popped[0], *popped[1]);
            let (_, r) = u512_safe_div_rem_by_u256(add_res, n.try_into().unwrap());
            result = r;
        }

        self.stack.push(result);
    }
    
      fn u256_wide_add(a: u256, b: u256) -> u512 {
    let (sum, overflow) = u256_overflowing_add(a, b);

    let limb0 = sum.low;
    let limb1 = sum.high;

    let limb2 = if overflow {
        1
    } else {
        0
    };

    let limb3 = 0;

    u512 { limb0, limb1, limb2, limb3 }
} 
```

Here is the test output 

```shell
❯ scarb test -f test_exec_addmod_overflow
Running tests for package: kakarot
testing kakarot ...
running 1 tests
[DEBUG]	                               	(raw: 0x3b72c

test kakarot::tests::test_instructions::test_stop_and_arithmetic_operations::test_exec_addmod_overflow ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 78 filtered out;
```


The other implementation is 

```rust
    fn exec_addmod(ref self: ExecutionContext) {
        let popped = self.stack.pop_n(3);

        let n: u256 = *popped[2];
        let mut result = 0;
        if n != 0 {
            // (x + y) mod N <=> (x mod N) + (y mod N) mod N
            result = (*popped[0] % n) + (*popped[1] % n) % n;
        }
        self.stack.push(result);
    }
```
 
    Here is the test output

```shell 
❯ scarb test -f test_exec_addmod_overflow
Running tests for package: kakarot
testing kakarot ...
running 1 tests
[DEBUG]	                               	(raw: 0x3d5b8

test kakarot::tests::test_instructions::test_stop_and_arithmetic_operations::test_exec_addmod_overflow ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 78 filtered out;
```
 
  This second version is ~3% more costly. Therefore, we will keep the first one with u256_wide_add.