### PR TITLE
Fix: changed endian syntax to le/be

### DIFF
--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -71,12 +71,12 @@ fn pow256_rev(i: usize) -> u256 {
 
 /// Splits a u256 into `len` bytes, big-endian, and appends the result to `dst`.
 fn split_word(mut value: u256, mut len: usize, ref dst: Array<u8>) {
-    let little_endian = split_word_little(value, len);
-    let big_endian = ArrayExtensionTrait::reverse(little_endian.span());
-    ArrayExtensionTrait::concat(ref dst, big_endian.span());
+    let word_le = split_word_le(value, len);
+    let word_be = ArrayExtensionTrait::reverse(word_le.span());
+    ArrayExtensionTrait::concat(ref dst, word_be.span());
 }
 
-fn split_u128_little(ref dest: Array<u8>, mut value: u128, mut len: usize) {
+fn split_u128_le(ref dest: Array<u8>, mut value: u128, mut len: usize) {
     loop {
         if len == 0 {
             assert(value == 0, 'split_words:value not 0');
@@ -89,12 +89,12 @@ fn split_u128_little(ref dest: Array<u8>, mut value: u128, mut len: usize) {
 }
 
 /// Splits a u256 into `len` bytes, little-endian, and returns the bytes array.
-fn split_word_little(mut value: u256, mut len: usize) -> Array<u8> {
+fn split_word_le(mut value: u256, mut len: usize) -> Array<u8> {
     let mut dst: Array<u8> = ArrayTrait::new();
     let low_len = min(len, 16);
-    split_u128_little(ref dst, value.low, low_len);
+    split_u128_le(ref dst, value.low, low_len);
     let high_len = min(len - low_len, 16);
-    split_u128_little(ref dst, value.high, high_len);
+    split_u128_le(ref dst, value.high, high_len);
     dst
 }
 

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -69,24 +69,24 @@ fn test_load_word() {
 
 #[test]
 #[available_gas(2000000000)]
-fn test_split_word_little() {
+fn test_split_word_le() {
     // Test with 0 value and 0 len
-    let res0 = helpers::split_word_little(0, 0);
+    let res0 = helpers::split_word_le(0, 0);
     assert(res0.len() == 0, 'res0: wrong length');
 
     // Test with single byte value
-    let res1 = helpers::split_word_little(1, 1);
+    let res1 = helpers::split_word_le(1, 1);
     assert(res1.len() == 1, 'res1: wrong length');
     assert(*res1[0] == 1, 'res1: wrong value');
 
     // Test with two byte value
-    let res2 = helpers::split_word_little(257, 2); // 257 = 0x0101
+    let res2 = helpers::split_word_le(257, 2); // 257 = 0x0101
     assert(res2.len() == 2, 'res2: wrong length');
     assert(*res2[0] == 1, 'res2: wrong value at index 0');
     assert(*res2[1] == 1, 'res2: wrong value at index 1');
 
     // Test with four byte value
-    let res3 = helpers::split_word_little(67305985, 4); // 67305985 = 0x04030201
+    let res3 = helpers::split_word_le(67305985, 4); // 67305985 = 0x04030201
     assert(res3.len() == 4, 'res3: wrong length');
     assert(*res3[0] == 1, 'res3: wrong value at index 0');
     assert(*res3[1] == 2, 'res3: wrong value at index 1');
@@ -95,7 +95,7 @@ fn test_split_word_little() {
 
     // Test with 16 byte value (u128 max value)
     let max_u128: u256 = 340282366920938463463374607431768211454; // u128 max value - 1
-    let res4 = helpers::split_word_little(max_u128, 16);
+    let res4 = helpers::split_word_le(max_u128, 16);
     assert(res4.len() == 16, 'res4: wrong length');
     assert(*res4[0] == 0xfe, 'res4: wrong MSB value');
 


### PR DESCRIPTION
For the sake of consitency, we are switching the syntax of endian wording.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
