### PR TITLE
Fix compare_snapshot CI

### DIFF
--- a/.github/workflows/gas_reports.yml
+++ b/.github/workflows/gas_reports.yml
@@ -35,21 +35,3 @@ jobs:
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
-
-      # - name: Comment on PR
-      #   uses: thollander/actions-comment-pull-request@v2
-      #   with:
-      #     message: "Snapshot Comparison Report:\n\n${{
-      #       steps.run-script.outputs.result }}" # Access the result output variable
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     comment_tag: gas-report
-
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "Snapshot Comparison Report:\n\n${{steps.run-script.outputs.result }}"
-            })

--- a/.github/workflows/gas_reports.yml
+++ b/.github/workflows/gas_reports.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   compare-snapshot:
+    permissions: write-all
     runs-on: ubuntu-latest
 
     steps:
@@ -35,10 +36,20 @@ jobs:
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
 
-      - name: Comment on PR
-        uses: thollander/actions-comment-pull-request@v2
+      # - name: Comment on PR
+      #   uses: thollander/actions-comment-pull-request@v2
+      #   with:
+      #     message: "Snapshot Comparison Report:\n\n${{
+      #       steps.run-script.outputs.result }}" # Access the result output variable
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     comment_tag: gas-report
+
+      - uses: actions/github-script@v6
         with:
-          message: "Snapshot Comparison Report:\n\n${{
-            steps.run-script.outputs.result }}" # Access the result output variable
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          comment_tag: gas-report
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Snapshot Comparison Report:\n\n${{steps.run-script.outputs.result }}"
+            })


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The gas report CI is not allowed to post on PR page. After some research, it seems like the only way to have such a feature would be:
- long and honest: create an app (like codecov)
- short and hacky: create a personal token and use it, the user owning the token would be the posting username

See also: https://github.com/actions/first-interaction/issues/10

## What is the new behavior?

Since the detailed output is also visible in the CI logs, I've just removed the comment step to have the job pass if there is no change and fail otherwise

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
