### PR TITLE
bug: add missing `?` operators in methods and `unwrap`s in tests

### DIFF
--- a/crates/evm/src/instructions/comparison_operations.cairo
+++ b/crates/evm/src/instructions/comparison_operations.cairo
@@ -56,7 +56,7 @@ impl ComparisonAndBitwiseOperations of ComparisonAndBitwiseOperationsTrait {
         let a = *popped[0];
         let b = *popped[1];
         let result = a & b;
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -73,7 +73,7 @@ impl ComparisonAndBitwiseOperations of ComparisonAndBitwiseOperationsTrait {
         let a = *popped[0];
         let b = *popped[1];
         let result = a ^ b;
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -83,7 +83,7 @@ impl ComparisonAndBitwiseOperations of ComparisonAndBitwiseOperationsTrait {
     fn exec_not(ref self: ExecutionContext) -> Result<(), EVMError> {
         let a = self.stack.pop()?;
         let result = ~a;
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -97,13 +97,13 @@ impl ComparisonAndBitwiseOperations of ComparisonAndBitwiseOperationsTrait {
 
         /// If the byte offset is out of range, we early return with 0.
         if i > 31 {
-            self.stack.push(0);
+            self.stack.push(0)?;
             return Result::Ok(());
         }
 
         // Right shift value by offset bits and then take the least significant byte by applying modulo 256.
         let result = (x / 2.pow((31 - i) * 8)) % 256;
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 

--- a/crates/evm/src/instructions/duplication_operations.cairo
+++ b/crates/evm/src/instructions/duplication_operations.cairo
@@ -23,7 +23,7 @@ mod internal {
         let i: u8 = i.into();
 
         let item = context.stack.peek_at((i - 1).into())?;
-        context.stack.push(item);
+        context.stack.push(item)?;
         Result::Ok(())
     }
 }

--- a/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
@@ -37,7 +37,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         // Compute the addition
         let (result, _) = u256_overflowing_add(*popped[0], *popped[1]);
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -51,7 +51,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         // Compute the multiplication
         let (result, _) = u256_overflow_mul(*popped[0], *popped[1]);
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -65,7 +65,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
         // Compute the substraction
         let (result, _) = u256_overflow_sub(*popped[0], *popped[1]);
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -87,7 +87,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             Option::None => 0,
         };
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -109,7 +109,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             Option::None => 0,
         };
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -131,7 +131,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             Option::None => 0,
         };
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -153,7 +153,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             },
             Option::None => 0,
         };
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -179,7 +179,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             Option::None => 0,
         };
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -205,7 +205,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             Option::None => 0,
         };
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -220,7 +220,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
 
         let result = a.pow_mod(b);
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 
@@ -262,7 +262,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
             x
         };
 
-        self.stack.push(result);
+        self.stack.push(result)?;
         Result::Ok(())
     }
 }

--- a/crates/evm/src/tests/test_instructions/test_comparison_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_comparison_operations.cairo
@@ -11,8 +11,8 @@ use evm::context::BoxDynamicExecutionContextDestruct;
 fn test_and_zero_and_max() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0x00);
-    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(0x00).unwrap();
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
 
     // When
     ctx.exec_and();
@@ -27,8 +27,8 @@ fn test_and_zero_and_max() {
 fn test_and_max_and_max() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::<u256>::max());
-    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
 
     // When
     ctx.exec_and();
@@ -45,8 +45,8 @@ fn test_and_max_and_max() {
 fn test_and_two_random_uint() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0xAB8765432DCBA98765410F149E87610FDCBA98765432543217654DCBA93210F8);
-    ctx.stack.push(0xFEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210);
+    ctx.stack.push(0xAB8765432DCBA98765410F149E87610FDCBA98765432543217654DCBA93210F8).unwrap();
+    ctx.stack.push(0xFEDCBA9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876543210).unwrap();
 
     // When
     ctx.exec_and();
@@ -68,8 +68,8 @@ fn test_and_two_random_uint() {
 fn test_xor_different_pair() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0b010101);
-    ctx.stack.push(0b101010);
+    ctx.stack.push(0b010101).unwrap();
+    ctx.stack.push(0b101010).unwrap();
 
     // When
     ctx.exec_xor();
@@ -84,8 +84,8 @@ fn test_xor_different_pair() {
 fn test_xor_same_pair() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0b000111);
-    ctx.stack.push(0b000111);
+    ctx.stack.push(0b000111).unwrap();
+    ctx.stack.push(0b000111).unwrap();
 
     // When
     ctx.exec_xor();
@@ -100,8 +100,8 @@ fn test_xor_same_pair() {
 fn test_xor_half_same_pair() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0b111000);
-    ctx.stack.push(0b000000);
+    ctx.stack.push(0b111000).unwrap();
+    ctx.stack.push(0b000000).unwrap();
 
     // When
     ctx.exec_xor();
@@ -117,7 +117,7 @@ fn test_xor_half_same_pair() {
 fn test_not_zero() {
     // Given 
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0x00);
+    ctx.stack.push(0x00).unwrap();
 
     // When
     ctx.exec_not();
@@ -134,7 +134,7 @@ fn test_not_zero() {
 fn test_not_max_uint() {
     // Given 
     let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
 
     // When
     ctx.exec_not();
@@ -149,7 +149,7 @@ fn test_not_max_uint() {
 fn test_not_random_uint() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0x123456789ABCDEF123456789ABCDEF123456789ABCDEF123456789ABCDEF1234);
+    ctx.stack.push(0x123456789ABCDEF123456789ABCDEF123456789ABCDEF123456789ABCDEF1234).unwrap();
 
     // When
     ctx.exec_not();
@@ -170,8 +170,8 @@ fn test_not_random_uint() {
 fn test_byte_random_u256() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0xf7ec8b2ea4a6b7fd5f4ed41b66197fcc14c4a37d68275ea151d899bb4d7c2ae7);
-    ctx.stack.push(0x08);
+    ctx.stack.push(0xf7ec8b2ea4a6b7fd5f4ed41b66197fcc14c4a37d68275ea151d899bb4d7c2ae7).unwrap();
+    ctx.stack.push(0x08).unwrap();
 
     // When
     ctx.exec_byte();
@@ -186,8 +186,8 @@ fn test_byte_random_u256() {
 fn test_byte_offset_out_of_range() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0x01be893aefcfa1592f60622b80d45c2db74281d2b9e10c14b0f6ce7c8f58e209);
-    ctx.stack.push(32_u256);
+    ctx.stack.push(0x01be893aefcfa1592f60622b80d45c2db74281d2b9e10c14b0f6ce7c8f58e209).unwrap();
+    ctx.stack.push(32_u256).unwrap();
 
     // When
     ctx.exec_byte();

--- a/crates/evm/src/tests/test_instructions/test_duplication_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_duplication_operations.cairo
@@ -34,7 +34,7 @@ fn push_zeros(ref stack: Stack, n: u8) {
         if i == n {
             break;
         }
-        stack.push(0x0);
+        stack.push(0x0).unwrap();
         i += 1;
     }
 }
@@ -46,7 +46,7 @@ fn test_dup1() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
 
     let old_stack_len = ctx.stack.len();
 
@@ -71,7 +71,7 @@ fn test_dup2() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 1);
 
     let old_stack_len = ctx.stack.len();
@@ -97,7 +97,7 @@ fn test_dup3() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 2);
 
     let old_stack_len = ctx.stack.len();
@@ -123,7 +123,7 @@ fn test_dup4() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 3);
 
     let old_stack_len = ctx.stack.len();
@@ -149,7 +149,7 @@ fn test_dup5() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 4);
 
     let old_stack_len = ctx.stack.len();
@@ -175,7 +175,7 @@ fn test_dup6() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 5);
 
     let old_stack_len = ctx.stack.len();
@@ -201,7 +201,7 @@ fn test_dup7() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 6);
 
     let old_stack_len = ctx.stack.len();
@@ -227,7 +227,7 @@ fn test_dup8() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 7);
 
     let old_stack_len = ctx.stack.len();
@@ -253,7 +253,7 @@ fn test_dup9() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 8);
 
     let old_stack_len = ctx.stack.len();
@@ -279,7 +279,7 @@ fn test_dup10() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 9);
 
     let old_stack_len = ctx.stack.len();
@@ -305,7 +305,7 @@ fn test_dup11() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 10);
 
     let old_stack_len = ctx.stack.len();
@@ -331,7 +331,7 @@ fn test_dup12() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 11);
 
     let old_stack_len = ctx.stack.len();
@@ -357,7 +357,7 @@ fn test_dup13() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 12);
 
     let old_stack_len = ctx.stack.len();
@@ -383,7 +383,7 @@ fn test_dup14() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 13);
 
     let old_stack_len = ctx.stack.len();
@@ -409,7 +409,7 @@ fn test_dup15() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 14);
 
     let old_stack_len = ctx.stack.len();
@@ -435,7 +435,7 @@ fn test_dup16() {
     let mut ctx = setup_execution_context();
     let initial_len = ctx.stack.len();
 
-    ctx.stack.push(0x01);
+    ctx.stack.push(0x01).unwrap();
     push_zeros(ref ctx.stack, 15);
 
     let old_stack_len = ctx.stack.len();

--- a/crates/evm/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_stop_and_arithmetic_operations.cairo
@@ -26,9 +26,9 @@ fn test_exec_stop() {
 fn test_exec_add() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(1);
-    ctx.stack.push(2);
-    ctx.stack.push(3);
+    ctx.stack.push(1).unwrap();
+    ctx.stack.push(2).unwrap();
+    ctx.stack.push(3).unwrap();
 
     // When
     ctx.exec_add();
@@ -44,8 +44,8 @@ fn test_exec_add() {
 fn test_exec_add_overflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::<u256>::max());
-    ctx.stack.push(1);
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
+    ctx.stack.push(1).unwrap();
 
     // When
     ctx.exec_add();
@@ -60,8 +60,8 @@ fn test_exec_add_overflow() {
 fn test_exec_mul() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(4);
-    ctx.stack.push(5);
+    ctx.stack.push(4).unwrap();
+    ctx.stack.push(5).unwrap();
 
     // When
     ctx.exec_mul();
@@ -76,8 +76,8 @@ fn test_exec_mul() {
 fn test_exec_mul_overflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::<u256>::max());
-    ctx.stack.push(2);
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
+    ctx.stack.push(2).unwrap();
 
     // When
     ctx.exec_mul();
@@ -92,8 +92,8 @@ fn test_exec_mul_overflow() {
 fn test_exec_sub() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(7);
-    ctx.stack.push(10);
+    ctx.stack.push(7).unwrap();
+    ctx.stack.push(10).unwrap();
 
     // When
     ctx.exec_sub();
@@ -108,8 +108,8 @@ fn test_exec_sub() {
 fn test_exec_sub_underflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(1);
-    ctx.stack.push(0);
+    ctx.stack.push(1).unwrap();
+    ctx.stack.push(0).unwrap();
 
     // When
     ctx.exec_sub();
@@ -125,8 +125,8 @@ fn test_exec_sub_underflow() {
 fn test_exec_div() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(4);
-    ctx.stack.push(100);
+    ctx.stack.push(4).unwrap();
+    ctx.stack.push(100).unwrap();
 
     // When
     ctx.exec_div();
@@ -141,8 +141,8 @@ fn test_exec_div() {
 fn test_exec_div_by_zero() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0);
-    ctx.stack.push(100);
+    ctx.stack.push(0).unwrap();
+    ctx.stack.push(100).unwrap();
 
     // When
     ctx.exec_div();
@@ -157,8 +157,8 @@ fn test_exec_div_by_zero() {
 fn test_exec_sdiv_pos() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(5);
-    ctx.stack.push(10);
+    ctx.stack.push(5).unwrap();
+    ctx.stack.push(10).unwrap();
 
     // When
     ctx.exec_sdiv(); // 10 / 5
@@ -173,8 +173,8 @@ fn test_exec_sdiv_pos() {
 fn test__exec_sdiv_neg() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(BoundedInt::max());
-    ctx.stack.push(2);
+    ctx.stack.push(BoundedInt::max()).unwrap();
+    ctx.stack.push(2).unwrap();
 
     // When
     ctx.exec_sdiv(); // 2 / -1
@@ -189,8 +189,8 @@ fn test__exec_sdiv_neg() {
 fn test_exec_sdiv_by_0() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0);
-    ctx.stack.push(10);
+    ctx.stack.push(0).unwrap();
+    ctx.stack.push(10).unwrap();
 
     // When
     ctx.exec_sdiv();
@@ -205,8 +205,8 @@ fn test_exec_sdiv_by_0() {
 fn test_exec_mod() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(6);
-    ctx.stack.push(100);
+    ctx.stack.push(6).unwrap();
+    ctx.stack.push(100).unwrap();
 
     // When
     ctx.exec_mod();
@@ -221,8 +221,8 @@ fn test_exec_mod() {
 fn test_exec_mod_by_zero() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0);
-    ctx.stack.push(100);
+    ctx.stack.push(0).unwrap();
+    ctx.stack.push(100).unwrap();
 
     // When
     ctx.exec_smod();
@@ -237,8 +237,8 @@ fn test_exec_mod_by_zero() {
 fn test_exec_smod() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(3);
-    ctx.stack.push(10);
+    ctx.stack.push(3).unwrap();
+    ctx.stack.push(10).unwrap();
 
     // When
     ctx.exec_smod();
@@ -253,8 +253,14 @@ fn test_exec_smod() {
 fn test_exec_smod_neg() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD); // -3
-    ctx.stack.push(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8); // -8
+    ctx
+        .stack
+        .push(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD)
+        .unwrap(); // -3
+    ctx
+        .stack
+        .push(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8)
+        .unwrap(); // -8
 
     // When
     ctx.exec_smod();
@@ -275,8 +281,8 @@ fn test_exec_smod_neg() {
 fn test_exec_smod_zero() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0);
-    ctx.stack.push(10);
+    ctx.stack.push(0).unwrap();
+    ctx.stack.push(10).unwrap();
 
     // When
     ctx.exec_mod();
@@ -292,9 +298,9 @@ fn test_exec_smod_zero() {
 fn test_exec_addmod() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(7);
-    ctx.stack.push(10);
-    ctx.stack.push(20);
+    ctx.stack.push(7).unwrap();
+    ctx.stack.push(10).unwrap();
+    ctx.stack.push(20).unwrap();
 
     // When
     ctx.exec_addmod();
@@ -309,9 +315,9 @@ fn test_exec_addmod() {
 fn test_exec_addmod_by_zero() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0);
-    ctx.stack.push(10);
-    ctx.stack.push(20);
+    ctx.stack.push(0).unwrap();
+    ctx.stack.push(10).unwrap();
+    ctx.stack.push(20).unwrap();
 
     // When
     ctx.exec_addmod();
@@ -327,9 +333,9 @@ fn test_exec_addmod_by_zero() {
 fn test_exec_addmod_overflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(3);
-    ctx.stack.push(2);
-    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(3).unwrap();
+    ctx.stack.push(2).unwrap();
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
 
     // When
     ctx.exec_addmod();
@@ -345,9 +351,9 @@ fn test_exec_addmod_overflow() {
 #[available_gas(20000000)]
 fn test_mulmod_basic() {
     let mut ctx = setup_execution_context();
-    ctx.stack.push(10);
-    ctx.stack.push(7);
-    ctx.stack.push(5);
+    ctx.stack.push(10).unwrap();
+    ctx.stack.push(7).unwrap();
+    ctx.stack.push(5).unwrap();
 
     // When
     ctx.exec_mulmod();
@@ -360,9 +366,9 @@ fn test_mulmod_basic() {
 #[available_gas(20000000)]
 fn test_mulmod_zero_modulus() {
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0);
-    ctx.stack.push(7);
-    ctx.stack.push(5);
+    ctx.stack.push(0).unwrap();
+    ctx.stack.push(7).unwrap();
+    ctx.stack.push(5).unwrap();
 
     ctx.exec_mulmod();
 
@@ -374,9 +380,9 @@ fn test_mulmod_zero_modulus() {
 #[available_gas(20000000)]
 fn test_mulmod_overflow() {
     let mut ctx = setup_execution_context();
-    ctx.stack.push(12);
-    ctx.stack.push(BoundedInt::<u256>::max());
-    ctx.stack.push(BoundedInt::<u256>::max());
+    ctx.stack.push(12).unwrap();
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
+    ctx.stack.push(BoundedInt::<u256>::max()).unwrap();
 
     ctx.exec_mulmod();
 
@@ -390,9 +396,9 @@ fn test_mulmod_overflow() {
 #[available_gas(20000000)]
 fn test_mulmod_zero() {
     let mut ctx = setup_execution_context();
-    ctx.stack.push(10);
-    ctx.stack.push(7);
-    ctx.stack.push(0);
+    ctx.stack.push(10).unwrap();
+    ctx.stack.push(7).unwrap();
+    ctx.stack.push(0).unwrap();
 
     ctx.exec_mulmod();
 
@@ -405,8 +411,8 @@ fn test_mulmod_zero() {
 fn test_exec_exp() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(2);
-    ctx.stack.push(10);
+    ctx.stack.push(2).unwrap();
+    ctx.stack.push(10).unwrap();
 
     // When
     ctx.exec_exp();
@@ -421,8 +427,8 @@ fn test_exec_exp() {
 fn test_exec_exp_overflow() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(2);
-    ctx.stack.push(BoundedInt::<u128>::max().into() + 1);
+    ctx.stack.push(2).unwrap();
+    ctx.stack.push(BoundedInt::<u128>::max().into() + 1).unwrap();
 
     // When
     ctx.exec_exp();
@@ -439,8 +445,8 @@ fn test_exec_exp_overflow() {
 fn test_exec_signextend() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0xFF);
-    ctx.stack.push(0x00);
+    ctx.stack.push(0xFF).unwrap();
+    ctx.stack.push(0x00).unwrap();
 
     // When
     ctx.exec_signextend();
@@ -461,8 +467,8 @@ fn test_exec_signextend() {
 fn test_exec_signextend_no_effect() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0x7F);
-    ctx.stack.push(0x00);
+    ctx.stack.push(0x7F).unwrap();
+    ctx.stack.push(0x00).unwrap();
 
     // When
     ctx.exec_signextend();
@@ -479,8 +485,8 @@ fn test_exec_signextend_no_effect() {
 fn test_exec_signextend_on_negative() {
     // Given
     let mut ctx = setup_execution_context();
-    ctx.stack.push(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0001);
-    ctx.stack.push(0x01); // s = 15, v = 0
+    ctx.stack.push(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0001).unwrap();
+    ctx.stack.push(0x01).unwrap(); // s = 15, v = 0
 
     // When
     ctx.exec_signextend();

--- a/crates/evm/src/tests/test_stack.cairo
+++ b/crates/evm/src/tests/test_stack.cairo
@@ -30,7 +30,7 @@ fn test__empty__should_return_if_stack_is_empty() {
     assert(stack.is_empty() == true, 'stack should be empty');
 
     // When
-    stack.push(1);
+    stack.push(1).unwrap();
     // Then
     assert(stack.is_empty() == false, 'stack should not be empty');
 }
@@ -45,7 +45,7 @@ fn test__len__should_return_the_length_of_the_stack() {
     assert(stack.len() == 0, 'stack length should be 0');
 
     // When
-    stack.push(1);
+    stack.push(1).unwrap();
     // Then
     assert(stack.len() == 1, 'stack length should be 1');
 }
@@ -65,7 +65,7 @@ mod push {
         let mut stack = StackTrait::new();
 
         // When
-        stack.push(1);
+        stack.push(1).unwrap();
 
         // Then
         let res = stack.peek().unwrap();
@@ -76,7 +76,7 @@ mod push {
     }
 
     #[test]
-    #[available_gas(27000000)]
+    #[available_gas(30000000)]
     fn test_should_fail_when_overflow() {
         // Given
         let mut stack = StackTrait::new();
@@ -89,7 +89,7 @@ mod push {
             }
             i += 1;
 
-            stack.push(1);
+            stack.push(1).unwrap();
         };
 
         // Then
@@ -115,9 +115,9 @@ mod pop {
     fn test_should_pop_an_element_from_the_stack() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
-        stack.push(2);
-        stack.push(3);
+        stack.push(1).unwrap();
+        stack.push(2).unwrap();
+        stack.push(3).unwrap();
 
         // When
         let last_item = stack.pop().unwrap();
@@ -132,9 +132,9 @@ mod pop {
     fn test_should_pop_N_elements_from_the_stack() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
-        stack.push(2);
-        stack.push(3);
+        stack.push(1).unwrap();
+        stack.push(2).unwrap();
+        stack.push(3).unwrap();
 
         // When
         let elements = stack.pop_n(3).unwrap();
@@ -163,11 +163,11 @@ mod pop {
     }
 
     #[test]
-    #[available_gas(50000)]
+    #[available_gas(55000)]
     fn test_pop_n_should_return_err_when_stack_underflow() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
+        stack.push(1).unwrap();
 
         // When & Then
         let result = stack.pop_n(2);
@@ -193,8 +193,8 @@ mod peek {
         let mut stack = StackTrait::new();
 
         // When
-        stack.push(1);
-        stack.push(2);
+        stack.push(1).unwrap();
+        stack.push(2).unwrap();
 
         // Then
         let last_item = stack.peek().unwrap();
@@ -206,9 +206,9 @@ mod peek {
     fn test_should_return_stack_at_given_index_when_value_is_0() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
-        stack.push(2);
-        stack.push(3);
+        stack.push(1).unwrap();
+        stack.push(2).unwrap();
+        stack.push(3).unwrap();
 
         // When
         let result = stack.peek_at(0).unwrap();
@@ -222,9 +222,9 @@ mod peek {
     fn test_should_return_stack_at_given_index_when_value_is_1() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
-        stack.push(2);
-        stack.push(3);
+        stack.push(1).unwrap();
+        stack.push(2).unwrap();
+        stack.push(3).unwrap();
 
         // When
         let result = stack.peek_at(1).unwrap();
@@ -261,10 +261,10 @@ mod swap {
     fn test_should_swap_2_stack_items() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
-        stack.push(2);
-        stack.push(3);
-        stack.push(4);
+        stack.push(1).unwrap();
+        stack.push(2).unwrap();
+        stack.push(3).unwrap();
+        stack.push(4).unwrap();
         let index3 = stack.peek_at(3).unwrap();
         assert(index3 == 1, 'wrong index3');
         let index2 = stack.peek_at(2).unwrap();
@@ -309,7 +309,7 @@ mod swap {
     fn test_should_return_err_when_index_2_is_underflow() {
         // Given
         let mut stack = StackTrait::new();
-        stack.push(1);
+        stack.push(1).unwrap();
 
         // When & Then
         let result = stack.swap_i(2);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related: #141 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- Linked PR missed to add this operator during refactoring, so fixed it.
- Without this it won't propagate stackoverflow error and ignore it silently.
- Inside tests call `unwrap` on methods that can fail
  - due to this `unwrap`s needed to increase gas for few tests

## Does this introduce a breaking change?

- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
