### PR TITLE
Feat: Divide Bitshift into Bitshift and WrappingBitshift

### DIFF
--- a/crates/evm/src/instructions/comparison_operations.cairo
+++ b/crates/evm/src/instructions/comparison_operations.cairo
@@ -4,7 +4,7 @@ use evm::context::ExecutionContextTrait;
 use evm::stack::StackTrait;
 use evm::errors::STACK_UNDERFLOW;
 use evm::errors::EVMError;
-use utils::math::{Exponentiation, Bitshift};
+use utils::math::{Exponentiation, Bitshift, WrappingBitshift};
 use utils::constants::{POW_2_127};
 use evm::context::BoxDynamicExecutionContextDestruct;
 use utils::u256_signed_math::SignedPartialOrd;

--- a/crates/utils/src/math.cairo
+++ b/crates/utils/src/math.cairo
@@ -135,7 +135,22 @@ impl Felt252WrappingBitshiftImpl of WrappingBitshift<felt252> {
     }
 
     fn wrapping_shr(self: felt252, shift: felt252) -> felt252 {
-        panic_with_felt252('felt252 shl not implemented')
+        
+        // converting to u256
+        let val: u256 = self.into();
+        let shift_u256: u256 = shift.into();
+
+        // early return to save gas if shift > 255 
+        if shift_u256 > 255 {
+            return 0;
+        }
+
+        let shifted_u256 = val / 2_u256.wrapping_pow(shift_u256);
+
+        // convert back to felt252
+        let result: felt252 = shifted_u256.try_into().unwrap();
+
+        result 
     }
 }
 

--- a/crates/utils/src/math.cairo
+++ b/crates/utils/src/math.cairo
@@ -94,7 +94,6 @@ trait Bitshift<T> {
     // # Panics
     // Panics if the shift is greater than 255.
     fn shr(self: T, shift: T) -> T;
-
 }
 
 impl U256BitshiftImpl of Bitshift<u256> {
@@ -113,11 +112,9 @@ impl U256BitshiftImpl of Bitshift<u256> {
         }
         self / 2.pow(shift)
     }
-
 }
 
 trait WrappingBitshift<T> {
-
     // Shift a number left by a given number of bits.
     // If the shift is greater than 255, the result is 0.
     // The bits moved after the 256th one are discarded, the new bits are set to 0.
@@ -129,13 +126,11 @@ trait WrappingBitshift<T> {
 }
 
 impl Felt252WrappingBitshiftImpl of WrappingBitshift<felt252> {
-
     fn wrapping_shl(self: felt252, shift: felt252) -> felt252 {
         self * 2.wrapping_pow(shift)
     }
 
     fn wrapping_shr(self: felt252, shift: felt252) -> felt252 {
-        
         // converting to u256
         let val: u256 = self.into();
         let shift_u256: u256 = shift.into();
@@ -150,12 +145,11 @@ impl Felt252WrappingBitshiftImpl of WrappingBitshift<felt252> {
         // convert back to felt252
         let result: felt252 = shifted_u256.try_into().unwrap();
 
-        result 
+        result
     }
 }
 
 impl U256WrappingBitshiftImpl of WrappingBitshift<u256> {
-
     fn wrapping_shl(self: u256, shift: u256) -> u256 {
         let (result, _) = u256_overflow_mul(self, 2.wrapping_pow(shift));
         result

--- a/crates/utils/src/math.cairo
+++ b/crates/utils/src/math.cairo
@@ -144,7 +144,6 @@ impl Felt252WrappingBitshiftImpl of WrappingBitshift<felt252> {
 
         // convert back to felt252
         shifted_u256.try_into().unwrap()
-
     }
 }
 

--- a/crates/utils/src/math.cairo
+++ b/crates/utils/src/math.cairo
@@ -133,19 +133,18 @@ impl Felt252WrappingBitshiftImpl of WrappingBitshift<felt252> {
     fn wrapping_shr(self: felt252, shift: felt252) -> felt252 {
         // converting to u256
         let val: u256 = self.into();
-        let shift_u256: u256 = shift.into();
+        let shift: u256 = shift.into();
 
         // early return to save gas if shift > 255 
-        if shift_u256 > 255 {
+        if shift > 255 {
             return 0;
         }
 
-        let shifted_u256 = val / 2_u256.wrapping_pow(shift_u256);
+        let shifted_u256 = val / 2_u256.wrapping_pow(shift);
 
         // convert back to felt252
-        let result: felt252 = shifted_u256.try_into().unwrap();
+        shifted_u256.try_into().unwrap()
 
-        result
     }
 }
 

--- a/crates/utils/src/math.cairo
+++ b/crates/utils/src/math.cairo
@@ -95,14 +95,6 @@ trait Bitshift<T> {
     // Panics if the shift is greater than 255.
     fn shr(self: T, shift: T) -> T;
 
-    // Shift a number left by a given number of bits.
-    // If the shift is greater than 255, the result is 0.
-    // The bits moved after the 256th one are discarded, the new bits are set to 0.
-    fn wrapping_shl(self: T, shift: T) -> T;
-
-    // Shift a number right by a given number of bits.
-    // If the shift is greater than 255, the result is 0.
-    fn wrapping_shr(self: T, shift: T) -> T;
 }
 
 impl Felt252BitshiftImpl of Bitshift<felt252> {
@@ -117,13 +109,6 @@ impl Felt252BitshiftImpl of Bitshift<felt252> {
         panic_with_felt252('felt252 shr not implemented')
     }
 
-    fn wrapping_shl(self: felt252, shift: felt252) -> felt252 {
-        self * 2.wrapping_pow(shift)
-    }
-
-    fn wrapping_shr(self: felt252, shift: felt252) -> felt252 {
-        panic_with_felt252('felt252 shl not implemented')
-    }
 }
 
 impl U256BitshiftImpl of Bitshift<u256> {
@@ -142,6 +127,33 @@ impl U256BitshiftImpl of Bitshift<u256> {
         }
         self / 2.pow(shift)
     }
+
+}
+
+trait WrappingBitshift<T> {
+
+    // Shift a number left by a given number of bits.
+    // If the shift is greater than 255, the result is 0.
+    // The bits moved after the 256th one are discarded, the new bits are set to 0.
+    fn wrapping_shl(self: T, shift: T) -> T;
+
+    // Shift a number right by a given number of bits.
+    // If the shift is greater than 255, the result is 0.
+    fn wrapping_shr(self: T, shift: T) -> T;
+}
+
+impl Felt252WrappingBitshiftImpl of WrappingBitshift<felt252> {
+
+    fn wrapping_shl(self: felt252, shift: felt252) -> felt252 {
+        self * 2.wrapping_pow(shift)
+    }
+
+    fn wrapping_shr(self: felt252, shift: felt252) -> felt252 {
+        panic_with_felt252('felt252 shl not implemented')
+    }
+}
+
+impl U256WrappingBitshiftImpl of WrappingBitshift<u256> {
 
     fn wrapping_shl(self: u256, shift: u256) -> u256 {
         let (result, _) = u256_overflow_mul(self, 2.wrapping_pow(shift));

--- a/crates/utils/src/math.cairo
+++ b/crates/utils/src/math.cairo
@@ -97,20 +97,6 @@ trait Bitshift<T> {
 
 }
 
-impl Felt252BitshiftImpl of Bitshift<felt252> {
-    // felt252 should normally not be used for a such operation.
-    // However, taking optimisation into account, there are cases that arise
-    // where using them is safe when values are bounded, and it is less expensive than their u256 counterparty.
-    fn shl(self: felt252, shift: felt252) -> felt252 {
-        panic_with_felt252('felt252 shl not implemented')
-    }
-
-    fn shr(self: felt252, shift: felt252) -> felt252 {
-        panic_with_felt252('felt252 shr not implemented')
-    }
-
-}
-
 impl U256BitshiftImpl of Bitshift<u256> {
     fn shl(self: u256, shift: u256) -> u256 {
         if shift > 255 {

--- a/crates/utils/src/tests/test_math.cairo
+++ b/crates/utils/src/tests/test_math.cairo
@@ -219,3 +219,36 @@ fn test_wrapping_shr_to_zero() {
     assert(result == expected, 'wrong result');
 }
 
+#[test]
+#[available_gas(20000000)]
+fn test_felt252_wrapping_shr() {
+    // Given
+    let a = 0x0091b2efa2bfd58aee61f24201bac4e64f70ca2b9d9491e82a498f2aade6263a_felt252;
+    // 1-byte shift is an 8-bit shift
+    let shift = 2 * 8;
+
+    // When
+    let result = a.wrapping_shr(shift);
+
+    // Then
+    let expected = 0x00000091b2efa2bfd58aee61f24201bac4e64f70ca2b9d9491e82a498f2aade6_felt252;
+    assert(result == expected, 'wrong result');
+}
+
+
+#[test]
+#[available_gas(20000000000)]
+fn test_felt252_wrapping_shr_to_zero() {
+    // Given
+    let a = 0x0091b2efa2bfd58aee61f24201bac4e64f70ca2b9d9491e82a498f2aade6263a_felt252;
+    // 1-byte shift is an 8-bit shift
+    let shift = 32 * 8;
+
+    // When
+    let result = a.wrapping_shr(shift);
+
+    // Then
+    let expected = 0_felt252;
+    assert(result == expected, 'wrong result');
+}
+

--- a/crates/utils/src/tests/test_math.cairo
+++ b/crates/utils/src/tests/test_math.cairo
@@ -1,5 +1,7 @@
 use integer::{u256_overflowing_add, BoundedInt, u512};
-use utils::math::{Exponentiation, WrappingExponentiation, u256_wide_add, Bitshift, WrappingBitshift};
+use utils::math::{
+    Exponentiation, WrappingExponentiation, u256_wide_add, Bitshift, WrappingBitshift
+};
 
 #[test]
 #[available_gas(20000000)]

--- a/crates/utils/src/tests/test_math.cairo
+++ b/crates/utils/src/tests/test_math.cairo
@@ -1,5 +1,5 @@
 use integer::{u256_overflowing_add, BoundedInt, u512};
-use utils::math::{Exponentiation, WrappingExponentiation, u256_wide_add, Bitshift};
+use utils::math::{Exponentiation, WrappingExponentiation, u256_wide_add, Bitshift, WrappingBitshift};
 
 #[test]
 #[available_gas(20000000)]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
 Split Bitshift into two traits, Modified the existing implementations of bitshift, Removed the shl and shr implementations for felt252, Added support for wrapping_shr for the felt252 type by converting the value to u256, doing the operations, and then back to felt252 instead of panicking

## Pull Request type
<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
wrapping_shl and wrapping_shl implemented as part of the Bitshift trait. 

Resolves: #338 

## What is the new behavior?
split Bitshift into Bitshift and WrappingBitshift traits by adding a new WrappingBitshift trait and moving the logic for wrapping bitshifts into it. Added support for felt252 wrapping shr, and tests for the felt252 type. Removed implementations for felt252 shl and shr


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
