### PR TITLE
refactor: u256_signed_div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- math: u256_signed_div now enforces div to be NonZero
 - fix: ADDMOD opcode
 - opcodes: add 0x09-MULMOD opcode
 - ci: add `CHANGELOG.md` and enforce it is edited for each PR on `main`

--- a/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/instructions/stop_and_arithmetic_operations.cairo
@@ -90,8 +90,12 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         let a = *popped[0];
         let b = *popped[1];
 
-        // Compute the division
-        let (result, _) = u256_signed_div_rem(a, b);
+        let mut result = 0;
+        if b != 0 {
+            // Won't panic since 0 case is handled manually
+            let (q, _) = u256_signed_div_rem(a, b.try_into().unwrap());
+            result = q;
+        }
 
         self.stack.push(result);
     }

--- a/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/instructions/stop_and_arithmetic_operations.cairo
@@ -148,7 +148,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             Option::Some(nonzero_n) => {
                 // This is more gas efficient than computing (a mod N) + (b mod N) mod N
                 let sum = u256_wide_add(*popped[0], *popped[1]);
-                let (_, r) = u512_safe_div_rem_by_u256(add_res, nonzero_n);
+                let (_, r) = u512_safe_div_rem_by_u256(sum, nonzero_n);
                 r
             },
             Option::None => 0,

--- a/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/instructions/stop_and_arithmetic_operations.cairo
@@ -147,7 +147,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         let result: u256 = match u256_try_as_non_zero(n) {
             Option::Some(nonzero_n) => {
                 // This is more gas efficient than computing (a mod N) + (b mod N) mod N
-                let add_res = u256_wide_add(*popped[0], *popped[1]);
+                let sum = u256_wide_add(*popped[0], *popped[1]);
                 let (_, r) = u512_safe_div_rem_by_u256(add_res, nonzero_n);
                 r
             },

--- a/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/instructions/stop_and_arithmetic_operations.cairo
@@ -145,11 +145,10 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         let n = *popped[2];
 
         let result: u256 = match u256_try_as_non_zero(n) {
-            Option::Some(_) => {
+            Option::Some(nonzero_n) => {
                 // This is more gas efficient than computing (a mod N) + (b mod N) mod N
                 let add_res = u256_wide_add(*popped[0], *popped[1]);
-                // Won't panic since 0 case is handled manually
-                let (_, r) = u512_safe_div_rem_by_u256(add_res, n.try_into().unwrap());
+                let (_, r) = u512_safe_div_rem_by_u256(add_res, nonzero_n);
                 r
             },
             Option::None => 0,

--- a/src/tests/test_utils/test_u256_signed_math.cairo
+++ b/src/tests/test_utils/test_u256_signed_math.cairo
@@ -1,6 +1,8 @@
 use kakarot::utils::u256_signed_math::{u256_not, u256_neg, u256_signed_div_rem, ALL_ONES, MAX_U256};
 use integer::u256_safe_div_rem;
 use debug::PrintTrait;
+use traits::{Into, TryInto};
+use option::OptionTrait;
 
 const MAX_SIGNED_VALUE: u256 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 const MIN_SIGNED_VALUE: u256 = 0x8000000000000000000000000000000000000000000000000000000000000000;
@@ -42,39 +44,44 @@ fn test_u256_neg() {
 #[test]
 #[available_gas(20000000)]
 fn test_signed_div_rem() {
-    //     Zero Division
-    assert(u256_signed_div_rem(0, 0) == (0, 0), 'Zero Division failed - 1.');
-    assert(u256_signed_div_rem(0xc0ffee, 0) == (0, 0), 'Zero Division failed - 2.');
-
     // Division by -1
     assert(
-        u256_signed_div_rem(1, MAX_U256) == (MAX_U256, 0), 'Division by -1 failed - 1.'
+        u256_signed_div_rem(1, MAX_U256.try_into().unwrap()) == (MAX_U256, 0),
+        'Division by -1 failed - 1.'
     ); // 1 / -1 == -1
     assert(
-        u256_signed_div_rem(MAX_U256, MAX_U256) == (1, 0), 'Division by -1 failed - 2.'
+        u256_signed_div_rem(MAX_U256, MAX_U256.try_into().unwrap()) == (1, 0),
+        'Division by -1 failed - 2.'
     ); // -1 / -1 == 1
-    assert(u256_signed_div_rem(0, MAX_U256) == (0, 0), 'Division by -1 failed - 3.'); // 0 / -1 == 0
+    assert(
+        u256_signed_div_rem(0, MAX_U256.try_into().unwrap()) == (0, 0), 'Division by -1 failed - 3.'
+    ); // 0 / -1 == 0
 
     // Simple Division
-    assert(u256_signed_div_rem(10, 2) == (5, 0), 'Simple Division failed - 1.'); // 10 / 2 == 5
     assert(
-        u256_signed_div_rem(10, 3) == (3, 1), 'Simple Division failed - 2.'
+        u256_signed_div_rem(10, 2_u256.try_into().unwrap()) == (5, 0), 'Simple Division failed - 1.'
+    ); // 10 / 2 == 5
+    assert(
+        u256_signed_div_rem(10, 3_u256.try_into().unwrap()) == (3, 1), 'Simple Division failed - 2.'
     ); // 10 / 3 == 3 remainder 1
 
     // Dividing a Negative Number
     assert(
-        u256_signed_div_rem(MAX_U256, 1) == (MAX_U256, 0), 'Dividing a neg num failed - 1.'
+        u256_signed_div_rem(MAX_U256, 1_u256.try_into().unwrap()) == (MAX_U256, 0),
+        'Dividing a neg num failed - 1.'
     ); // -1 / 1 == -1
     assert(
         u256_signed_div_rem(
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE, 0x2
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE,
+            0x2_u256.try_into().unwrap()
         ) == (MAX_U256, 0),
         'Dividing a neg num failed - 2.'
     ); // -2 / 2 == -1
     // - 2**255 / 2 == - 2**254
     assert(
         u256_signed_div_rem(
-            0x8000000000000000000000000000000000000000000000000000000000000000, 0x2
+            0x8000000000000000000000000000000000000000000000000000000000000000,
+            0x2_u256.try_into().unwrap()
         ) == (0xc000000000000000000000000000000000000000000000000000000000000000, 0),
         'Dividing a neg num failed - 3.'
     );
@@ -82,19 +89,28 @@ fn test_signed_div_rem() {
     // Dividing by a Negative Number
     assert(
         u256_signed_div_rem(
-            0x4, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE
+            0x4,
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE_u256
+                .try_into()
+                .unwrap()
         ) == (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE, 0),
         'Div by a neg num failed - 1.'
     ); // 4 / -2 == -2
     assert(
         u256_signed_div_rem(
-            MAX_SIGNED_VALUE, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            MAX_SIGNED_VALUE,
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256
+                .try_into()
+                .unwrap()
         ) == (MIN_SIGNED_VALUE + 1, 0),
         'Div by a neg num failed - 2.'
     ); // MAX_VALUE (2**255 -1) / -1 == MIN_VALUE + 1
     assert(
         u256_signed_div_rem(
-            0x1, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            0x1,
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256
+                .try_into()
+                .unwrap()
         ) == (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 0),
         'Div by a neg num failed - 3.'
     ); // 1 / -1 == -1
@@ -103,14 +119,18 @@ fn test_signed_div_rem() {
     assert(
         u256_signed_div_rem(
             0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF6,
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB_u256
+                .try_into()
+                .unwrap()
         ) == (2, 0),
         'Div w/ both neg num failed - 1.'
     ); // -10 / -5 == 2
     assert(
         u256_signed_div_rem(
             0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF6,
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5_u256
+                .try_into()
+                .unwrap()
         ) == (0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF6),
         'Div w/ both neg num failed - 2.'
     ); // -10 / -11 == 0 remainder -10
@@ -118,7 +138,8 @@ fn test_signed_div_rem() {
     // Division with Remainder
     assert(
         u256_signed_div_rem(
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9, 0x3
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9,
+            0x3_u256.try_into().unwrap()
         ) == (
             0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE,
             0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
@@ -127,7 +148,8 @@ fn test_signed_div_rem() {
     ); // -7 / 3 == -2 remainder -1
     assert(
         u256_signed_div_rem(
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 0x2
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+            0x2_u256.try_into().unwrap()
         ) == (0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
         'Div with rem failed - 2.'
     ); // -1 / 2 == 0 remainder -1
@@ -135,9 +157,21 @@ fn test_signed_div_rem() {
     // Edge Case: Dividing Minimum Value by -1
     assert(
         u256_signed_div_rem(
-            MIN_SIGNED_VALUE, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            MIN_SIGNED_VALUE,
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256
+                .try_into()
+                .unwrap()
         ) == (MIN_SIGNED_VALUE, 0),
         'Div w/ both neg num failed - 3.'
     ); // MIN / -1 == MIN because 2**255 is out of range
 }
 
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('u256 is 0', ))]
+fn test_signed_div_rem_by_zero() {
+    //     Zero Division
+    assert(
+        u256_signed_div_rem(0, 0_u256.try_into().unwrap()) == (0, 0), 'Zero Division failed - 1.'
+    );
+}

--- a/src/utils/u256_signed_math.cairo
+++ b/src/utils/u256_signed_math.cairo
@@ -1,5 +1,5 @@
 use integer::u256_safe_div_rem;
-use traits::TryInto;
+use traits::{Into, TryInto};
 use option::OptionTrait;
 
 const ALL_ONES: u128 = 0xffffffffffffffffffffffffffffffff;
@@ -23,14 +23,12 @@ fn u256_neg(a: u256) -> u256 {
 }
 
 /// Signed integer division between two integers. Returns the quotient and the remainder.
-/// Conforms to EVM specifications.
+/// Conforms to EVM specifications - except that the type system enforces div != zero.
 /// See ethereum yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf, page 29).
 /// Note that the remainder may be negative if one of the inputs is negative and that
 /// (-2**255) / (-1) = -2**255 because 2*255 is out of range.
-fn u256_signed_div_rem(a: u256, div: u256) -> (u256, u256) {
-    if div == 0 {
-        return (0, 0);
-    }
+fn u256_signed_div_rem(a: u256, div: NonZero<u256>) -> (u256, u256) {
+    let mut div: u256 = div.into();
 
     // When div=-1, simply return -a.
     if div == MAX_U256 {
@@ -45,8 +43,9 @@ fn u256_signed_div_rem(a: u256, div: u256) -> (u256, u256) {
     } else {
         u256_neg(a)
     };
+
     let div_positive = div.high < TWO_POW_127;
-    let div = if div_positive {
+    div = if div_positive {
         div
     } else {
         u256_neg(div)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Refactors `u256_signed_div` to enforce `div !=0` through the type system.
This is open to discussion if you believe that the benefits are not high enough to implement it.
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #89 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Zero case is explicitly handled in SDIV opcode
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
