### PR TITLE
feat: implement the test suite for 0x52 - MSTORE opcode

### DIFF
--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -6,7 +6,6 @@ use evm::context::{
 use evm::errors::EVMError;
 use evm::stack::StackTrait;
 
-
 #[generate_trait]
 impl MemoryOperation of MemoryOperationTrait {
     /// MLOAD operation.

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -19,6 +19,7 @@ impl MemoryOperation of MemoryOperationTrait {
     /// Save word to memory.
     /// # Specification: https://www.evm.codes/#52?fork=shanghai
     fn exec_mstore(ref self: ExecutionContext) -> Result<(), EVMError> {
+        panic_with_felt252('MSTORE not implement yet');
         Result::Ok(())
     }
 

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -77,3 +77,82 @@ fn test_exec_pop_should_stack_underflow() {
         result.unwrap_err() == EVMError::StackError(STACK_UNDERFLOW), 'should return StackUnderflow'
     );
 }
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('MSTORE not implement yet',))]
+fn test_exec_mstore_should_store_only_F_offset_1() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    ctx.stack.push(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    ctx.stack.push(0x01);
+
+    // When
+    let result = ctx.exec_mstore();
+
+    // Then
+    assert(result.is_ok(), 'should have succeed');
+    let (stored, _) = ctx.memory.load(1);
+    assert(
+        stored == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+        'should have store only Fs'
+    );
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('MSTORE not implement yet',))]
+fn test_exec_mstore_should_store_1_offset_1() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    ctx.stack.push(0x01);
+    ctx.stack.push(0x01);
+
+    // When
+    let result = ctx.exec_mstore();
+
+    // Then
+    assert(result.is_ok(), 'should have succeed');
+    let (stored, _) = ctx.memory.load(1);
+    assert(stored == 0x01, 'should have store 0x01');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('MSTORE not implement yet',))]
+fn test_exec_mstore_should_store_0xFF_offset_1() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    ctx.stack.push(0xFF);
+    ctx.stack.push(0x01);
+
+    // When
+    let result = ctx.exec_mstore();
+
+    // Then
+    assert(result.is_ok(), 'should have succeed');
+    let (stored, _) = ctx.memory.load(0);
+    assert(stored == 0x00, 'should be 0s');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('MSTORE not implement yet',))]
+fn test_exec_mstore_should_store_0xFF00_offset_1() {
+    // Given
+    let mut ctx = setup_execution_context();
+
+    ctx.stack.push(0xFF);
+    ctx.stack.push(0x01);
+
+    // When
+    let result = ctx.exec_mstore();
+
+    // Then
+    assert(result.is_ok(), 'should have succeed');
+    let (stored, _) = ctx.memory.load(0);
+    assert(stored == 0xFF, 'should be 0xFF');
+}

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -145,7 +145,7 @@ fn test_exec_mstore_should_store_0xFF00_offset_1() {
     // Given
     let mut ctx = setup_execution_context();
 
-    ctx.stack.push(0xFF);
+    ctx.stack.push(0xFF00);
     ctx.stack.push(0x01);
 
     // When


### PR DESCRIPTION
I have implemented the tests found at https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/VMTests/vmIOandFlowOperations/mstoreFiller.yml which include those from kakarot v0.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #247 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
