### PR TITLE
bug: Memory expansion should only increments modulo 32

### DIFF
--- a/crates/evm/src/memory.cairo
+++ b/crates/evm/src/memory.cairo
@@ -413,11 +413,15 @@ impl InternalMemoryMethods of InternalMemoryTrait {
     ///
     /// The cost of the expansion.
     fn expand(ref self: Memory, length: usize) -> usize {
+        if (length == 0) {
+            return 0;
+        }
+
         let last_memory_size_word = (self.bytes_len + 31) / 32;
         let mut last_memory_cost = (last_memory_size_word * last_memory_size_word) / 512;
         last_memory_cost += (3 * last_memory_size_word);
 
-        let new_bytes_len = self.bytes_len + length;
+        let new_bytes_len = self.bytes_len + (((length + 31) / 32) * 32);
         let new_memory_size_word = (new_bytes_len + 31) / 32;
         let new_memory_cost = (new_memory_size_word * new_memory_size_word) / 512;
         let new_memory_cost = new_memory_cost + (3 * new_memory_size_word);

--- a/crates/evm/src/tests/test_memory.cairo
+++ b/crates/evm/src/tests/test_memory.cairo
@@ -223,7 +223,47 @@ fn test__expand__should_return_expanded_memory_and_cost() {
 
     // Then
     assert(cost >= 0, 'cost should be positive');
-    assert(memory.bytes_len == 33, 'memory should be 33bytes');
+    assert(memory.bytes_len == 64, 'memory should be 64bytes');
+    let value = memory.load_internal(0);
+    assert(value == 1, 'value should be 1');
+}
+
+#[test]
+#[available_gas(2000000000)]
+fn test__expand__should_return_expanded_memory_by_exactly_one_word_and_cost() {
+    // Given
+    let mut memory = MemoryTrait::new();
+    let value: u256 = 1;
+    let bytes_array = helpers::u256_to_bytes_array(value);
+
+    memory.store_n(bytes_array.span(), 0);
+
+    // When
+    let cost = memory.expand(32);
+
+    // Then
+    assert(cost >= 0, 'cost should be positive');
+    assert(memory.bytes_len == 64, 'memory should be 64bytes');
+    let value = memory.load_internal(0);
+    assert(value == 1, 'value should be 1');
+}
+
+#[test]
+#[available_gas(2000000000)]
+fn test__expand__should_return_expanded_memory_by_two_words_and_cost() {
+    // Given
+    let mut memory = MemoryTrait::new();
+    let value: u256 = 1;
+    let bytes_array = helpers::u256_to_bytes_array(value);
+
+    memory.store_n(bytes_array.span(), 0);
+
+    // When
+    let cost = memory.expand(33);
+
+    // Then
+    assert(cost >= 0, 'cost should be positive');
+    assert(memory.bytes_len == 96, 'memory should be 96bytes');
     let value = memory.load_internal(0);
     assert(value == 1, 'value should be 1');
 }
@@ -263,7 +303,7 @@ fn test__ensure_length__should_return_expanded_memory_and_cost() {
 
     // Then
     assert(cost >= 0, 'cost should be positive');
-    assert(memory.bytes_len == 33, 'memory should be 33bytes');
+    assert(memory.bytes_len == 64, 'memory should be 64bytes');
     let value = memory.load_internal(0);
     assert(value == 1, 'value should be 1');
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #283 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Memory expansion is by increments of modulo 32.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
