### PR TITLE
feat: add tests for JUMP instruction

### DIFF
--- a/crates/evm/src/errors.cairo
+++ b/crates/evm/src/errors.cairo
@@ -11,12 +11,16 @@ const TYPE_CONVERSION_ERROR: felt252 = 'KKT: type conversion error';
 // RETURNDATA
 const RETURNDATA_OUT_OF_BOUNDS_ERROR: felt252 = 'KKT: ReturnDataOutOfBounds';
 
+// JUMP
+const INVALID_DESTINATION: felt252 = 'KKT: invalid JUMP destination';
+
 #[derive(Drop, Copy, PartialEq)]
 enum EVMError {
     StackError: felt252,
     InvalidProgramCounter: felt252,
     TypeConversionError: felt252,
-    ReturnDataError: felt252
+    ReturnDataError: felt252,
+    JumpError: felt252,
 }
 
 
@@ -27,6 +31,7 @@ impl EVMErrorIntoU256 of Into<EVMError, u256> {
             EVMError::InvalidProgramCounter(error_message) => error_message.into(),
             EVMError::TypeConversionError(error_message) => error_message.into(),
             EVMError::ReturnDataError(error_message) => error_message.into(),
+            EVMError::JumpError(error_message) => error_message.into(),
         }
     }
 }

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -50,7 +50,7 @@ impl MemoryOperation of MemoryOperationTrait {
     /// The new pc target has to be a JUMPDEST opcode.
     /// # Specification: https://www.evm.codes/#56?fork=shanghai
     fn exec_jump(ref self: ExecutionContext) -> Result<(), EVMError> {
-        Result::Ok(())
+        panic_with_felt252('JUMP not implement yet')
     }
 
     /// 0x57 - JUMPI operation.

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -8,7 +8,7 @@ use evm::memory::{InternalMemoryTrait, MemoryTrait};
 use starknet::EthAddressIntoFelt252;
 use utils::helpers::{u256_to_bytes_array};
 use utils::traits::{EthAddressIntoU256};
-use evm::errors::{EVMError, STACK_UNDERFLOW};
+use evm::errors::{EVMError, STACK_UNDERFLOW, INVALID_DESTINATION};
 use evm::context::{
     ExecutionContext, ExecutionContextTrait, BoxDynamicExecutionContextDestruct, CallContextTrait,
 };
@@ -253,7 +253,6 @@ fn test_exec_mstore8_should_store_last_uint8_offset_63() {
     assert(stored == 0xEF, 'mstore8 failed');
 }
 
-
 #[test]
 #[available_gas(20000000)]
 fn test_msize_initial() {
@@ -299,4 +298,81 @@ fn test_exec_msize_store_max_offset_1() {
     assert(result.is_ok(), 'should have succeeded');
     assert(ctx.stack.len() == 1, 'stack should have one element');
     assert(ctx.stack.pop().unwrap() == 64, 'should 64 bytes after MSTORE');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMP not implement yet',))]
+fn test_exec_jump_valid() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let counter = 0x03;
+    ctx.stack.push(counter);
+
+    // When
+    ctx.exec_jump();
+
+    // Then
+    let pc = ctx.program_counter;
+    assert(pc == 0x03, 'PC should be JUMPDEST');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMP not implement yet',))]
+fn test_exec_jump_invalid() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let counter = 0x02;
+    ctx.stack.push(counter);
+
+    // When
+    let result = ctx.exec_jump();
+
+    // Then
+    assert(result.is_err(), 'invalid jump dest');
+    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMP not implement yet',))]
+fn test_exec_jump_out_of_bounds() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let counter = 0xFF;
+    ctx.stack.push(counter);
+
+    // When
+    let result = ctx.exec_jump();
+
+    // Then
+    assert(result.is_err(), 'invalid jump dest');
+    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+}
+
+// TODO: This is third edge case in which `0x5B` is part of PUSHN instruction and hence
+// not a valid opcode to jump to
+//
+// Remove ignore once its handled
+#[test]
+#[available_gas(20000000)]
+#[ignore]
+fn test_exec_jump_inside_pushn() {
+    // Given
+    let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let counter = 0x01;
+    ctx.stack.push(counter);
+
+    // When
+    let result = ctx.exec_jump();
+
+    // Then
+    assert(result.is_err(), 'invalid jump dest');
+    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Other (please describe): adding test before implementing instruction as mentioned in issue

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #251

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- evm.codes doesn't contain an example for this
- i couldn't find test for this in geth or kakarot cairo0 (lmk if i missed something)
- i think thats because there are only 2 cases, one in which location to which we need to jump is `JUMPDEST` (in that case its valid) else its invalid
- actually there is one more case in which: `0x5B` is part of data segment and is not an opcode (in an PUSHN) context.
  - kakarot 0 also doesn't handle this case, i will see geth's code and figure out how to implement this.

## Does this introduce a breaking change?

- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
