### PR TITLE
feat: implement JUMPI tests

### DIFF
--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -86,7 +86,7 @@ impl MemoryOperation of MemoryOperationTrait {
     /// The new pc target has to be a JUMPDEST opcode.
     /// # Specification: https://www.evm.codes/#57?fork=shanghai
     fn exec_jumpi(ref self: ExecutionContext) -> Result<(), EVMError> {
-        Result::Ok(())
+        panic_with_felt252('JUMPI not implemented yet')
     }
 
     /// 0x5b - JUMPDEST operation

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -434,7 +434,7 @@ fn test_exec_jumpi_valid_zero() {
 
     // Then
     let pc = ctx.program_counter;
-    // ideally we should assert that it incremented, but incrementing is done by `decode_and_execut`
+    // ideally we should assert that it incremented, but incrementing is done by `decode_and_execute`
     // so we can assume that will be done
     assert(pc == old_pc, 'PC should be same');
 }

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -373,3 +373,137 @@ fn test_exec_jump_inside_pushn() {
     assert(result.is_err(), 'invalid jump dest');
     assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
 }
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMPI not implemented yet',))]
+fn test_exec_jumpi_valid_non_zero_1() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let b = 0x1;
+    ctx.stack.push(b);
+    let counter = 0x03;
+    ctx.stack.push(counter);
+    let old_pc = ctx.program_counter;
+
+    // When
+    ctx.exec_jumpi();
+
+    // Then
+    let pc = ctx.program_counter;
+    assert(pc == 0x03, 'PC should be JUMPDEST');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMPI not implemented yet',))]
+fn test_exec_jumpi_valid_non_zero_2() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let b = 0x69;
+    ctx.stack.push(b);
+    let counter = 0x03;
+    ctx.stack.push(counter);
+    let old_pc = ctx.program_counter;
+
+    // When
+    ctx.exec_jumpi();
+
+    // Then
+    let pc = ctx.program_counter;
+    assert(pc == 0x03, 'PC should be JUMPDEST');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMPI not implemented yet',))]
+fn test_exec_jumpi_valid_zero() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let b = 0x0;
+    ctx.stack.push(b);
+    let counter = 0x03;
+    ctx.stack.push(counter);
+    let old_pc = ctx.program_counter;
+
+    // When
+    ctx.exec_jumpi();
+
+    // Then
+    let pc = ctx.program_counter;
+    // ideally we should assert that it incremented, but incrementing is done by `decode_and_execut`
+    // so we can assume that will be done
+    assert(pc == old_pc, 'PC should be same');
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMPI not implemented yet',))]
+fn test_exec_jumpi_invalid_non_zero() {
+    // Given
+    let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let b = 0x69;
+    ctx.stack.push(b);
+    let counter = 0x69;
+    ctx.stack.push(counter);
+
+    // When
+    let result = ctx.exec_jumpi();
+
+    // Then
+    assert(result.is_err(), 'invalid jump dest');
+    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMPI not implemented yet',))]
+fn test_exec_jumpi_invalid_zero() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let b = 0x0;
+    ctx.stack.push(b);
+    let counter = 0x69;
+    ctx.stack.push(counter);
+    let old_pc = ctx.program_counter;
+
+    // When
+    ctx.exec_jumpi();
+
+    // Then
+    let pc = ctx.program_counter;
+    // ideally we should assert that it incremented, but incrementing is done by `decode_and_execut`
+    // so we can assume that will be done
+    assert(pc == old_pc, 'PC should be same');
+}
+
+// TODO: This is third edge case in which `0x5B` is part of PUSHN instruction and hence
+// not a valid opcode to jump to
+//
+// Remove ignore once its handled
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('JUMPI not implemented yet',))]
+#[ignore]
+fn test_exec_jumpi_inside_pushn() {
+    // Given
+    let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();
+    let mut ctx = setup_execution_context_with_bytecode(bytecode);
+    let b = 0x00;
+    ctx.stack.push(b);
+    let counter = 0x01;
+    ctx.stack.push(counter);
+
+    // When
+    let result = ctx.exec_jumpi();
+
+    // Then
+    assert(result.is_err(), 'invalid jump dest');
+    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #253 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- didn't find test for this in kakarot0, evm.codes, geth
- execution spec has something to test jumpi [(but it tests something very different)](https://github.com/ethereum/execution-specs/blob/master/tests/constantinople/vm/test_control_flow_operations.py) 
- out of bounds and those tests are not required because we would be using implementation of `JUMP` opcode to implement `JUMPI` which tests those cases.

## Does this introduce a breaking change?

- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
