### PR TITLE
fix: store_aligned_words slice

### DIFF
--- a/crates/evm/src/memory.cairo
+++ b/crates/evm/src/memory.cairo
@@ -113,7 +113,7 @@ impl MemoryImpl of MemoryTrait {
             let aligned_bytes = elements
                 .slice(
                     16 - offset_in_chunk_i,
-                    elements.len() - 16 - offset_in_chunk_i - offset_in_chunk_f,
+                    elements.len() - (16 - offset_in_chunk_i) - offset_in_chunk_f,
                 );
             self.store_aligned_words(initial_chunk + 1, aligned_bytes);
         }

--- a/crates/evm/src/memory.cairo
+++ b/crates/evm/src/memory.cairo
@@ -262,7 +262,7 @@ impl InternalMemoryMethods of InternalMemoryTrait {
 
             self.items.insert(chunk_index.into(), current.try_into().unwrap());
             chunk_index += 1;
-            elements = elements.slice(0, 16);
+            elements = elements.slice(16, elements.len() - 16);
         }
     }
 

--- a/crates/evm/src/tests/test_memory.cairo
+++ b/crates/evm/src/tests/test_memory.cairo
@@ -112,6 +112,58 @@ fn test_store_n_no_aligned_words() {
     assert(memory.bytes_len == 32, 'memory should be 32 bytes');
 }
 
+#[test]
+#[available_gas(200000000)]
+fn test_store_n_2_aligned_words() {
+    let mut memory = MemoryTrait::new();
+    let bytes_arr = array![
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35
+    ]
+        .span();
+    memory.store_n(bytes_arr, 15);
+    // value [1], will be stored in first word, values [2:34] will be stored in aligned words,
+    // value [35] will be stored in final word
+    assert(memory.bytes_len == 64, 'memory should be 64 bytes');
+
+    let mut stored_bytes = array![];
+    memory.load_n_internal(35, ref stored_bytes, 15);
+    assert(stored_bytes.span() == bytes_arr, 'stored bytes not == expected');
+}
+
 
 #[test]
 #[available_gas(20000000)]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #270 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Array is now moved 16 elements further instead of staying the same
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
