### PR TITLE
feat: ContractAccount storage methods

### DIFF
--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -1,4 +1,6 @@
-//! Contract Account related functions, including bytecode storage
+//! Contract Account related functions to interact with the storage of a
+//! contract account.  The storage of a contract account is embedded in
+//! KakarotCore's storage.
 
 use alexandria_storage::list::{List, ListTrait};
 use hash::{HashStateTrait, HashStateExTrait};
@@ -12,11 +14,11 @@ use utils::helpers::{ByteArrayExTrait};
 use utils::storage::{compute_storage_base_address};
 use utils::traits::{StorageBaseAddressIntoFelt252, StoreBytes31};
 
+
+/// Wrapper struct around an evm_address corresponding to a ContractAccount
 #[derive(Copy, Drop)]
 struct ContractAccount {
     evm_address: EthAddress,
-//TODO: add valid jumps as a field for ContractAccount
-// valid_jumps: LegacyMap<usize, bool>
 }
 
 #[generate_trait]
@@ -74,7 +76,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// Returns the value stored at a `u256` key inside the Contract Account storage.
     /// The new value is written in Kakarot Core's contract storage.
     /// The storage address used is h(sn_keccak("contract_account_storage_keys"), evm_address, key), where `h` is the poseidon hash function.
-    fn get_key(self: @ContractAccount, key: u256) -> u256 {
+    fn get_storage(self: @ContractAccount, key: u256) -> u256 {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_storage_keys"),
             array![(*self.evm_address).into(), key.low.into(), key.high.into()].span()
@@ -89,7 +91,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `self` - The contract account instance
     /// * `key` - The key to set
     /// * `value` - The value to set
-    fn set_key(ref self: ContractAccount, key: u256, value: u256) {
+    fn set_storage(ref self: ContractAccount, key: u256, value: u256) {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_storage_keys"),
             array![self.evm_address.into(), key.low.into(), key.high.into()].span()

--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -3,6 +3,7 @@
 //! KakarotCore's storage.
 
 use alexandria_storage::list::{List, ListTrait};
+use evm::errors::{EVMError, READ_SYSCALL_FAILED};
 use hash::{HashStateTrait, HashStateExTrait};
 use poseidon::PoseidonTrait;
 use starknet::{
@@ -10,10 +11,9 @@ use starknet::{
     storage_write_syscall, storage_address_from_base, storage_read_syscall,
     storage_address_from_base_and_offset
 };
-use utils::helpers::{ByteArrayExTrait};
+use utils::helpers::{ByteArrayExTrait, ResultExTrait};
 use utils::storage::{compute_storage_base_address};
 use utils::traits::{StorageBaseAddressIntoFelt252, StoreBytes31};
-
 
 /// Wrapper struct around an evm_address corresponding to a ContractAccount
 #[derive(Copy, Drop)]
@@ -32,11 +32,11 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// # Arguments
     /// * `self` - The contract account instance
     #[inline(always)]
-    fn nonce(self: @ContractAccount) -> u64 {
+    fn nonce(self: @ContractAccount) -> Result<u64, EVMError> {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_nonce"), array![(*self.evm_address).into()].span()
         );
-        Store::<u64>::read(0, storage_address).unwrap()
+        Store::<u64>::read(0, storage_address).map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Increments the nonce of a contract account.
@@ -45,22 +45,25 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// # Arguments
     /// * `self` - The contract account instance
     #[inline(always)]
-    fn increment_nonce(ref self: ContractAccount) {
+    fn increment_nonce(ref self: ContractAccount) -> Result<(), EVMError> {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_nonce"), array![self.evm_address.into()].span()
         );
-        let nonce = Store::<u64>::read(0, storage_address).unwrap();
-        Store::<u64>::write(0, storage_address, nonce + 1);
+        let nonce: u64 = Store::<u64>::read(0, storage_address)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
+        Store::<u64>::write(0, storage_address, nonce + 1)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Returns the balance of a contract account.
     /// * `self` - The contract account instance
     #[inline(always)]
-    fn balance(self: @ContractAccount) -> u256 {
+    fn balance(self: @ContractAccount) -> Result<u256, EVMError> {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_balance"), array![(*self.evm_address).into()].span()
         );
-        Store::<u256>::read(0, storage_address).unwrap()
+        Store::<u256>::read(0, storage_address)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Sets the balance of a contract account.
@@ -70,23 +73,25 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `self` - The contract account instance
     /// * `balance` - The new balance
     #[inline(always)]
-    fn set_balance(ref self: ContractAccount, balance: u256) {
+    fn set_balance(ref self: ContractAccount, balance: u256) -> Result<(), EVMError> {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_balance"), array![self.evm_address.into()].span()
         );
-        Store::<u256>::write(0, storage_address, balance);
+        Store::<u256>::write(0, storage_address, balance)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Returns the value stored at a `u256` key inside the Contract Account storage.
     /// The new value is written in Kakarot Core's contract storage.
     /// The storage address used is h(sn_keccak("contract_account_storage_keys"), evm_address, key), where `h` is the poseidon hash function.
     #[inline(always)]
-    fn get_storage(self: @ContractAccount, key: u256) -> u256 {
+    fn storage_at(self: @ContractAccount, key: u256) -> Result<u256, EVMError> {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_storage_keys"),
             array![(*self.evm_address).into(), key.low.into(), key.high.into()].span()
         );
-        Store::<u256>::read(0, storage_address).unwrap()
+        Store::<u256>::read(0, storage_address)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Sets the value stored at a `u256` key inside the Contract Account storage.
@@ -97,12 +102,13 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `key` - The key to set
     /// * `value` - The value to set
     #[inline(always)]
-    fn set_storage(ref self: ContractAccount, key: u256, value: u256) {
+    fn set_storage_at(ref self: ContractAccount, key: u256, value: u256) -> Result<(), EVMError> {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_storage_keys"),
             array![self.evm_address.into(), key.low.into(), key.high.into()].span()
         );
-        Store::<u256>::write(0, storage_address, value);
+        Store::<u256>::write(0, storage_address, value)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Stores the EVM bytecode of a contract account in Kakarot Core's contract storage.  The bytecode is first packed
@@ -110,7 +116,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// # Arguments
     /// * `evm_address` - The EVM address of the contract account
     /// * `bytecode` - The bytecode to store
-    fn store_bytecode(ref self: ContractAccount, bytecode: Span<u8>) {
+    fn store_bytecode(ref self: ContractAccount, bytecode: Span<u8>) -> Result<(), EVMError> {
         let packed_bytecode: ByteArray = ByteArrayExTrait::from_bytes(bytecode);
         // data_address is h(h(sn_keccak("contract_account_bytecode")), evm_address)
         let data_address = compute_storage_base_address(
@@ -131,15 +137,19 @@ impl ContractAccountImpl of ContractAccountTrait {
             felt252
         >::write(
             0, storage_base_address_from_felt252(pending_word_addr), packed_bytecode.pending_word
-        );
+        )
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
         Store::<
             usize
         >::write(
             0,
             storage_base_address_from_felt252(pending_word_len_addr),
             packed_bytecode.pending_word_len
-        );
+        )
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
+        //TODO(eni) PR Alexandria so that from_span returns SyscallResult
         stored_list.from_span(packed_bytecode.data.span());
+        Result::Ok(())
     }
 
     /// Loads the bytecode of a ContractAccount from Kakarot Core's contract storage into a ByteArray.
@@ -147,7 +157,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `self` - The Contract Account to load the bytecode from
     /// # Returns
     /// * The bytecode of the Contract Account as a ByteArray
-    fn load_bytecode(self: @ContractAccount) -> ByteArray {
+    fn load_bytecode(self: @ContractAccount) -> Result<ByteArray, EVMError> {
         let data_address = compute_storage_base_address(
             selector!("contract_account_bytecode"), array![(*self.evm_address).into()].span()
         );
@@ -155,7 +165,8 @@ impl ContractAccountImpl of ContractAccountTrait {
         // `data_address`.  The `pending_word` and `pending_word_len` are stored at
         // address `data_address-2` and `data_address-1` respectively.
         //TODO(eni) replace with ListTrait::new() once merged in alexandria
-        let list_len = Store::<usize>::read(0, data_address).unwrap();
+        let list_len = Store::<usize>::read(0, data_address)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
         let mut stored_list: List<bytes31> = List {
             address_domain: 0,
             base: data_address,
@@ -167,17 +178,18 @@ impl ContractAccountImpl of ContractAccountTrait {
 
         // Read the `ByteArray` in the contract storage.
         let bytecode = ByteArray {
+            //TODO(eni) PR alexandria to make List methods return SyscallResult
             data: stored_list.array(),
             pending_word: Store::<
                 felt252
             >::read(0, storage_base_address_from_felt252(pending_word_addr))
-                .unwrap(),
+                .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?,
             pending_word_len: Store::<
                 usize
             >::read(0, storage_base_address_from_felt252(pending_word_len_addr))
-                .unwrap()
+                .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?
         };
-        bytecode
+        Result::Ok(bytecode)
     }
 
     /// Returns true if the given `offset` is a valid jump destination in the bytecode.
@@ -188,12 +200,12 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `true` - If the offset is a valid jump destination
     /// * `false` - Otherwise
     #[inline(always)]
-    fn is_valid_jump(self: @ContractAccount, offset: usize) -> bool {
+    fn is_valid_jump(self: @ContractAccount, offset: usize) -> Result<bool, EVMError> {
         let data_address = compute_storage_base_address(
             selector!("contract_account_valid_jumps"),
             array![(*self.evm_address).into(), offset.into()].span()
         );
-        Store::<bool>::read(0, data_address).unwrap()
+        Store::<bool>::read(0, data_address).map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 
     /// Sets the given `offset` as a valid jump destination in the bytecode.
@@ -202,12 +214,13 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `self` - The ContractAccount
     /// * `offset` - The offset to set as a valid jump destination
     #[inline(always)]
-    fn set_valid_jump(ref self: ContractAccount, offset: usize) {
+    fn set_valid_jump(ref self: ContractAccount, offset: usize) -> Result<(), EVMError> {
         let data_address = compute_storage_base_address(
             selector!("contract_account_valid_jumps"),
             array![self.evm_address.into(), offset.into()].span()
         );
-        Store::<bool>::write(0, data_address, true);
+        Store::<bool>::write(0, data_address, true)
+            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
     }
 }
 

--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -3,7 +3,7 @@
 //! KakarotCore's storage.
 
 use alexandria_storage::list::{List, ListTrait};
-use evm::errors::{EVMError, READ_SYSCALL_FAILED};
+use evm::errors::{EVMError, READ_SYSCALL_FAILED, WRITE_SYSCALL_FAILED};
 use hash::{HashStateTrait, HashStateExTrait};
 use poseidon::PoseidonTrait;
 use starknet::{
@@ -52,7 +52,7 @@ impl ContractAccountImpl of ContractAccountTrait {
         let nonce: u64 = Store::<u64>::read(0, storage_address)
             .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
         Store::<u64>::write(0, storage_address, nonce + 1)
-            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
+            .map_err(EVMError::SyscallFailed(WRITE_SYSCALL_FAILED))
     }
 
     /// Returns the balance of a contract account.
@@ -78,7 +78,7 @@ impl ContractAccountImpl of ContractAccountTrait {
             selector!("contract_account_balance"), array![self.evm_address.into()].span()
         );
         Store::<u256>::write(0, storage_address, balance)
-            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
+            .map_err(EVMError::SyscallFailed(WRITE_SYSCALL_FAILED))
     }
 
     /// Returns the value stored at a `u256` key inside the Contract Account storage.
@@ -108,7 +108,7 @@ impl ContractAccountImpl of ContractAccountTrait {
             array![self.evm_address.into(), key.low.into(), key.high.into()].span()
         );
         Store::<u256>::write(0, storage_address, value)
-            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
+            .map_err(EVMError::SyscallFailed(WRITE_SYSCALL_FAILED))
     }
 
     /// Stores the EVM bytecode of a contract account in Kakarot Core's contract storage.  The bytecode is first packed
@@ -138,7 +138,7 @@ impl ContractAccountImpl of ContractAccountTrait {
         >::write(
             0, storage_base_address_from_felt252(pending_word_addr), packed_bytecode.pending_word
         )
-            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
+            .map_err(EVMError::SyscallFailed(WRITE_SYSCALL_FAILED))?;
         Store::<
             usize
         >::write(
@@ -146,7 +146,7 @@ impl ContractAccountImpl of ContractAccountTrait {
             storage_base_address_from_felt252(pending_word_len_addr),
             packed_bytecode.pending_word_len
         )
-            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))?;
+            .map_err(EVMError::SyscallFailed(WRITE_SYSCALL_FAILED))?;
         //TODO(eni) PR Alexandria so that from_span returns SyscallResult
         stored_list.from_span(packed_bytecode.data.span());
         Result::Ok(())
@@ -220,7 +220,7 @@ impl ContractAccountImpl of ContractAccountTrait {
             array![self.evm_address.into(), offset.into()].span()
         );
         Store::<bool>::write(0, data_address, true)
-            .map_err(EVMError::SyscallFailed(READ_SYSCALL_FAILED))
+            .map_err(EVMError::SyscallFailed(WRITE_SYSCALL_FAILED))
     }
 }
 

--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -31,6 +31,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// Returns the nonce of a contract account.
     /// # Arguments
     /// * `self` - The contract account instance
+    #[inline(always)]
     fn nonce(self: @ContractAccount) -> u64 {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_nonce"), array![(*self.evm_address).into()].span()
@@ -43,6 +44,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// The storage address used is h(sn_keccak("contract_account_nonce"), evm_address), where `h` is the poseidon hash function.
     /// # Arguments
     /// * `self` - The contract account instance
+    #[inline(always)]
     fn increment_nonce(ref self: ContractAccount) {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_nonce"), array![self.evm_address.into()].span()
@@ -53,6 +55,7 @@ impl ContractAccountImpl of ContractAccountTrait {
 
     /// Returns the balance of a contract account.
     /// * `self` - The contract account instance
+    #[inline(always)]
     fn balance(self: @ContractAccount) -> u256 {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_balance"), array![(*self.evm_address).into()].span()
@@ -66,6 +69,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// # Arguments
     /// * `self` - The contract account instance
     /// * `balance` - The new balance
+    #[inline(always)]
     fn set_balance(ref self: ContractAccount, balance: u256) {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_balance"), array![self.evm_address.into()].span()
@@ -76,6 +80,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// Returns the value stored at a `u256` key inside the Contract Account storage.
     /// The new value is written in Kakarot Core's contract storage.
     /// The storage address used is h(sn_keccak("contract_account_storage_keys"), evm_address, key), where `h` is the poseidon hash function.
+    #[inline(always)]
     fn get_storage(self: @ContractAccount, key: u256) -> u256 {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_storage_keys"),
@@ -91,6 +96,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// * `self` - The contract account instance
     /// * `key` - The key to set
     /// * `value` - The value to set
+    #[inline(always)]
     fn set_storage(ref self: ContractAccount, key: u256, value: u256) {
         let storage_address = compute_storage_base_address(
             selector!("contract_account_storage_keys"),
@@ -181,6 +187,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// # Returns
     /// * `true` - If the offset is a valid jump destination
     /// * `false` - Otherwise
+    #[inline(always)]
     fn is_valid_jump(self: @ContractAccount, offset: usize) -> bool {
         let data_address = compute_storage_base_address(
             selector!("contract_account_valid_jumps"),
@@ -194,6 +201,7 @@ impl ContractAccountImpl of ContractAccountTrait {
     /// # Arguments
     /// * `self` - The ContractAccount
     /// * `offset` - The offset to set as a valid jump destination
+    #[inline(always)]
     fn set_valid_jump(ref self: ContractAccount, offset: usize) {
         let data_address = compute_storage_base_address(
             selector!("contract_account_valid_jumps"),

--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -12,37 +12,192 @@ use utils::helpers::{ByteArrayExTrait};
 use utils::storage::{compute_storage_base_address};
 use utils::traits::{StorageBaseAddressIntoFelt252, StoreBytes31};
 
-/// Stores the EVM bytecode of a contract account in Kakarot Core's contract storage.  The bytecode is first packed
-/// into a ByteArray and then stored in the contract storage.
-/// # Arguments
-/// * `evm_address` - The EVM address of the contract account
-/// * `bytecode` - The bytecode to store
-fn store_bytecode(evm_address: EthAddress, bytecode: Span<u8>) {
-    let packed_bytecode: ByteArray = ByteArrayExTrait::from_bytes(bytecode);
-    // data_address is h(h(sn_keccak("contract_account_bytecode")), evm_address)
-    let data_address = compute_storage_base_address(
-        selector!("contract_account_bytecode"), array![evm_address.into()].span()
-    );
-    // We start storing the full 31-byte words of bytecode data at address
-    // `data_address`.  The `pending_word` and `pending_word_len` are stored at
-    // address `data_address-2` and `data_address-1` respectively.
-    //TODO(eni) replace with ListTrait::new() once merged in alexandria
-    let mut stored_list: List<bytes31> = List {
-        address_domain: 0, base: data_address, len: 0, storage_size: Store::<bytes31>::size()
-    };
-    let pending_word_addr: felt252 = data_address.into() - 2;
-    let pending_word_len_addr: felt252 = pending_word_addr + 1;
-
-    // Store the `ByteArray` in the contract storage.
-    Store::<
-        felt252
-    >::write(0, storage_base_address_from_felt252(pending_word_addr), packed_bytecode.pending_word);
-    Store::<
-        usize
-    >::write(
-        0,
-        storage_base_address_from_felt252(pending_word_len_addr),
-        packed_bytecode.pending_word_len
-    );
-    stored_list.from_span(packed_bytecode.data.span());
+#[derive(Copy, Drop)]
+struct ContractAccount {
+    evm_address: EthAddress,
+//TODO: add valid jumps as a field for ContractAccount
+// valid_jumps: LegacyMap<usize, bool>
 }
+
+#[generate_trait]
+impl ContractAccountImpl of ContractAccountTrait {
+    /// Creates a new ContractAccount instance from the given `evm_address`.
+    fn new(evm_address: EthAddress) -> ContractAccount {
+        ContractAccount { evm_address: evm_address, }
+    }
+
+    /// Returns the nonce of a contract account.
+    /// # Arguments
+    /// * `self` - The contract account instance
+    fn nonce(self: @ContractAccount) -> u64 {
+        let storage_address = compute_storage_base_address(
+            selector!("contract_account_nonce"), array![(*self.evm_address).into()].span()
+        );
+        Store::<u64>::read(0, storage_address).unwrap()
+    }
+
+    /// Increments the nonce of a contract account.
+    /// The new nonce is written in Kakarot Core's contract storage.
+    /// The storage address used is h(sn_keccak("contract_account_nonce"), evm_address), where `h` is the poseidon hash function.
+    /// # Arguments
+    /// * `self` - The contract account instance
+    fn increment_nonce(ref self: ContractAccount) {
+        let storage_address = compute_storage_base_address(
+            selector!("contract_account_nonce"), array![self.evm_address.into()].span()
+        );
+        let nonce = Store::<u64>::read(0, storage_address).unwrap();
+        Store::<u64>::write(0, storage_address, nonce + 1);
+    }
+
+    /// Returns the balance of a contract account.
+    /// * `self` - The contract account instance
+    fn balance(self: @ContractAccount) -> u256 {
+        let storage_address = compute_storage_base_address(
+            selector!("contract_account_balance"), array![(*self.evm_address).into()].span()
+        );
+        Store::<u256>::read(0, storage_address).unwrap()
+    }
+
+    /// Sets the balance of a contract account.
+    /// The new balance is written in Kakarot Core's contract storage.
+    /// The storage address used is h(sn_keccak("contract_account_balance"), evm_address), where `h` is the poseidon hash function.
+    /// # Arguments
+    /// * `self` - The contract account instance
+    /// * `balance` - The new balance
+    fn set_balance(ref self: ContractAccount, balance: u256) {
+        let storage_address = compute_storage_base_address(
+            selector!("contract_account_balance"), array![self.evm_address.into()].span()
+        );
+        Store::<u256>::write(0, storage_address, balance);
+    }
+
+    /// Returns the value stored at a `u256` key inside the Contract Account storage.
+    /// The new value is written in Kakarot Core's contract storage.
+    /// The storage address used is h(sn_keccak("contract_account_storage_keys"), evm_address, key), where `h` is the poseidon hash function.
+    fn get_key(self: @ContractAccount, key: u256) -> u256 {
+        let storage_address = compute_storage_base_address(
+            selector!("contract_account_storage_keys"),
+            array![(*self.evm_address).into(), key.low.into(), key.high.into()].span()
+        );
+        Store::<u256>::read(0, storage_address).unwrap()
+    }
+
+    /// Sets the value stored at a `u256` key inside the Contract Account storage.
+    /// The new value is written in Kakarot Core's contract storage.
+    /// The storage address used is h(sn_keccak("contract_account_storage_keys"), evm_address, key), where `h` is the poseidon hash function.
+    /// # Arguments
+    /// * `self` - The contract account instance
+    /// * `key` - The key to set
+    /// * `value` - The value to set
+    fn set_key(ref self: ContractAccount, key: u256, value: u256) {
+        let storage_address = compute_storage_base_address(
+            selector!("contract_account_storage_keys"),
+            array![self.evm_address.into(), key.low.into(), key.high.into()].span()
+        );
+        Store::<u256>::write(0, storage_address, value);
+    }
+
+    /// Stores the EVM bytecode of a contract account in Kakarot Core's contract storage.  The bytecode is first packed
+    /// into a ByteArray and then stored in the contract storage.
+    /// # Arguments
+    /// * `evm_address` - The EVM address of the contract account
+    /// * `bytecode` - The bytecode to store
+    fn store_bytecode(ref self: ContractAccount, bytecode: Span<u8>) {
+        let packed_bytecode: ByteArray = ByteArrayExTrait::from_bytes(bytecode);
+        // data_address is h(h(sn_keccak("contract_account_bytecode")), evm_address)
+        let data_address = compute_storage_base_address(
+            selector!("contract_account_bytecode"), array![self.evm_address.into()].span()
+        );
+        // We start storing the full 31-byte words of bytecode data at address
+        // `data_address`.  The `pending_word` and `pending_word_len` are stored at
+        // address `data_address-2` and `data_address-1` respectively.
+        //TODO(eni) replace with ListTrait::new() once merged in alexandria
+        let mut stored_list: List<bytes31> = List {
+            address_domain: 0, base: data_address, len: 0, storage_size: Store::<bytes31>::size()
+        };
+        let pending_word_addr: felt252 = data_address.into() - 2;
+        let pending_word_len_addr: felt252 = pending_word_addr + 1;
+
+        // Store the `ByteArray` in the contract storage.
+        Store::<
+            felt252
+        >::write(
+            0, storage_base_address_from_felt252(pending_word_addr), packed_bytecode.pending_word
+        );
+        Store::<
+            usize
+        >::write(
+            0,
+            storage_base_address_from_felt252(pending_word_len_addr),
+            packed_bytecode.pending_word_len
+        );
+        stored_list.from_span(packed_bytecode.data.span());
+    }
+
+    /// Loads the bytecode of a ContractAccount from Kakarot Core's contract storage into a ByteArray.
+    /// # Arguments
+    /// * `self` - The Contract Account to load the bytecode from
+    /// # Returns
+    /// * The bytecode of the Contract Account as a ByteArray
+    fn load_bytecode(self: @ContractAccount) -> ByteArray {
+        let data_address = compute_storage_base_address(
+            selector!("contract_account_bytecode"), array![(*self.evm_address).into()].span()
+        );
+        // We start loading the full 31-byte words of bytecode data at address
+        // `data_address`.  The `pending_word` and `pending_word_len` are stored at
+        // address `data_address-2` and `data_address-1` respectively.
+        //TODO(eni) replace with ListTrait::new() once merged in alexandria
+        let list_len = Store::<usize>::read(0, data_address).unwrap();
+        let mut stored_list: List<bytes31> = List {
+            address_domain: 0,
+            base: data_address,
+            len: list_len,
+            storage_size: Store::<bytes31>::size()
+        };
+        let pending_word_addr: felt252 = data_address.into() - 2;
+        let pending_word_len_addr: felt252 = pending_word_addr + 1;
+
+        // Read the `ByteArray` in the contract storage.
+        let bytecode = ByteArray {
+            data: stored_list.array(),
+            pending_word: Store::<
+                felt252
+            >::read(0, storage_base_address_from_felt252(pending_word_addr))
+                .unwrap(),
+            pending_word_len: Store::<
+                usize
+            >::read(0, storage_base_address_from_felt252(pending_word_len_addr))
+                .unwrap()
+        };
+        bytecode
+    }
+
+    /// Returns true if the given `offset` is a valid jump destination in the bytecode.
+    /// The valid jump destinations are stored in Kakarot Core's contract storage first.
+    /// # Arguments
+    /// * `offset` - The offset to check
+    /// # Returns
+    /// * `true` - If the offset is a valid jump destination
+    /// * `false` - Otherwise
+    fn is_valid_jump(self: @ContractAccount, offset: usize) -> bool {
+        let data_address = compute_storage_base_address(
+            selector!("contract_account_valid_jumps"),
+            array![(*self.evm_address).into(), offset.into()].span()
+        );
+        Store::<bool>::read(0, data_address).unwrap()
+    }
+
+    /// Sets the given `offset` as a valid jump destination in the bytecode.
+    /// The valid jump destinations are stored in Kakarot Core's contract storage.
+    /// # Arguments
+    /// * `self` - The ContractAccount
+    /// * `offset` - The offset to set as a valid jump destination
+    fn set_valid_jump(ref self: ContractAccount, offset: usize) {
+        let data_address = compute_storage_base_address(
+            selector!("contract_account_valid_jumps"),
+            array![self.evm_address.into(), offset.into()].span()
+        );
+        Store::<bool>::write(0, data_address, true);
+    }
+}
+

--- a/crates/contracts/src/kakarot_core.cairo
+++ b/crates/contracts/src/kakarot_core.cairo
@@ -1,4 +1,4 @@
 mod interface;
 mod kakarot;
 
-use kakarot::{KakarotCore, ContractAccountStorage};
+use kakarot::KakarotCore;

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -1,5 +1,5 @@
-use utils::traits::ByteArraySerde;
 use starknet::{ContractAddress, EthAddress, ClassHash};
+use utils::traits::ByteArraySerde;
 
 #[starknet::interface]
 trait IKakarotCore<TContractState> {

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -1,4 +1,4 @@
-use contracts::kakarot_core::ContractAccountStorage;
+use utils::traits::ByteArraySerde;
 use starknet::{ContractAddress, EthAddress, ClassHash};
 
 #[starknet::interface]
@@ -29,10 +29,22 @@ trait IKakarotCore<TContractState> {
     /// Otherwise, returns 0
     fn eoa_starknet_address(self: @TContractState, evm_address: EthAddress) -> ContractAddress;
 
-    /// Gets the storage associated to a contract account
-    fn contract_account_storage(
-        self: @TContractState, evm_address: EthAddress
-    ) -> ContractAccountStorage;
+    /// Gets the nonce associated to a contract account
+    fn contract_account_nonce(self: @TContractState, evm_address: EthAddress) -> u64;
+
+    /// Gets the balance associated to a contract account
+    fn contract_account_balance(self: @TContractState, evm_address: EthAddress) -> u256;
+
+    /// Gets the value associated to a key in the contract account storage
+    fn contract_account_storage(self: @TContractState, evm_address: EthAddress, key: u256) -> u256;
+
+    /// Gets the bytecode associated to a contract account
+    fn contract_account_bytecode(self: @TContractState, evm_address: EthAddress) -> ByteArray;
+
+    /// Returns true if the given `offset` is a valid jump destination in the bytecode of a contract account.
+    fn contract_account_valid_jump(
+        self: @TContractState, evm_address: EthAddress, offset: usize
+    ) -> bool;
 
     /// Deploys an EOA for a particular EVM address
     fn deploy_eoa(ref self: TContractState, evm_address: EthAddress) -> ContractAddress;
@@ -92,12 +104,6 @@ trait IExtendedKakarotCore<TContractState> {
     /// Checks into KakarotCore storage if an EOA has been deployed for a
     /// particular EVM address and if so, returns its corresponding Starknet Address
     fn eoa_starknet_address(self: @TContractState, evm_address: EthAddress) -> ContractAddress;
-
-
-    /// Gets the storage associated to a contract account
-    fn contract_account_storage(
-        self: @TContractState, evm_address: EthAddress
-    ) -> ContractAccountStorage;
 
     /// Deploys an EOA for a particular EVM address
     fn deploy_eoa(ref self: TContractState, evm_address: EthAddress) -> ContractAddress;

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -36,7 +36,9 @@ trait IKakarotCore<TContractState> {
     fn contract_account_balance(self: @TContractState, evm_address: EthAddress) -> u256;
 
     /// Gets the value associated to a key in the contract account storage
-    fn contract_account_storage(self: @TContractState, evm_address: EthAddress, key: u256) -> u256;
+    fn contract_account_storage_at(
+        self: @TContractState, evm_address: EthAddress, key: u256
+    ) -> u256;
 
     /// Gets the bytecode associated to a contract account
     fn contract_account_bytecode(self: @TContractState, evm_address: EthAddress) -> ByteArray;

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -291,31 +291,5 @@ mod KakarotCore {
             }
             Result::Ok(())
         }
-
-        /// Deploys a contract account by setting up the storage associated to a contract account for a particular EVM address
-        /// # Arguments
-        /// * `evm_address` - The EVM address of the contract account
-        /// * `nonce` - The value to be transferred as part of this operation
-        /// * `balance` - The value to be transferred as part of this operation
-        /// * `bytecode` - The deploy bytecode
-        fn deploy_contract_account(
-            ref self: ContractState, evm_address: EthAddress, value: u256, bytecode: Span<u8>
-        ) {
-            let mut ca = ContractAccountTrait::new(evm_address);
-            let execution_result = execute(
-                :evm_address,
-                :bytecode,
-                calldata: array![].span(),
-                :value,
-                gas_price: 0,
-                gas_limit: 0,
-            );
-            //TODO gas params
-            if execution_result.status == Status::Reverted {
-                return;
-            }
-
-            ca.store_bytecode(execution_result.return_data);
-        }
     }
 }

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -169,28 +169,28 @@ mod KakarotCore {
         /// Gets the nonce associated to a contract account
         fn contract_account_nonce(self: @ContractState, evm_address: EthAddress) -> u64 {
             let ca = ContractAccountTrait::new(evm_address);
-            ca.nonce()
+            ca.nonce().unwrap()
         }
 
         /// Gets the balance associated to a contract account
         fn contract_account_balance(self: @ContractState, evm_address: EthAddress) -> u256 {
             let ca = ContractAccountTrait::new(evm_address);
-            ca.balance()
+            ca.balance().unwrap()
         }
 
         /// Gets the value associated to a key in the contract account storage
-        fn contract_account_storage(
+        fn contract_account_storage_at(
             self: @ContractState, evm_address: EthAddress, key: u256
         ) -> u256 {
             let ca = ContractAccountTrait::new(evm_address);
-            ca.get_storage(key)
+            ca.storage_at(key).unwrap()
         }
 
 
         /// Gets the bytecode associated to a contract account
         fn contract_account_bytecode(self: @ContractState, evm_address: EthAddress) -> ByteArray {
             let mut ca = ContractAccountTrait::new(evm_address);
-            ca.load_bytecode()
+            ca.load_bytecode().unwrap()
         }
 
         /// Returns true if the given `offset` is a valid jump destination in the bytecode of a contract account.
@@ -198,7 +198,7 @@ mod KakarotCore {
             self: @ContractState, evm_address: EthAddress, offset: usize
         ) -> bool {
             let ca = ContractAccountTrait::new(evm_address);
-            ca.is_valid_jump(offset)
+            ca.is_valid_jump(offset).unwrap()
         }
 
         /// Deploys an EOA for a particular EVM address

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -8,9 +8,9 @@ mod KakarotCore {
     use contracts::components::ownable::ownable_component::InternalTrait;
     use contracts::components::ownable::{ownable_component};
     use contracts::components::upgradeable::{IUpgradeable, upgradeable_component};
+    use contracts::contract_account::{ContractAccount, ContractAccountTrait};
     use contracts::kakarot_core::interface::IKakarotCore;
     use contracts::kakarot_core::interface;
-    use contracts::contract_account::{ContractAccount, ContractAccountTrait};
     use core::hash::{HashStateExTrait, HashStateTrait};
     use core::pedersen::{HashState, PedersenTrait};
     use core::starknet::SyscallResultTrait;
@@ -183,7 +183,7 @@ mod KakarotCore {
             self: @ContractState, evm_address: EthAddress, key: u256
         ) -> u256 {
             let ca = ContractAccountTrait::new(evm_address);
-            ca.get_key(key)
+            ca.get_storage(key)
         }
 
 

--- a/crates/contracts/src/tests/test_contract_account.cairo
+++ b/crates/contracts/src/tests/test_contract_account.cairo
@@ -1,5 +1,5 @@
 use alexandria_storage::list::{List, ListTrait};
-use contracts::contract_account::{store_bytecode};
+use contracts::contract_account::{ContractAccount, ContractAccountTrait};
 use contracts::tests::utils::constants::EVM_ADDRESS;
 use starknet::{storage_base_address_from_felt252, Store};
 use utils::storage::{compute_storage_base_address};
@@ -11,7 +11,8 @@ fn test_store_bytecode_word_not_full() {
     let byte_array: Array<u8> = array![0x01, 0x02, 0x03, // 3 elements
     ];
     let evm_address = EVM_ADDRESS();
-    store_bytecode(evm_address, byte_array.span());
+    let mut ca = ContractAccountTrait::new(evm_address);
+    ca.store_bytecode(byte_array.span());
 
     // Address at which the bytecode should be stored
     let data_addr = compute_storage_base_address(
@@ -70,7 +71,8 @@ fn test_store_bytecode_one_word() {
         0x1F, // 31 elements
     ];
     let evm_address = EVM_ADDRESS();
-    store_bytecode(evm_address, byte_array.span());
+    let mut ca = ContractAccountTrait::new(evm_address);
+    ca.store_bytecode(byte_array.span());
 
     // Address at which the bytecode should be stored
     let data_addr = compute_storage_base_address(
@@ -137,7 +139,8 @@ fn test_store_bytecode_one_word_pending() {
         0x21 // 33 elements
     ];
     let evm_address = EVM_ADDRESS();
-    store_bytecode(evm_address, byte_array.span());
+    let mut ca = ContractAccountTrait::new(evm_address);
+    ca.store_bytecode(byte_array.span());
 
     // Address at which the bytecode should be stored
     let data_addr = compute_storage_base_address(

--- a/crates/contracts/src/tests/test_contract_account.cairo
+++ b/crates/contracts/src/tests/test_contract_account.cairo
@@ -10,9 +10,9 @@ use utils::traits::{StoreBytes31, StorageBaseAddressIntoFelt252};
 fn test_nonce() {
     let evm_address = EVM_ADDRESS();
     let mut ca = ContractAccountTrait::new(evm_address);
-    assert(ca.nonce() == 0, 'initial nonce not 0');
+    assert(ca.nonce().unwrap() == 0, 'initial nonce not 0');
     ca.increment_nonce();
-    assert(ca.nonce() == 1, 'nonce not incremented');
+    assert(ca.nonce().unwrap() == 1, 'nonce not incremented');
 }
 
 #[test]
@@ -20,9 +20,9 @@ fn test_nonce() {
 fn test_balance() {
     let evm_address = EVM_ADDRESS();
     let mut ca = ContractAccountTrait::new(evm_address);
-    assert(ca.balance() == 0, 'initial balance not 0');
+    assert(ca.balance().unwrap() == 0, 'initial balance not 0');
     ca.set_balance(1);
-    assert(ca.balance() == 1, 'balance not incremented');
+    assert(ca.balance().unwrap() == 1, 'balance not incremented');
 }
 
 #[test]
@@ -31,10 +31,10 @@ fn test_contract_storage() {
     let evm_address = EVM_ADDRESS();
     let mut ca = ContractAccountTrait::new(evm_address);
     let key = u256 { low: 10, high: 10 };
-    assert(ca.get_storage(key) == 0, 'initial key not null');
+    assert(ca.storage_at(key).unwrap() == 0, 'initial key not null');
     let value = u256 { low: 0, high: 1 };
-    ca.set_storage(key, value);
-    let value_read = ca.get_storage(key);
+    ca.set_storage_at(key, value);
+    let value_read = ca.storage_at(key).unwrap();
     assert(value_read == value, 'value not read correctly');
 }
 
@@ -242,7 +242,7 @@ fn test_load_bytecode() {
     let evm_address = EVM_ADDRESS();
     let mut ca = ContractAccountTrait::new(evm_address);
     ca.store_bytecode(byte_array.span());
-    let bytecode = ca.load_bytecode();
+    let bytecode = ca.load_bytecode().unwrap();
     let mut i: u32 = 0;
     loop {
         if i == byte_array.len() {
@@ -258,9 +258,9 @@ fn test_load_bytecode() {
 fn test_valid_jumps() {
     let evm_address = EVM_ADDRESS();
     let mut ca = ContractAccountTrait::new(evm_address);
-    assert(!ca.is_valid_jump(10), 'should default false');
+    assert(!ca.is_valid_jump(10).unwrap(), 'should default false');
     ca.set_valid_jump(10);
-    assert(ca.is_valid_jump(10), 'should be true')
+    assert(ca.is_valid_jump(10).unwrap(), 'should be true')
 }
 //TODO add a test with huge amount of bytecode - using SNFoundry and loading data from txt
 

--- a/crates/contracts/src/tests/test_contract_account.cairo
+++ b/crates/contracts/src/tests/test_contract_account.cairo
@@ -6,6 +6,39 @@ use utils::storage::{compute_storage_base_address};
 use utils::traits::{StoreBytes31, StorageBaseAddressIntoFelt252};
 
 #[test]
+#[available_gas(2000000)]
+fn test_nonce() {
+    let evm_address = EVM_ADDRESS();
+    let mut ca = ContractAccountTrait::new(evm_address);
+    assert(ca.nonce() == 0, 'initial nonce not 0');
+    ca.increment_nonce();
+    assert(ca.nonce() == 1, 'nonce not incremented');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_balance() {
+    let evm_address = EVM_ADDRESS();
+    let mut ca = ContractAccountTrait::new(evm_address);
+    assert(ca.balance() == 0, 'initial balance not 0');
+    ca.set_balance(1);
+    assert(ca.balance() == 1, 'balance not incremented');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_contract_storage() {
+    let evm_address = EVM_ADDRESS();
+    let mut ca = ContractAccountTrait::new(evm_address);
+    let key = u256 { low: 10, high: 10 };
+    assert(ca.get_storage(key) == 0, 'initial key not null');
+    let value = u256 { low: 0, high: 1 };
+    ca.set_storage(key, value);
+    let value_read = ca.get_storage(key);
+    assert(value_read == value, 'value not read correctly');
+}
+
+#[test]
 #[available_gas(20000000)]
 fn test_store_bytecode_word_not_full() {
     let byte_array: Array<u8> = array![0x01, 0x02, 0x03, // 3 elements
@@ -166,6 +199,68 @@ fn test_store_bytecode_one_word_pending() {
         assert(bytecode[i] == *byte_array[i], 'stored bytecode error');
         i += 1;
     }
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_load_bytecode() {
+    let byte_array: Array<u8> = array![
+        0x01,
+        0x02,
+        0x03,
+        0x04,
+        0x05,
+        0x06,
+        0x07,
+        0x08,
+        0x09,
+        0x0A,
+        0x0B,
+        0x0C,
+        0x0D,
+        0x0E,
+        0x0F,
+        0x10,
+        0x11,
+        0x12,
+        0x13,
+        0x14,
+        0x15,
+        0x16,
+        0x17,
+        0x18,
+        0x19,
+        0x1A,
+        0x1B,
+        0x1C,
+        0x1D,
+        0x1E,
+        0x1F,
+        0x20,
+        0x21 // 33 elements
+    ];
+    let evm_address = EVM_ADDRESS();
+    let mut ca = ContractAccountTrait::new(evm_address);
+    ca.store_bytecode(byte_array.span());
+    let bytecode = ca.load_bytecode();
+    let mut i: u32 = 0;
+    loop {
+        if i == byte_array.len() {
+            break;
+        }
+        assert(bytecode[i] == *byte_array[i], 'loaded bytecode error');
+        i += 1;
+    }
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_valid_jumps() {
+    let evm_address = EVM_ADDRESS();
+    let mut ca = ContractAccountTrait::new(evm_address);
+    assert(!ca.is_valid_jump(10), 'should default false');
+    ca.set_valid_jump(10);
+    assert(ca.is_valid_jump(10), 'should be true')
 }
 //TODO add a test with huge amount of bytecode - using SNFoundry and loading data from txt
 

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -115,3 +115,6 @@ fn test_kakarot_core_upgrade_contract() {
         .version();
     assert(version == 1, 'version is not 1');
 }
+// TODO add tests related to contract accounts once they can be deployed.
+
+

--- a/crates/evm/src/balance.cairo
+++ b/crates/evm/src/balance.cairo
@@ -1,5 +1,6 @@
 use contracts::kakarot_core::interface::{IKakarotCore};
-use contracts::kakarot_core::{ContractAccountStorage, KakarotCore};
+use contracts::kakarot_core::{KakarotCore};
+use contracts::contract_account::{ContractAccount, ContractAccountTrait};
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 use starknet::EthAddress;
 
@@ -27,9 +28,9 @@ fn balance(evm_address: EthAddress) -> u256 {
     // We check if a contract account is initialized at evm_address
     // A good condition to check is nonce > 0, as deploying a contract account
     // will set its nonce to 1
-    let ca_storage = kakarot_state.contract_account_storage(evm_address);
-    if ca_storage.nonce != 0 {
-        return ca_storage.balance;
+    let ca = ContractAccountTrait::new(evm_address);
+    if ca.nonce() != 0 {
+        return ca.balance();
     }
 
     // Case 3: No EOA nor CA are deployed at `evm_address`

--- a/crates/evm/src/balance.cairo
+++ b/crates/evm/src/balance.cairo
@@ -1,13 +1,14 @@
 use contracts::contract_account::{ContractAccount, ContractAccountTrait};
 use contracts::kakarot_core::interface::{IKakarotCore};
 use contracts::kakarot_core::{KakarotCore};
+use evm::errors::EVMError;
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 use starknet::EthAddress;
 
 
 /// Returns the balance in native token for a given EVM account (EOA or CA)
 /// This is equivalent to checking the balance in native coin, i.e. ETHER of an account in Ethereum
-fn balance(evm_address: EthAddress) -> u256 {
+fn balance(evm_address: EthAddress) -> Result<u256, EVMError> {
     // Get access to Kakarot State locally
     let kakarot_state = KakarotCore::unsafe_new_contract_state();
 
@@ -21,7 +22,7 @@ fn balance(evm_address: EthAddress) -> u256 {
         // As native_token might become a snake_case implementation
         // instead of camelCase
         let native_token = IERC20CamelDispatcher { contract_address: native_token_address };
-        return native_token.balanceOf(eoa_starknet_address);
+        return Result::Ok(native_token.balanceOf(eoa_starknet_address));
     }
 
     // Case 2: EOA is not deployed and CA is deployed
@@ -29,11 +30,12 @@ fn balance(evm_address: EthAddress) -> u256 {
     // A good condition to check is nonce > 0, as deploying a contract account
     // will set its nonce to 1
     let ca = ContractAccountTrait::new(evm_address);
-    if ca.nonce() != 0 {
+    let nonce = ca.nonce()?;
+    if nonce != 0 {
         return ca.balance();
     }
 
     // Case 3: No EOA nor CA are deployed at `evm_address`
     // Return 0
-    0
+    Result::Ok(0)
 }

--- a/crates/evm/src/balance.cairo
+++ b/crates/evm/src/balance.cairo
@@ -1,6 +1,6 @@
+use contracts::contract_account::{ContractAccount, ContractAccountTrait};
 use contracts::kakarot_core::interface::{IKakarotCore};
 use contracts::kakarot_core::{KakarotCore};
-use contracts::contract_account::{ContractAccount, ContractAccountTrait};
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 use starknet::EthAddress;
 

--- a/crates/evm/src/errors.cairo
+++ b/crates/evm/src/errors.cairo
@@ -19,6 +19,7 @@ const WRITE_IN_STATIC_CONTEXT: felt252 = 'KKT: WriteInStaticContext';
 
 // STARKNET_SYSCALLS
 const READ_SYSCALL_FAILED: felt252 = 'KKT: read syscall failed';
+const WRITE_SYSCALL_FAILED: felt252 = 'KKT: write syscall failed';
 
 #[derive(Drop, Copy, PartialEq)]
 enum EVMError {

--- a/crates/evm/src/instructions/block_information.cairo
+++ b/crates/evm/src/instructions/block_information.cairo
@@ -68,7 +68,7 @@ impl BlockInformation of BlockInformationTrait {
     fn exec_selfbalance(ref self: Machine) -> Result<(), EVMError> {
         let evm_address = self.evm_address();
 
-        let balance = balance(evm_address);
+        let balance = balance(evm_address)?;
 
         self.stack.push(balance)
     }

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -1,5 +1,5 @@
 use contracts::kakarot_core::interface::{IKakarotCore};
-use contracts::kakarot_core::{ContractAccountStorage, KakarotCore};
+use contracts::kakarot_core::{KakarotCore};
 use core::hash::{HashStateExTrait, HashStateTrait};
 use evm::balance::balance;
 use evm::context::ExecutionContextTrait;

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -29,7 +29,7 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
     fn exec_balance(ref self: Machine) -> Result<(), EVMError> {
         let evm_address = self.stack.pop_eth_address()?;
 
-        let balance = balance(evm_address);
+        let balance = balance(evm_address)?;
 
         return self.stack.push(balance);
     }

--- a/crates/evm/src/tests/test_balance.cairo
+++ b/crates/evm/src/tests/test_balance.cairo
@@ -19,7 +19,7 @@ fn test_balance_eoa() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let balance = balance(evm_address());
+    let balance = balance(evm_address()).unwrap();
 
     // Then
     assert(balance == native_token.balanceOf(eoa), 'wrong balance');
@@ -34,7 +34,7 @@ fn test_balance_zero() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let balance = balance(evm_address());
+    let balance = balance(evm_address()).unwrap();
 
     // Then
     assert(balance == 0x00, 'wrong balance');

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -507,14 +507,15 @@ impl SpanExtension<T, +Copy<T>, +Drop<T>> of SpanExtTrait<T> {
     }
 }
 
-trait BytesSerde<T> {
-    /// Serialize/deserialize bytes into/from
-    /// an array of bytes.
-    fn deserialize(self: Span<u8>) -> Option<T>;
-}
-
-impl BytesSerdeU32Impl of BytesSerde<u32> {
-    fn deserialize(self: Span<u8>) -> Option<u32> {
+#[generate_trait]
+impl U32Impl of U32Trait {
+    /// Packs 4 bytes into a u32
+    /// # Arguments
+    /// * `self` a Span<u8> of len <=4
+    /// # Returns
+    /// * Option::Some(u32) if the operation succeeds
+    /// * Option::None otherwise
+    fn from_bytes(self: Span<u8>) -> Option<u32> {
         let len = self.len();
         if len > 4 {
             return Option::None(());
@@ -594,5 +595,16 @@ impl ByteArrayExt of ByteArrayExTrait {
         arr.pending_word_len = pending_word_len;
         arr.pending_word = pending_word;
         arr
+    }
+}
+
+#[generate_trait]
+impl ResultExImpl<T, E, +Drop<T>, +Drop<E>> of ResultExTrait<T, E> {
+    /// Converts a Result<T,E> to a Result<T,F>
+    fn map_err<F, +Drop<F>>(self: Result<T, E>, err: F) -> Result<T, F> {
+        match self {
+            Result::Ok(val) => Result::Ok(val),
+            Result::Err(_) => Result::Err(err)
+        }
     }
 }

--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -4,7 +4,7 @@ use array::{Array, ArrayTrait, Span, SpanTrait};
 use clone::Clone;
 use traits::{Into, TryInto};
 use utils::errors::{RLPError, RLP_EMPTY_INPUT, RLP_INPUT_TOO_SHORT};
-use utils::helpers::BytesSerde;
+use utils::helpers::U32Trait;
 
 // All possible RLP types
 #[derive(Drop, PartialEq)]
@@ -81,7 +81,7 @@ fn rlp_decode(input: Span<u8>) -> Result<(RLPItem, usize), RLPError> {
             }
 
             let string_len_bytes = input.slice(1, len_bytes_count);
-            let string_len: u32 = string_len_bytes.deserialize().unwrap();
+            let string_len: u32 = U32Trait::from_bytes(string_len_bytes).unwrap();
             if input.len() <= string_len + len_bytes_count {
                 return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
             }
@@ -107,7 +107,7 @@ fn rlp_decode(input: Span<u8>) -> Result<(RLPItem, usize), RLPError> {
             }
 
             let list_len_bytes = input.slice(1, len_bytes_count);
-            let list_len: u32 = list_len_bytes.deserialize().unwrap();
+            let list_len: u32 = U32Trait::from_bytes(list_len_bytes).unwrap();
             if input.len() < list_len + len_bytes_count + 1 {
                 return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
             }

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -1,8 +1,9 @@
 use utils::helpers;
 use utils::helpers::{
-    SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, BytesSerde
+    SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, U32Trait
 };
 use utils::helpers::{ByteArrayExTrait};
+use utils::traits::{ByteArraySerde};
 
 #[test]
 #[available_gas(2000000000)]
@@ -275,9 +276,61 @@ fn test_pack_bytes_ge_bytes31() {
 #[available_gas(2000000000)]
 fn test_bytes_serde_u32_deserialize() {
     let input: Array<u8> = array![0xf4, 0x32, 0x15, 0x62];
-    let res: Option<u32> = input.span().deserialize();
+    let res: Option<u32> = U32Trait::from_bytes(input.span());
 
     assert(res != Option::None, 'should have a value');
     let res = res.unwrap();
     assert(res == 0xf4321562, 'wrong result value');
+}
+
+#[test]
+#[available_gas(2000000000)]
+fn test_bytearray_deserialize() {
+    let mut serialized: Span<felt252> = array![
+        0x03, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xabcdef
+    ]
+        .span();
+
+    let deserialized: ByteArray = Serde::<ByteArray>::deserialize(ref serialized).unwrap();
+
+    let expected = ByteArray {
+        data: array![
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.try_into().unwrap()
+        ],
+        pending_word_len: 3,
+        pending_word: 0xabcdef
+    };
+    assert(expected.len() == deserialized.len(), 'len mismatch');
+    let mut i = 0;
+    loop {
+        if i == deserialized.len() {
+            break;
+        }
+
+        assert(expected[i] == deserialized[i], 'item mismatch');
+        i += 1;
+    };
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytearray_serialize() {
+    let byte_arr = ByteArray {
+        data: array![
+            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.try_into().unwrap()
+        ],
+        pending_word_len: 3,
+        pending_word: 0xabcdef
+    };
+    let mut serialized: Array<felt252> = Default::default();
+    byte_arr.serialize(ref serialized);
+
+    // One extra element encodes the length of the pending word
+    assert(serialized.len() == 3, 'len mismatch');
+    assert(*serialized[0] == 3, 'pending_word_len mismatch');
+    assert(
+        *serialized[1] == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+        'full_word mismatch'
+    );
+    assert(*serialized[2] == 0xabcdef, 'pending_word mismatch');
 }

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -287,7 +287,7 @@ fn test_bytes_serde_u32_deserialize() {
 #[available_gas(2000000000)]
 fn test_bytearray_deserialize() {
     let mut serialized: Span<felt252> = array![
-        0x03, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xabcdef
+        0x03, 0xabcdef, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
     ]
         .span();
 
@@ -328,9 +328,9 @@ fn test_bytearray_serialize() {
     // One extra element encodes the length of the pending word
     assert(serialized.len() == 3, 'len mismatch');
     assert(*serialized[0] == 3, 'pending_word_len mismatch');
+    assert(*serialized[1] == 0xabcdef, 'pending_word mismatch');
     assert(
-        *serialized[1] == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+        *serialized[2] == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
         'full_word mismatch'
     );
-    assert(*serialized[2] == 0xabcdef, 'pending_word mismatch');
 }

--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -135,8 +135,10 @@ impl StoreBytes31 of Store<bytes31> {
 impl ByteArraySerde of Serde<ByteArray> {
     fn serialize(self: @ByteArray, ref output: Array<felt252>) {
         // First felt is number of bytes used in the last felt
+        // Second felt is the pending word
         // Subsequent felts are the full 31-byte words
         output.append((*self.pending_word_len).into());
+        output.append((*self.pending_word).into());
         let mut i = 0;
         loop {
             if i == self.data.len() {
@@ -145,14 +147,11 @@ impl ByteArraySerde of Serde<ByteArray> {
             output.append((*self.data[i]).into());
             i += 1;
         };
-
-        // Last felt is the pending_word.
-        output.append(*self.pending_word);
     }
 
     fn deserialize(ref serialized: Span<felt252>) -> Option<ByteArray> {
         let pending_word_len: u32 = (*serialized.pop_front()?).try_into()?;
-        let pending_word = *serialized.pop_back()?;
+        let pending_word = *serialized.pop_front()?;
         let mut data: Array<bytes31> = Default::default();
         loop {
             match serialized.pop_front() {

--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -142,7 +142,8 @@ impl ByteArraySerde of Serde<ByteArray> {
             if i == self.data.len() {
                 break;
             }
-            output.append((*self.data[i]).into())
+            output.append((*self.data[i]).into());
+            i += 1;
         };
 
         // Last felt is the pending_word.

--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -131,3 +131,36 @@ impl StoreBytes31 of Store<bytes31> {
         1_u8
     }
 }
+
+impl ByteArraySerde of Serde<ByteArray> {
+    fn serialize(self: @ByteArray, ref output: Array<felt252>) {
+        // First felt is number of bytes used in the last felt
+        // Subsequent felts are the full 31-byte words
+        output.append((*self.pending_word_len).into());
+        let mut i = 0;
+        loop {
+            if i == self.data.len() {
+                break;
+            }
+            output.append((*self.data[i]).into())
+        };
+
+        // Last felt is the pending_word.
+        output.append(*self.pending_word);
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<ByteArray> {
+        let pending_word_len: u32 = (*serialized.pop_front()?).try_into()?;
+        let pending_word = *serialized.pop_back()?;
+        let mut data: Array<bytes31> = Default::default();
+        loop {
+            match serialized.pop_front() {
+                Option::Some(val) => { data.append((*val).try_into().unwrap()); },
+                Option::None => { break; }
+            }
+        };
+        Option::Some(
+            ByteArray { data: data, pending_word: pending_word, pending_word_len: pending_word_len }
+        )
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Defines a `ContractAccount` struct and its associated methods to interact with the storage of a Contract Account, embedded into the contract storage.

Defines a ByteArraySerde implementation that allows us to serialize/deserialize the ByteArray type. The first stored element in the serialized ByteArray is the `pending_word_len` - the last element is the `pending_word` - the elements are the full world.

Removes the explicit storage fields inside the KakarotCore Storage struct. Contract-Account related storage is now entirely performed in the ContractAccount module.

KakarotCore functions requiring interactions with the storage of a contract account need to first wrap an `evm_address` inside a `ContractAccount` struct, and then call the corresponding methods.

This allows for atomic querying of CA-related storage values.

I believe we should do the same for an EOA struct - the KakarotCore contract would just call methods on the EOA type which is a wrapper around an EVM address, and the internals would be defined in an `eoa.cairo` file that would perform the required calls to the actually deployed EOA account.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #437 Resolves #436

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
