### PR TITLE
fix: returndata

### DIFF
--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -165,7 +165,7 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
     /// Get the size of return data.
     /// # Specification: https://www.evm.codes/#3d?fork=shanghai
     fn exec_returndatasize(ref self: Machine) -> Result<(), EVMError> {
-        let size: u32 = self.return_data().len();
+        let size = self.return_data().len();
         self.stack.push(size.into())
     }
 

--- a/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
@@ -17,7 +17,7 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
     /// Halts the execution of the current program.
     /// # Specification: https://www.evm.codes/#00?fork=shanghai
     fn exec_stop(ref self: Machine) -> Result<(), EVMError> {
-        self.stop();
+        self.set_stopped();
         Result::Ok(())
     }
 

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -35,7 +35,7 @@ impl SystemOperations of SystemOperationsTrait {
         let mut return_data = Default::default();
         self.memory.load_n(size, ref return_data, offset);
         self.set_return_data(return_data.span());
-        self.stopped();
+        self.set_stopped();
         Result::Ok(())
     }
 

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -34,8 +34,8 @@ impl SystemOperations of SystemOperationsTrait {
         let size = self.stack.pop_usize()?;
         let mut return_data = Default::default();
         self.memory.load_n(size, ref return_data, offset);
-        self.set_parent_return_data(return_data.span());
-        self.stop();
+        self.set_return_data(return_data.span());
+        self.stopped();
         Result::Ok(())
     }
 

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -32,9 +32,9 @@ impl SystemOperations of SystemOperationsTrait {
     fn exec_return(ref self: Machine) -> Result<(), EVMError> {
         let offset = self.stack.pop_usize()?;
         let size = self.stack.pop_usize()?;
-        let mut return_data = array![];
+        let mut return_data = Default::default();
         self.memory.load_n(size, ref return_data, offset);
-        self.set_return_data(return_data);
+        self.set_parent_return_data(return_data.span());
         self.stop();
         Result::Ok(())
     }

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -2,6 +2,7 @@
 
 /// Internal imports.
 use evm::context::{CallContextTrait, Status};
+use evm::context::{ExecutionContextTrait, ExecutionContext};
 use evm::errors::{EVMError, PC_OUT_OF_BOUNDS};
 use evm::instructions::{
     duplication_operations, environmental_information, ExchangeOperationsTrait, logging_operations,
@@ -11,7 +12,6 @@ use evm::instructions::{
     MemoryOperationTrait
 };
 use evm::machine::{Machine, MachineCurrentContextTrait};
-use evm::context::{ExecutionContextTrait, ExecutionContext};
 use evm::storage_journal::JournalTrait;
 use utils::{helpers::u256_to_bytes_array};
 

--- a/crates/evm/src/machine.cairo
+++ b/crates/evm/src/machine.cairo
@@ -6,9 +6,9 @@ use evm::{
     },
     stack::{Stack, StackTrait}, memory::{Memory, MemoryTrait}
 };
+use nullable::{match_nullable, FromNullableResult};
 
 use starknet::{EthAddress, ContractAddress};
-use nullable::{match_nullable, FromNullableResult};
 
 #[derive(Destruct)]
 struct Machine {

--- a/crates/evm/src/tests/test_execution_context.cairo
+++ b/crates/evm/src/tests/test_execution_context.cairo
@@ -77,8 +77,7 @@ fn test_execution_context_new() {
         starknet_address,
         call_ctx,
         parent_ctx,
-        Default::default(),
-        return_data
+        return_data.span()
     );
 
     // Then
@@ -107,7 +106,7 @@ fn test_execution_context_stop_and_revert() {
     let mut execution_context = setup_execution_context();
 
     // When
-    execution_context.stop();
+    execution_context.set_stopped();
 
     // Then
     assert(execution_context.stopped() == true, 'should be stopped');
@@ -121,11 +120,10 @@ fn test_execution_context_revert() {
 
     // When
     let revert_reason = array![0, 1, 2, 3].span();
-    execution_context.revert(revert_reason);
+    execution_context.set_reverted();
 
     // Then
     assert(execution_context.reverted() == true, 'should be reverted');
-    assert(execution_context.return_data() == revert_reason, 'wrong revert reason');
 }
 
 #[test]
@@ -159,20 +157,6 @@ fn test_is_root() {
 
 #[test]
 #[available_gas(300000)]
-fn test_child_return_data() {
-    // Given
-    let mut execution_context = setup_execution_context();
-
-    // When
-    let child_return_data = execution_context.child_return_data().unwrap();
-
-    // Then
-    assert(child_return_data == array![1, 2, 3].span(), 'wrong child_return_data');
-}
-
-
-#[test]
-#[available_gas(300000)]
 fn test_origin() {
     // Given
     let mut execution_context = setup_nested_execution_context();
@@ -181,5 +165,5 @@ fn test_origin() {
     let origin = execution_context.origin();
 
     // Then
-    assert(origin == evm_address(), 'wrong child_return_data');
+    assert(origin == evm_address(), 'wrong origin');
 }

--- a/crates/evm/src/tests/test_execution_context.cairo
+++ b/crates/evm/src/tests/test_execution_context.cairo
@@ -72,12 +72,7 @@ fn test_execution_context_new() {
 
     // When
     let mut execution_context = ExecutionContextTrait::new(
-        context_id,
-        evm_address,
-        starknet_address,
-        call_ctx,
-        parent_ctx,
-        return_data.span()
+        context_id, evm_address, starknet_address, call_ctx, parent_ctx, return_data.span()
     );
 
     // Then

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -6,7 +6,7 @@ use evm::memory::{InternalMemoryTrait, MemoryTrait};
 use evm::stack::StackTrait;
 use evm::tests::test_utils::{
     setup_machine, setup_machine_with_calldata, setup_machine_with_bytecode, evm_address, callvalue,
-    setup_machine_with_nested_execution_context, other_evm_address
+    setup_machine_with_nested_execution_context, other_evm_address, return_from_subcontext
 };
 use integer::u32_overflowing_add;
 
@@ -474,14 +474,7 @@ fn test_returndatasize() {
     let return_data: Array<u8> = array![1, 2, 3, 4, 5];
     let size = return_data.len();
     let mut machine = setup_machine_with_nested_execution_context();
-
-    // Simulate return of subcontext where
-    /// 1. Set `return_data` field of parent context
-    /// 2. make `parent_ctx` of `current_ctx` the current ctx
-    machine.set_parent_return_data(return_data.span());
-    let current_ctx = machine.current_ctx.unbox();
-    let parent_ctx = current_ctx.parent_ctx.deref();
-    machine.current_ctx = BoxTrait::new(parent_ctx);
+    return_from_subcontext(ref machine, return_data.span());
 
     machine.exec_returndatasize();
 
@@ -588,13 +581,7 @@ fn test_returndata_copy(dest_offset: u32, offset: u32, mut size: u32) {
         36
     ];
 
-    // Simulate return of subcontext where
-    /// 1. Set `return_data` field of parent context
-    /// 2. make `parent_ctx` of `current_ctx` the current ctx
-    machine.set_parent_return_data(return_data.span());
-    let current_ctx = machine.current_ctx.unbox();
-    let parent_ctx = current_ctx.parent_ctx.deref();
-    machine.current_ctx = BoxTrait::new(parent_ctx);
+    return_from_subcontext(ref machine, return_data.span());
     let return_data: Span<u8> = machine.return_data();
 
     if (size == 0) {

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -473,8 +473,15 @@ fn test_returndatasize() {
     // Given
     let return_data: Array<u8> = array![1, 2, 3, 4, 5];
     let size = return_data.len();
-    let mut machine = setup_machine();
-    machine.set_return_data(return_data);
+    let mut machine = setup_machine_with_nested_execution_context();
+
+    // Simulate return of subcontext where
+    /// 1. Set `return_data` field of parent context
+    /// 2. make `parent_ctx` of `current_ctx` the current ctx
+    machine.set_parent_return_data(return_data.span());
+    let current_ctx = machine.current_ctx.unbox();
+    let parent_ctx = current_ctx.parent_ctx.deref();
+    machine.current_ctx = BoxTrait::new(parent_ctx);
 
     machine.exec_returndatasize();
 
@@ -539,49 +546,55 @@ fn test_returndata_copy_with_multiple_words() {
 
 fn test_returndata_copy(dest_offset: u32, offset: u32, mut size: u32) {
     // Given
-    let mut machine = setup_machine();
-    machine
-        .set_return_data(
-            array![
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36
-            ]
-        );
+    let mut machine = setup_machine_with_nested_execution_context();
+    // Set the return data of the current context
 
+    let return_data = array![
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36
+    ];
+
+    // Simulate return of subcontext where
+    /// 1. Set `return_data` field of parent context
+    /// 2. make `parent_ctx` of `current_ctx` the current ctx
+    machine.set_parent_return_data(return_data.span());
+    let current_ctx = machine.current_ctx.unbox();
+    let parent_ctx = current_ctx.parent_ctx.deref();
+    machine.current_ctx = BoxTrait::new(parent_ctx);
     let return_data: Span<u8> = machine.return_data();
 
     if (size == 0) {

--- a/crates/evm/src/tests/test_instructions/test_system_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_system_operations.cairo
@@ -24,6 +24,7 @@ fn test_exec_return() {
 
     // Then
     assert(1000 == load_word(32, parent_ctx_return_data(ref machine)), 'Wrong return_data');
+    assert(machine.stopped(), 'machine should be stopped')
 }
 
 #[test]
@@ -42,4 +43,5 @@ fn test_exec_return_with_offset() {
 
     // Then
     assert(256 == load_word(32, parent_ctx_return_data(ref machine)), 'Wrong return_data');
+    assert(machine.stopped(), 'machine should be stopped')
 }

--- a/crates/evm/src/tests/test_instructions/test_system_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_system_operations.cairo
@@ -3,14 +3,16 @@ use evm::instructions::MemoryOperationTrait;
 use evm::instructions::SystemOperationsTrait;
 use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::stack::StackTrait;
-use evm::tests::test_utils::setup_machine;
+use evm::tests::test_utils::{
+    setup_machine_with_nested_execution_context, setup_machine, parent_ctx_return_data
+};
 use utils::helpers::load_word;
 
 #[test]
 #[available_gas(20000000)]
 fn test_exec_return() {
     // Given
-    let mut machine = setup_machine();
+    let mut machine = setup_machine_with_nested_execution_context();
     // When
     machine.stack.push(1000);
     machine.stack.push(0);
@@ -21,14 +23,14 @@ fn test_exec_return() {
     assert(machine.exec_return().is_ok(), 'Exec return failed');
 
     // Then
-    assert(1000 == load_word(32, machine.return_data()), 'Wrong return_data');
+    assert(1000 == load_word(32, parent_ctx_return_data(ref machine)), 'Wrong return_data');
 }
 
 #[test]
 #[available_gas(20000000)]
 fn test_exec_return_with_offset() {
     // Given
-    let mut machine = setup_machine();
+    let mut machine = setup_machine_with_nested_execution_context();
     // When
     machine.stack.push(1);
     machine.stack.push(0);
@@ -39,5 +41,5 @@ fn test_exec_return_with_offset() {
     assert(machine.exec_return().is_ok(), 'Exec return failed');
 
     // Then
-    assert(256 == load_word(32, machine.return_data()), 'Wrong return_data');
+    assert(256 == load_word(32, parent_ctx_return_data(ref machine)), 'Wrong return_data');
 }

--- a/crates/evm/src/tests/test_machine.cairo
+++ b/crates/evm/src/tests/test_machine.cairo
@@ -55,7 +55,7 @@ fn test_set_pc() {
 fn test_revert() {
     let mut machine = Default::default();
 
-    machine.revert(array![0xde, 0xbf].span());
+    machine.set_reverted();
 
     assert(machine.reverted(), 'ctx should be reverted');
     assert(machine.stopped(), 'ctx should be stopped');
@@ -160,14 +160,4 @@ fn test_return_data() {
 
     let return_data = machine.return_data();
     assert(return_data.len() == 0, 'wrong length');
-}
-
-
-#[test]
-#[available_gas(20000000)]
-fn test_child_return_data() {
-    let mut machine: Machine = setup_machine();
-
-    let return_data = machine.child_return_data().unwrap();
-    assert(return_data == array![1, 2, 3].span(), 'wrong child return data');
 }

--- a/crates/evm/src/tests/test_machine.cairo
+++ b/crates/evm/src/tests/test_machine.cairo
@@ -2,7 +2,7 @@ use evm::context::CallContextTrait;
 use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::tests::test_utils::{
     evm_address, setup_machine_with_bytecode, setup_machine, starknet_address,
-    setup_execution_context
+    setup_execution_context, setup_machine_with_nested_execution_context, parent_ctx_return_data
 };
 
 
@@ -63,10 +63,10 @@ fn test_revert() {
 
 #[test]
 #[available_gas(20000000)]
-fn test_stop() {
+fn test_stopped() {
     let mut machine = Default::default();
 
-    machine.stop();
+    machine.set_stopped();
 
     assert(!machine.reverted(), 'ctx should not be reverted');
     assert(machine.stopped(), 'ctx should be stopped');
@@ -151,6 +151,25 @@ fn test_create_addresses() {
 
     let create_addresses = machine.create_addresses();
     assert(create_addresses.len() == 0, 'wrong length');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+fn test_set_return_data_root() {
+    let mut machine: Machine = Default::default();
+    machine.set_return_data(array![0x01, 0x02, 0x03].span());
+    let return_data = machine.return_data();
+    assert(return_data == array![0x01, 0x02, 0x03].span(), 'wrong return data');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_set_return_data_subctx() {
+    let mut machine: Machine = setup_machine_with_nested_execution_context();
+    machine.set_return_data(array![0x01, 0x02, 0x03].span());
+    let return_data = parent_ctx_return_data(ref machine);
+    assert(return_data == array![0x01, 0x02, 0x03].span(), 'wrong return data');
 }
 
 #[test]

--- a/crates/evm/src/tests/test_machine.cairo
+++ b/crates/evm/src/tests/test_machine.cairo
@@ -63,7 +63,7 @@ fn test_revert() {
 
 #[test]
 #[available_gas(20000000)]
-fn test_stopped() {
+fn test_set_stopped() {
     let mut machine = Default::default();
 
     machine.set_stopped();

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -4,7 +4,7 @@ use evm::context::{
 };
 use evm::kakarot_core::{IExtendedKakarotCoreDispatcher, KakarotCore};
 
-use evm::machine::Machine;
+use evm::machine::{Machine, MachineCurrentContextTrait};
 use nullable::{match_nullable, FromNullableResult};
 use starknet::{
     StorageBaseAddress, storage_base_address_from_felt252, contract_address_try_from_felt252,
@@ -225,6 +225,17 @@ fn deploy_kakarot_core() -> IExtendedKakarotCoreDispatcher {
         .unwrap();
 
     IExtendedKakarotCoreDispatcher { contract_address }
+}
+
+
+// Simulate return of subcontext where
+/// 1. Set `return_data` field of parent context
+/// 2. make `parent_ctx` of `current_ctx` the current ctx
+fn return_from_subcontext(ref self: Machine, return_data: Span<u8>) {
+    self.set_parent_return_data(return_data);
+    let current_ctx = self.current_ctx.unbox();
+    let parent_ctx = current_ctx.parent_ctx.deref();
+    self.current_ctx = BoxTrait::new(parent_ctx);
 }
 
 /// Returns the `return_data` field of the parent_ctx of the current_ctx.

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -232,7 +232,7 @@ fn deploy_kakarot_core() -> IExtendedKakarotCoreDispatcher {
 /// 1. Set `return_data` field of parent context
 /// 2. make `parent_ctx` of `current_ctx` the current ctx
 fn return_from_subcontext(ref self: Machine, return_data: Span<u8>) {
-    self.set_parent_return_data(return_data);
+    self.set_return_data(return_data);
     let current_ctx = self.current_ctx.unbox();
     let parent_ctx = current_ctx.parent_ctx.deref();
     self.current_ctx = BoxTrait::new(parent_ctx);

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -5,11 +5,11 @@ use evm::context::{
 use evm::kakarot_core::{IExtendedKakarotCoreDispatcher, KakarotCore};
 
 use evm::machine::Machine;
+use nullable::{match_nullable, FromNullableResult};
 use starknet::{
     StorageBaseAddress, storage_base_address_from_felt252, contract_address_try_from_felt252,
     ContractAddress, EthAddress, deploy_syscall, get_contract_address, contract_address_const
 };
-use nullable::{match_nullable, FromNullableResult};
 
 fn starknet_address() -> ContractAddress {
     'starknet_address'.try_into().unwrap()

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -9,6 +9,7 @@ use starknet::{
     StorageBaseAddress, storage_base_address_from_felt252, contract_address_try_from_felt252,
     ContractAddress, EthAddress, deploy_syscall, get_contract_address, contract_address_const
 };
+use nullable::{match_nullable, FromNullableResult};
 
 fn starknet_address() -> ContractAddress {
     'starknet_address'.try_into().unwrap()
@@ -78,17 +79,10 @@ fn setup_execution_context() -> ExecutionContext {
     let call_ctx = setup_call_context();
     let starknet_address: ContractAddress = starknet_address();
     let evm_address: EthAddress = evm_address();
-    let return_data = Default::default();
-    let child_return_data = Option::Some(array![1, 2, 3].span());
+    let return_data = array![1, 2, 3].span();
 
     ExecutionContextTrait::new(
-        context_id,
-        evm_address,
-        starknet_address,
-        call_ctx,
-        Default::default(),
-        child_return_data,
-        return_data,
+        context_id, evm_address, starknet_address, call_ctx, Default::default(), return_data,
     )
 }
 
@@ -123,16 +117,10 @@ fn setup_execution_context_with_bytecode(bytecode: Span<u8>) -> ExecutionContext
     let call_ctx = setup_call_context_with_bytecode(bytecode);
     let starknet_address: ContractAddress = starknet_address();
     let evm_address: EthAddress = evm_address();
-    let return_data = Default::default();
+    let return_data = Default::default().span();
 
     ExecutionContextTrait::new(
-        context_id,
-        evm_address,
-        starknet_address,
-        call_ctx,
-        Default::default(),
-        Default::default(),
-        return_data,
+        context_id, evm_address, starknet_address, call_ctx, Default::default(), return_data,
     )
 }
 
@@ -153,16 +141,10 @@ fn setup_execution_context_with_calldata(calldata: Span<u8>) -> ExecutionContext
     let call_ctx = setup_call_context_with_calldata(calldata);
     let starknet_address: ContractAddress = starknet_address();
     let evm_address: EthAddress = evm_address();
-    let return_data = Default::default();
+    let return_data = Default::default().span();
 
     ExecutionContextTrait::new(
-        context_id,
-        evm_address,
-        starknet_address,
-        call_ctx,
-        Default::default(),
-        Default::default(),
-        return_data,
+        context_id, evm_address, starknet_address, call_ctx, Default::default(), return_data,
     )
 }
 
@@ -243,4 +225,25 @@ fn deploy_kakarot_core() -> IExtendedKakarotCoreDispatcher {
         .unwrap();
 
     IExtendedKakarotCoreDispatcher { contract_address }
+}
+
+/// Returns the `return_data` field of the parent_ctx of the current_ctx.
+fn parent_ctx_return_data(ref self: Machine) -> Span<u8> {
+    let mut current_ctx = self.current_ctx.unbox();
+    let maybe_parent_ctx = current_ctx.parent_ctx;
+    let value = match match_nullable(maybe_parent_ctx) {
+        // Due to ownership mechanism, both branches need to explicitly re-bind the parent_ctx.
+        FromNullableResult::Null => {
+            current_ctx.parent_ctx = Default::default();
+            array![].span()
+        },
+        FromNullableResult::NotNull(parent_ctx) => {
+            let mut parent_ctx = parent_ctx.unbox();
+            let value = parent_ctx.return_data();
+            current_ctx.parent_ctx = NullableTrait::new(parent_ctx);
+            value
+        }
+    };
+    self.current_ctx = BoxTrait::new(current_ctx);
+    value
 }

--- a/docs/general/execution_context.md
+++ b/docs/general/execution_context.md
@@ -25,9 +25,8 @@ classDiagram
         destroyed_contracts: Array~EthAddress~,
         events: Array~Event~,
         create_addresses: Array~EthAddress~,
-        return_data: Array~u32~,
+        return_data: Span~u8~,
         parent_ctx: Nullable~ExecutionContext~,
-        child_return_data: Option~Span~u8~~
     }
 
     class CallContext{

--- a/docs/general/machine.md
+++ b/docs/general/machine.md
@@ -28,18 +28,18 @@ To overcome the problem stated above, we have come up with the following design:
   it.
 - Each execution context has a `parent_ctx` field, which value is either a
   pointer to its parent execution context or `null`.
-- Each execution context has a `child_return_data` field, which value is either
+- Each execution context has a `return_data` field, whose value is either
   nothing or the return data from the child context. This is meant to enable
   opcodes `RETURNDATASIZE` and `RETURNDATACOPY`. These two opcodes are the only
   ones enabling a current context to access its child context's return data.
 - The execution context tree is a directed acyclic graph, where each execution
-  context has at most one parent, and at most one child.
+  context has at most one parent.
 - A specific execution context is accessible by traversing the execution context
   tree, starting from the root execution context, and following the execution
   context tree until the desired execution context is reached. The machine also
   stores a pointer to the current execution context.
 - The execution context tree is initialized with a single root execution
-  context, which has no parent and no child. It has `id` field equal to 0.
+  context, which has no parent and no child. It has an `id` field equal to 0.
 
 The following diagram describes the model of the Kakarot Machine.
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #383

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Correct behavior of returndatasize/returndatacopy
- Got rid of the `child_return_data` field
- `return_data` now refers to the return_data of the last executed subcontext
- renamed machine `revert` and `stop` to `set_reverted` and `set_stopped` to avoid confusion with `revert` and `stop` opcodes
- Unexpected revert (not the REVERT Opcode) reason is not appended to the parent's return data field.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
