### PR TITLE
Fix no GITHUB_STEP_SUMMARY

### DIFF
--- a/.github/workflows/gas_reports.yml
+++ b/.github/workflows/gas_reports.yml
@@ -33,9 +33,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          result=$(python scripts/compare_snapshot.py)
-          result=$(echo "$result" | tail -n +3) # Strip the first two lines
-          result="${result//'%'/'%25'}"
-          result="${result//$'\n'/'%0A'}"
-          result="${result//$'\r'/'%0D'}"
-          echo "${result}" >> $GITHUB_STEP_SUMMARY
+          result=$(python scripts/compare_snapshot.py 2>&1)
+          exit_code=$?
+          echo "$result" >> "$GITHUB_STEP_SUMMARY"
+          exit $exit_code


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Summary is not displayed in action when failure

## What is the new behavior?

Displayed in both success and failure.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
