### PR TITLE
feat: implement PC opcode

### DIFF
--- a/crates/evm/src/context.cairo
+++ b/crates/evm/src/context.cairo
@@ -343,6 +343,11 @@ impl ExecutionContextImpl of ExecutionContextTrait {
         dyn_ctx.return_data = value;
         self.dynamic_context = BoxTrait::new(dyn_ctx);
     }
+
+    #[inline(always)]
+    fn set_pc(ref self: ExecutionContext, value: u32) {
+        self.program_counter = value;
+    }
 }
 
 impl DefaultExecutionContext of Default<ExecutionContext> {

--- a/crates/evm/src/instructions.cairo
+++ b/crates/evm/src/instructions.cairo
@@ -16,6 +16,7 @@ mod exchange_operations;
 mod logging_operations;
 
 mod memory_operations;
+use memory_operations::MemoryOperationTrait;
 
 mod push_operations;
 use push_operations::PushOperationsTrait;

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -1,66 +1,97 @@
 //! Stack Memory Storage and Flow Operations.
 
-// Internal imports
-use evm::context::ExecutionContext;
-use evm::context::ExecutionContextTrait;
+use evm::context::{
+    ExecutionContext, ExecutionContextTrait, BoxDynamicExecutionContextDestruct, CallContextTrait
+};
+use evm::errors::EVMError;
+use evm::stack::StackTrait;
 
-/// MLOAD operation.
-/// Load word from memory and push to stack.
-fn exec_mload(ref context: ExecutionContext) {}
 
-/// 0x52 - MSTORE operation.
-/// Save word to memory.
-/// # Specification: https://www.evm.codes/#52?fork=shanghai
-fn exec_mstore(ref context: ExecutionContext) {}
+#[generate_trait]
+impl MemoryOperation of MemoryOperationTrait {
+    /// MLOAD operation.
+    /// Load word from memory and push to stack.
+    fn exec_mload(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x58 - PC operation
-/// Get the value of the program counter prior to the increment.
-/// # Specification: https://www.evm.codes/#58?fork=shanghai
-fn exec_pc(ref context: ExecutionContext) {}
+    /// 0x52 - MSTORE operation.
+    /// Save word to memory.
+    /// # Specification: https://www.evm.codes/#52?fork=shanghai
+    fn exec_mstore(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x59 - MSIZE operation.
-/// Get the value of memory size.
-/// # Specification: https://www.evm.codes/#59?fork=shanghai
-fn exec_msize(ref context: ExecutionContext) {}
+    /// 0x58 - PC operation
+    /// Get the value of the program counter prior to the increment.
+    /// # Specification: https://www.evm.codes/#58?fork=shanghai
+    fn exec_pc(ref self: ExecutionContext) -> Result<(), EVMError> {
+        let pc = self.program_counter.into();
+        self.stack.push(pc)
+    }
 
-/// 0x56 - JUMP operation
-/// The JUMP instruction changes the pc counter. 
-/// The new pc target has to be a JUMPDEST opcode.
-/// # Specification: https://www.evm.codes/#56?fork=shanghai
-fn exec_jump(ref context: ExecutionContext) {}
+    /// 0x59 - MSIZE operation.
+    /// Get the value of memory size.
+    /// # Specification: https://www.evm.codes/#59?fork=shanghai
+    fn exec_msize(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x57 - JUMPI operation.
-/// Change the pc counter under a provided certain condition.
-/// The new pc target has to be a JUMPDEST opcode.
-/// # Specification: https://www.evm.codes/#57?fork=shanghai
-fn exec_jumpi(ref context: ExecutionContext) {}
+    /// 0x56 - JUMP operation
+    /// The JUMP instruction changes the pc counter. 
+    /// The new pc target has to be a JUMPDEST opcode.
+    /// # Specification: https://www.evm.codes/#56?fork=shanghai
+    fn exec_jump(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x5b - JUMPDEST operation
-/// Serves as a check that JUMP or JUMPI was executed correctly.
-/// # Specification: https://www.evm.codes/#5b?fork=shanghai
-fn exec_jumpdest(ref context: ExecutionContext) {}
+    /// 0x57 - JUMPI operation.
+    /// Change the pc counter under a provided certain condition.
+    /// The new pc target has to be a JUMPDEST opcode.
+    /// # Specification: https://www.evm.codes/#57?fork=shanghai
+    fn exec_jumpi(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x50 - POP operation.
-/// Pops the first item on the stack (top of the stack).
-/// # Specification: https://www.evm.codes/#50?fork=shanghai
-fn exec_pop(ref context: ExecutionContext) {}
+    /// 0x5b - JUMPDEST operation
+    /// Serves as a check that JUMP or JUMPI was executed correctly.
+    /// # Specification: https://www.evm.codes/#5b?fork=shanghai
+    fn exec_jumpdest(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x53 - MSTORE8 operation.
-/// Save single byte to memory
-/// # Specification: https://www.evm.codes/#53?fork=shanghai
-fn exec_mstore8(ref context: ExecutionContext) {}
+    /// 0x50 - POP operation.
+    /// Pops the first item on the stack (top of the stack).
+    /// # Specification: https://www.evm.codes/#50?fork=shanghai
+    fn exec_pop(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x55 - SSTORE operation
-/// Save 32-byte word to storage.
-/// # Specification: https://www.evm.codes/#55?fork=shanghai
-fn exec_sstore(ref context: ExecutionContext) {}
+    /// 0x53 - MSTORE8 operation.
+    /// Save single byte to memory
+    /// # Specification: https://www.evm.codes/#53?fork=shanghai
+    fn exec_mstore8(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x54 - SLOAD operation
-/// Load from storage.
-/// # Specification: https://www.evm.codes/#54?fork=shanghai
-fn exec_sload(ref context: ExecutionContext) {}
+    /// 0x55 - SSTORE operation
+    /// Save 32-byte word to storage.
+    /// # Specification: https://www.evm.codes/#55?fork=shanghai
+    fn exec_sstore(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
 
-/// 0x5A - GAS operation
-/// Get the amount of available gas, including the corresponding reduction for the cost of this instruction.
-/// # Specification: https://www.evm.codes/#5a?fork=shanghai
-fn exec_gas(ref context: ExecutionContext) {}
+    /// 0x54 - SLOAD operation
+    /// Load from storage.
+    /// # Specification: https://www.evm.codes/#54?fork=shanghai
+    fn exec_sload(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
+
+    /// 0x5A - GAS operation
+    /// Get the amount of available gas, including the corresponding reduction for the cost of this instruction.
+    /// # Specification: https://www.evm.codes/#5a?fork=shanghai
+    fn exec_gas(ref self: ExecutionContext) -> Result<(), EVMError> {
+        Result::Ok(())
+    }
+}

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -15,7 +15,7 @@ use evm::instructions::{
     duplication_operations, environmental_information, exchange_operations, logging_operations,
     memory_operations, sha3, StopAndArithmeticOperationsTrait, ComparisonAndBitwiseOperationsTrait,
     system_operations, BlockInformationTrait, DuplicationOperationsTrait,
-    EnvironmentInformationTrait, PushOperationsTrait
+    EnvironmentInformationTrait, PushOperationsTrait, MemoryOperationTrait
 };
 use result::ResultTrait;
 
@@ -295,51 +295,51 @@ impl EVMInterpreterImpl of EVMInterpreterTrait {
         }
         if opcode == 80 {
             // POP
-            memory_operations::exec_pop(ref context);
+            return context.exec_pop();
         }
         if opcode == 81 {
             // MLOAD
-            memory_operations::exec_mload(ref context);
+            return context.exec_mload();
         }
         if opcode == 82 {
             // MSTORE
-            memory_operations::exec_mstore(ref context);
+            return context.exec_mstore();
         }
         if opcode == 83 {
             // MSTORE8
-            memory_operations::exec_mstore8(ref context);
+            return context.exec_mstore8();
         }
         if opcode == 84 {
             // SLOAD
-            memory_operations::exec_sload(ref context);
+            return context.exec_sload();
         }
         if opcode == 85 {
             // SSTORE
-            memory_operations::exec_sstore(ref context);
+            return context.exec_sstore();
         }
         if opcode == 86 {
             // JUMP
-            memory_operations::exec_jump(ref context);
+            return context.exec_jump();
         }
         if opcode == 87 {
             // JUMPI
-            memory_operations::exec_jumpi(ref context);
+            return context.exec_jumpi();
         }
         if opcode == 88 {
             // PC
-            memory_operations::exec_pc(ref context);
+            return context.exec_pc();
         }
         if opcode == 89 {
             // MSIZE
-            memory_operations::exec_msize(ref context);
+            return context.exec_msize();
         }
         if opcode == 90 {
             // GAS
-            memory_operations::exec_gas(ref context);
+            return context.exec_gas();
         }
         if opcode == 91 {
             // JUMPDEST
-            memory_operations::exec_jumpdest(ref context);
+            return context.exec_jumpdest();
         }
         if opcode == 95 {
             // PUSH0

--- a/crates/evm/src/tests/test_instructions.cairo
+++ b/crates/evm/src/tests/test_instructions.cairo
@@ -4,3 +4,4 @@ mod test_duplication_operations;
 mod test_block_information;
 mod test_environment_information;
 mod test_push_operations;
+mod test_memory_operations;

--- a/crates/evm/src/tests/test_instructions/test_comparison_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_comparison_operations.cairo
@@ -248,13 +248,7 @@ fn test_exec_shl_wrapping() {
 
     // Then
     assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(
-        ctx
-            .stack
-            .peek()
-            .unwrap() == 0,
-        'if shift > 255 should return 0'
-    );
+    assert(ctx.stack.peek().unwrap() == 0, 'if shift > 255 should return 0');
 }
 
 #[test]

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -26,6 +26,49 @@ fn test_pc_basic() {
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(ctx.stack.pop().unwrap() == 0, 'PC should be 0');
 }
-// TODO: Test that PC updates properly when instructions are executed
 
 
+#[test]
+#[available_gas(20000000)]
+fn test_pc_gets_updated_properly_1() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    // When
+    ctx.set_pc(9000);
+    ctx.exec_pc();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.pop().unwrap() == 9000, 'updating PC failed');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_pc_gets_updated_properly_2() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    // When
+    ctx.set_pc(42);
+    ctx.exec_pc();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.pop().unwrap() == 42, 'updating PC failed');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_pc_gets_updated_properly_3() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    // When
+    ctx.set_pc(7);
+    ctx.exec_pc();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.pop().unwrap() == 7, 'updating PC failed');
+}

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -1,0 +1,31 @@
+use evm::instructions::{MemoryOperationTrait, EnvironmentInformationTrait};
+use evm::tests::test_utils::{
+    setup_execution_context, setup_execution_context_with_bytecode, evm_address, callvalue
+};
+use evm::stack::StackTrait;
+use evm::memory::{InternalMemoryTrait, MemoryTrait};
+use option::OptionTrait;
+use starknet::EthAddressIntoFelt252;
+use utils::helpers::{EthAddressIntoU256, u256_to_bytes_array};
+use evm::errors::{EVMError, TYPE_CONVERSION_ERROR};
+use evm::context::{
+    ExecutionContext, ExecutionContextTrait, BoxDynamicExecutionContextDestruct, CallContextTrait,
+};
+
+
+#[test]
+#[available_gas(20000000)]
+fn test_pc_basic() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    // When
+    ctx.exec_pc();
+
+    // Then
+    assert(ctx.stack.len() == 1, 'stack should have one element');
+    assert(ctx.stack.pop().unwrap() == 0, 'PC should be 0');
+}
+// TODO: Test that PC updates properly when instructions are executed
+
+

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -42,33 +42,3 @@ fn test_pc_gets_updated_properly_1() {
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(ctx.stack.pop().unwrap() == 9000, 'updating PC failed');
 }
-
-#[test]
-#[available_gas(20000000)]
-fn test_pc_gets_updated_properly_2() {
-    // Given
-    let mut ctx = setup_execution_context();
-
-    // When
-    ctx.set_pc(42);
-    ctx.exec_pc();
-
-    // Then
-    assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.pop().unwrap() == 42, 'updating PC failed');
-}
-
-#[test]
-#[available_gas(20000000)]
-fn test_pc_gets_updated_properly_3() {
-    // Given
-    let mut ctx = setup_execution_context();
-
-    // When
-    ctx.set_pc(7);
-    ctx.exec_pc();
-
-    // Then
-    assert(ctx.stack.len() == 1, 'stack should have one element');
-    assert(ctx.stack.pop().unwrap() == 7, 'updating PC failed');
-}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #254 #255 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- implements `PC` opcode
- kakarot on cairo0 just increments the PC manually, which I don't think will be very useful
- i didn't find tests related PC specifically in geth.
- evm.codes also dont specify any examples.

## Does this introduce a breaking change?

- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
