### PR TITLE
dev: add pre-commit hook to format project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- add pre-commit hook to format project
 - refactor(22/08/2023): refactor project to use scarb workspace
 - opcode(22/08/2023): add 0x1A-BYTE opcode
 - tooling: CI now generates gas snapshots artifacts. pre-push hook to compare

--- a/scripts/install_hook.sh
+++ b/scripts/install_hook.sh
@@ -22,12 +22,15 @@ scarb fmt
 changed_files=$(git diff --name-only)
 
 if [ -n "$changed_files" ]; then
-    echo "The following files were reformatted. Please add them to your commit and try again:"
+    echo "The following files were reformatted and staged:"
     echo "$changed_files"
-    exit 1
+    # Stage the changes.
+    git add $changed_files
+else
+    echo "No files were reformatted."
 fi
 
-# Continue with the commit if no issues were found.
+# Continue with the commit
 exit 0
 '
 

--- a/scripts/install_hook.sh
+++ b/scripts/install_hook.sh
@@ -13,6 +13,24 @@ if [ $? -ne 0 ]; then
     exit 1
 fi'
 
+COMMIT_CONTENT='#!/bin/sh
+
+# Run scarb fmt to format the project.
+scarb fmt
+
+# Check if any files were modified after running scarb fmt.
+changed_files=$(git diff --name-only)
+
+if [ -n "$changed_files" ]; then
+    echo "The following files were reformatted. Please add them to your commit and try again:"
+    echo "$changed_files"
+    exit 1
+fi
+
+# Continue with the commit if no issues were found.
+exit 0
+'
+
 # Check if the current directory is a git repository
 if [ ! -d .git ]; then
     echo "Error: This is not a git repository."
@@ -20,10 +38,13 @@ if [ ! -d .git ]; then
 fi
 
 # Write the hook content to the pre-push file
+echo "$COMMIT_CONTENT" > .git/hooks/pre-commit
 echo "$HOOK_CONTENT" > .git/hooks/pre-push
 
 # Make the hook executable
+chmod +x .git/hooks/pre-commit
 chmod +x .git/hooks/pre-push
 
+echo "pre-commit hook has been installed successfully!"
 echo "pre-push hook has been installed successfully!"
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Feature Request

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [✔️] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Project does not have inbuilt format before pushing new changes

Issue Number: Closes #165

## What is the new behavior?
On commit, pre-commit hook will format the project with "scarb fmt" 

<!-- Please describe the behavior or changes that are being added by this PR. -->
- Added changes to install-hook.sh file for adding pre-commit

## Does this introduce a breaking change?

- [] Yes
- [✔️] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [✔️] Yes
- [ ] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
