### PR TITLE
feat: rlp string encoding

### DIFF
--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -542,18 +542,18 @@ impl U32Impl of U32Trait {
     /// * The bytes array representation of the value.
     fn to_bytes(mut self: u32) -> Span<u8> {
         let bytes_used: u32 = self.bytes_used().into();
-        let mut reversed_res: Array<u8> = Default::default();
+        let mut bytes: Array<u8> = Default::default();
         let mut i = 0;
         loop {
             if i == bytes_used {
                 break ();
             }
-            reversed_res.append((self & 0xFF).try_into().unwrap());
-            self = self.shr(8);
+            let val = self.shr(8 * (bytes_used.try_into().unwrap() - i - 1));
+            bytes.append((val & 0xFF).try_into().unwrap());
             i += 1;
         };
 
-        reversed_res.span().reverse().span()
+        bytes.span()
     }
 
     /// Returns the number of bytes used to represent a `u64` value.

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -556,9 +556,9 @@ impl U32Impl of U32Trait {
         bytes.span()
     }
 
-    /// Returns the number of bytes used to represent a `u64` value.
+    /// Returns the number of bytes used to represent a `u32` value.
     /// # Arguments
-    /// * `val` - The value to check.
+    /// * `self` - The value to check.
     /// # Returns
     /// The number of bytes used to represent the value.
     fn bytes_used(self: usize) -> u8 {
@@ -600,13 +600,11 @@ impl U256Impl of U256Trait {
 #[generate_trait]
 impl ByteArrayExt of ByteArrayExTrait {
     fn append_span_bytes(ref self: ByteArray, mut bytes: Span<u8>) {
-        let mut i = 0;
         loop {
-            if i == bytes.len() {
-                break;
+            match bytes.pop_front() {
+                Option::Some(val) => { self.append_byte(*val) },
+                Option::None => { break; }
             }
-            self.append_byte(*bytes.at(i));
-            i += 1;
         }
     }
 

--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -62,7 +62,7 @@ impl RLPImpl of RLPTrait {
             return Result::Ok(
                 ByteArray { data: Default::default(), pending_word: 0x80, pending_word_len: 1 }
             );
-        } else if len == 1 && input.at(0).unwrap() < 0x80 {
+        } else if len == 1 && input[0] < 0x80 {
             return Result::Ok(input);
         } else if len < 56 {
             let mut prefixes: ByteArray = Default::default();

--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -4,7 +4,7 @@ use array::{Array, ArrayTrait, Span, SpanTrait};
 use clone::Clone;
 use traits::{Into, TryInto};
 use utils::errors::{RLPError, RLP_EMPTY_INPUT, RLP_INPUT_TOO_SHORT};
-use utils::helpers::U32Trait;
+use utils::helpers::{U32Trait, ByteArrayExTrait};
 
 // All possible RLP types
 #[derive(Drop, PartialEq)]
@@ -24,100 +24,135 @@ enum RLPItem {
 }
 
 #[generate_trait]
-impl RLPTypeImpl of RLPTypeTrait {
+impl RLPImpl of RLPTrait {
     /// Returns RLPType from the leading byte
     ///
     /// # Arguments
     ///
-    /// * `byte` - Leading byte
+    /// * `byte` - Leading byte of the RLP encoded data
     /// Return result with RLPType
-    fn from_byte(byte: u8) -> RLPType {
-        if byte <= 0x7f {
+    fn decode_type(byte: u8) -> RLPType {
+        if byte < 0x80 {
             RLPType::String
-        } else if byte <= 0xb7 {
+        } else if byte < 0xb8 {
             RLPType::StringShort
-        } else if byte <= 0xbf {
+        } else if byte < 0xc0 {
             RLPType::StringLong
-        } else if byte <= 0xf7 {
+        } else if byte < 0xf8 {
             RLPType::ListShort
         } else {
             RLPType::ListLong
         }
     }
-}
 
-/// RLP decodes a rlp encoded byte array
-/// as described in https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
-///
-/// # Arguments
-///
-/// * `input` - RLP encoded bytes
-/// Return result with RLPItem and size of the decoded item
-fn rlp_decode(input: Span<u8>) -> Result<(RLPItem, usize), RLPError> {
-    if input.len() == 0 {
-        return Result::Err(RLPError::RlpEmptyInput(RLP_EMPTY_INPUT));
+
+    /// RLP encodes a ByteArray, which is the underlying type used to represent
+    /// string data in Cairo.  Since RLP encoding is only used for eth_address
+    /// computation by calculating the RLP::encode(deployer_address, deployer_nonce)
+    /// and then hash it, the input is a ByteArray and not a Span<u8>
+    /// # Arguments
+    /// * `input` - ByteArray to encode
+    /// # Returns
+    /// * `ByteArray - RLP encoded ByteArray
+    /// # Errors
+    /// * RLPError::RlpEmptyInput - if the input is empty
+    fn encode_string(input: ByteArray) -> Result<ByteArray, RLPError> {
+        let len = input.len();
+        if len == 0 {
+            return Result::Err(RLPError::RlpEmptyInput(RLP_EMPTY_INPUT));
+        } else if len == 1 && input.at(0).unwrap() < 0x80 {
+            return Result::Ok(input);
+        } else if len <= 55 {
+            let mut prefixes: ByteArray = Default::default();
+            prefixes.append_byte(0x80 + len.try_into().unwrap());
+            let encoding = ByteArrayTrait::concat(@prefixes, @input);
+            return Result::Ok(encoding);
+        } else {
+            let mut prefixes: ByteArray = Default::default();
+            let len_as_bytes = len.to_bytes();
+            let len_bytes_count = len_as_bytes.len();
+            let prefix = 0xb7 + len_bytes_count.try_into().unwrap();
+            prefixes.append_byte(prefix);
+            prefixes.append_span_bytes(len_as_bytes);
+            let encoding = ByteArrayTrait::concat(@prefixes, @input);
+            return Result::Ok(encoding);
+        }
     }
-    let prefix = *input.at(0);
 
-    let rlp_type = RLPTypeTrait::from_byte(prefix);
-    match rlp_type {
-        RLPType::String => {
-            let mut arr = array![prefix];
-            Result::Ok((RLPItem::Bytes(arr.span()), 1))
-        },
-        RLPType::StringShort => {
-            let len = prefix.into() - 0x80;
-            if input.len() <= len {
-                return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+    /// RLP decodes a rlp encoded byte array
+    /// as described in https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - RLP encoded bytes
+    /// Return result with RLPItem and size of the decoded item
+    fn decode(input: Span<u8>) -> Result<(RLPItem, usize), RLPError> {
+        if input.len() == 0 {
+            return Result::Err(RLPError::RlpEmptyInput(RLP_EMPTY_INPUT));
+        }
+        let prefix = *input.at(0);
+
+        let rlp_type = RLPTrait::decode_type(prefix);
+        match rlp_type {
+            RLPType::String => {
+                let mut arr = array![prefix];
+                Result::Ok((RLPItem::Bytes(arr.span()), 1))
+            },
+            RLPType::StringShort => {
+                let len = prefix.into() - 0x80;
+                if input.len() <= len {
+                    return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+                }
+                let decoded_string = input.slice(1, len);
+
+                Result::Ok((RLPItem::Bytes(decoded_string), 1 + len))
+            },
+            RLPType::StringLong => {
+                let len_bytes_count = prefix.into() - 0xb7;
+                if input.len() <= len_bytes_count {
+                    return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+                }
+
+                let string_len_bytes = input.slice(1, len_bytes_count);
+                let string_len: u32 = U32Trait::from_bytes(string_len_bytes).unwrap();
+                if input.len() <= string_len + len_bytes_count {
+                    return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+                }
+
+                let decoded_string = input.slice(1 + len_bytes_count, string_len);
+
+                Result::Ok((RLPItem::Bytes(decoded_string), 1 + len_bytes_count + string_len))
+            },
+            RLPType::ListShort => {
+                let len = prefix.into() - 0xc0;
+                if input.len() <= len {
+                    return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+                }
+
+                let mut list_input = input.slice(1, len);
+                let decoded_list = rlp_decode_list(ref list_input)?;
+                Result::Ok((RLPItem::List(decoded_list), 1 + len))
+            },
+            RLPType::ListLong => {
+                let len_bytes_count = prefix.into() - 0xf7;
+                if input.len() <= len_bytes_count {
+                    return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+                }
+
+                let list_len_bytes = input.slice(1, len_bytes_count);
+                let list_len: u32 = U32Trait::from_bytes(list_len_bytes).unwrap();
+                if input.len() < list_len + len_bytes_count + 1 {
+                    return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
+                }
+
+                let mut list_input = input.slice(1 + len_bytes_count, list_len);
+                let decoded_list = rlp_decode_list(ref list_input)?;
+                Result::Ok((RLPItem::List(decoded_list), 1 + len_bytes_count + list_len))
             }
-            let decoded_string = input.slice(1, len);
-
-            Result::Ok((RLPItem::Bytes(decoded_string), 1 + len))
-        },
-        RLPType::StringLong => {
-            let len_bytes_count = prefix.into() - 0xb7;
-            if input.len() <= len_bytes_count {
-                return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
-            }
-
-            let string_len_bytes = input.slice(1, len_bytes_count);
-            let string_len: u32 = U32Trait::from_bytes(string_len_bytes).unwrap();
-            if input.len() <= string_len + len_bytes_count {
-                return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
-            }
-
-            let decoded_string = input.slice(1 + len_bytes_count, string_len);
-
-            Result::Ok((RLPItem::Bytes(decoded_string), 1 + len_bytes_count + string_len))
-        },
-        RLPType::ListShort => {
-            let len = prefix.into() - 0xc0;
-            if input.len() <= len {
-                return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
-            }
-
-            let mut list_input = input.slice(1, len);
-            let decoded_list = rlp_decode_list(ref list_input)?;
-            Result::Ok((RLPItem::List(decoded_list), 1 + len))
-        },
-        RLPType::ListLong => {
-            let len_bytes_count = prefix.into() - 0xf7;
-            if input.len() <= len_bytes_count {
-                return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
-            }
-
-            let list_len_bytes = input.slice(1, len_bytes_count);
-            let list_len: u32 = U32Trait::from_bytes(list_len_bytes).unwrap();
-            if input.len() < list_len + len_bytes_count + 1 {
-                return Result::Err(RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT));
-            }
-
-            let mut list_input = input.slice(1 + len_bytes_count, list_len);
-            let decoded_list = rlp_decode_list(ref list_input)?;
-            Result::Ok((RLPItem::List(decoded_list), 1 + len_bytes_count + list_len))
         }
     }
 }
+
 
 fn rlp_decode_list(ref input: Span<u8>) -> Result<Span<Span<u8>>, RLPError> {
     let mut i = 0;
@@ -129,7 +164,7 @@ fn rlp_decode_list(ref input: Span<u8>) -> Result<Span<Span<u8>>, RLPError> {
             break Option::None;
         }
 
-        let res = rlp_decode(input);
+        let res = RLPTrait::decode(input);
 
         let (decoded, decoded_len) = match res {
             Result::Ok(res_dec) => { res_dec },

--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -59,13 +59,15 @@ impl RLPImpl of RLPTrait {
     fn encode_string(input: ByteArray) -> Result<ByteArray, RLPError> {
         let len = input.len();
         if len == 0 {
-            return Result::Err(RLPError::RlpEmptyInput(RLP_EMPTY_INPUT));
+            return Result::Ok(
+                ByteArray { data: Default::default(), pending_word: 0x80, pending_word_len: 1 }
+            );
         } else if len == 1 && input.at(0).unwrap() < 0x80 {
             return Result::Ok(input);
-        } else if len <= 55 {
+        } else if len < 56 {
             let mut prefixes: ByteArray = Default::default();
             prefixes.append_byte(0x80 + len.try_into().unwrap());
-            let encoding = ByteArrayTrait::concat(@prefixes, @input);
+            let encoding = prefixes + input;
             return Result::Ok(encoding);
         } else {
             let mut prefixes: ByteArray = Default::default();
@@ -74,7 +76,7 @@ impl RLPImpl of RLPTrait {
             let prefix = 0xb7 + len_bytes_count.try_into().unwrap();
             prefixes.append_byte(prefix);
             prefixes.append_span_bytes(len_as_bytes);
-            let encoding = ByteArrayTrait::concat(@prefixes, @input);
+            let encoding = prefixes + input;
             return Result::Ok(encoding);
         }
     }

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -273,14 +273,95 @@ fn test_pack_bytes_ge_bytes31() {
 }
 
 #[test]
-#[available_gas(2000000000)]
-fn test_bytes_serde_u32_deserialize() {
+#[available_gas(2000000)]
+fn test_bytearray_append_span_bytes() {
+    let bytes = array![0x01, 0x02, 0x03, 0x04];
+    let mut byte_arr: ByteArray = Default::default();
+    byte_arr.append_byte(0xFF);
+    byte_arr.append_byte(0xAA);
+    byte_arr.append_span_bytes(bytes.span());
+    assert(byte_arr.len() == 6, 'wrong length');
+    assert(byte_arr[0] == 0xFF, 'wrong value');
+    assert(byte_arr[1] == 0xAA, 'wrong value');
+    assert(byte_arr[2] == 0x01, 'wrong value');
+    assert(byte_arr[3] == 0x02, 'wrong value');
+    assert(byte_arr[4] == 0x03, 'wrong value');
+    assert(byte_arr[5] == 0x04, 'wrong value');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_u32_from_bytes() {
     let input: Array<u8> = array![0xf4, 0x32, 0x15, 0x62];
     let res: Option<u32> = U32Trait::from_bytes(input.span());
 
-    assert(res != Option::None, 'should have a value');
-    let res = res.unwrap();
-    assert(res == 0xf4321562, 'wrong result value');
+    assert(res.is_some(), 'should have a value');
+    assert(res.unwrap() == 0xf4321562, 'wrong result value');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_u32_from_bytes_too_big() {
+    let input: Array<u8> = array![0xf4, 0x32, 0x15, 0x62, 0x01];
+    let res: Option<u32> = U32Trait::from_bytes(input.span());
+
+    assert(res.is_none(), 'should not have a value');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_u32_to_bytes_full() {
+    let input: u32 = 0xf4321562;
+    let res: Span<u8> = input.to_bytes();
+
+    assert(res.len() == 4, 'wrong result length');
+    assert(*res[0] == 0xf4, 'wrong result value');
+    assert(*res[1] == 0x32, 'wrong result value');
+    assert(*res[2] == 0x15, 'wrong result value');
+    assert(*res[3] == 0x62, 'wrong result value');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_u32_to_bytes_partial() {
+    let input: u32 = 0xf43215;
+    let res: Span<u8> = input.to_bytes();
+
+    assert(res.len() == 3, 'wrong result length');
+    assert(*res[0] == 0xf4, 'wrong result value');
+    assert(*res[1] == 0x32, 'wrong result value');
+    assert(*res[2] == 0x15, 'wrong result value');
+}
+
+
+#[test]
+#[available_gas(2000000)]
+fn test_u32_to_bytes_leading_zeros() {
+    let input: u32 = 0x00f432;
+    let res: Span<u8> = input.to_bytes();
+
+    assert(res.len() == 2, 'wrong result length');
+    assert(*res[0] == 0xf4, 'wrong result value');
+    assert(*res[1] == 0x32, 'wrong result value');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+fn test_u32_bytes_used() {
+    let len = 0x1234;
+    let bytes_count = len.bytes_used();
+
+    assert(bytes_count == 2, 'wrong bytes count');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_u32_bytes_used_leading_zeroes() {
+    let len = 0x001234;
+    let bytes_count = len.bytes_used();
+
+    assert(bytes_count == 2, 'wrong bytes count');
 }
 
 #[test]

--- a/crates/utils/src/tests/test_rlp.cairo
+++ b/crates/utils/src/tests/test_rlp.cairo
@@ -1,7 +1,8 @@
-use utils::rlp::{rlp_decode, RLPType, RLPTypeTrait, RLPItem};
+use utils::rlp::{RLPType, RLPTrait, RLPItem};
 use array::{ArrayTrait, SpanTrait};
 use result::ResultTrait;
 use utils::errors::{RLPError, RLP_EMPTY_INPUT, RLP_INPUT_TOO_SHORT};
+use utils::helpers::U32Trait;
 
 // Tests source : https://github.com/HerodotusDev/cairo-lib/blob/main/src/encoding/tests/test_rlp.cairo
 #[test]
@@ -10,15 +11,15 @@ fn test_rlp_types() {
     let mut i = 0;
     loop {
         if i <= 0x7f {
-            assert(RLPTypeTrait::from_byte(i) == RLPType::String, 'Parse type String');
+            assert(RLPTrait::decode_type(i) == RLPType::String, 'Parse type String');
         } else if i <= 0xb7 {
-            assert(RLPTypeTrait::from_byte(i) == RLPType::StringShort, 'Parse type StringShort');
+            assert(RLPTrait::decode_type(i) == RLPType::StringShort, 'Parse type StringShort');
         } else if i <= 0xbf {
-            assert(RLPTypeTrait::from_byte(i) == RLPType::StringLong, 'Parse type StringLong');
+            assert(RLPTrait::decode_type(i) == RLPType::StringLong, 'Parse type StringLong');
         } else if i <= 0xf7 {
-            assert(RLPTypeTrait::from_byte(i) == RLPType::ListShort, 'Parse type ListShort');
+            assert(RLPTrait::decode_type(i) == RLPType::ListShort, 'Parse type ListShort');
         } else if i <= 0xff {
-            assert(RLPTypeTrait::from_byte(i) == RLPType::ListLong, 'Parse type ListLong');
+            assert(RLPTrait::decode_type(i) == RLPType::ListLong, 'Parse type ListLong');
         }
 
         if i == 0xff {
@@ -31,10 +32,143 @@ fn test_rlp_types() {
 #[test]
 #[available_gas(9999999)]
 fn test_rlp_empty() {
-    let res = rlp_decode(ArrayTrait::new().span());
+    let res = RLPTrait::decode(ArrayTrait::new().span());
 
     assert(res.is_err(), 'should return an error');
     assert(res.unwrap_err() == RLPError::RlpEmptyInput(RLP_EMPTY_INPUT), 'err != RlpInvalidLength');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_rlp_encode_string_empty_input() {
+    let input: ByteArray = Default::default();
+    let res = RLPTrait::encode_string(input);
+    assert(res.is_err(), 'should return error');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_rlp_encode_single_byte_lt_0x80() {
+    let mut input: ByteArray = Default::default();
+    input.append_byte(0x40);
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 1, 'wrong len');
+    assert(res[0] == 0x40, 'wrong encoded value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_rlp_encode_single_byte_ge_0x80() {
+    let mut input: ByteArray = Default::default();
+    input.append_byte(0x80);
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 2, 'wrong len');
+    assert(res[0] == 0x81, 'wrong prefix');
+    assert(res[1] == 0x80, 'wrong encoded value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_rlp_encode_length_between_2_and_55() {
+    let mut input: ByteArray = Default::default();
+    input.append_byte(0x40);
+    input.append_byte(0x50);
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 3, 'wrong len');
+    assert(res[0] == 0x82, 'wrong prefix');
+    assert(res[1] == 0x40, 'wrong first value');
+    assert(res[2] == 0x50, 'wrong second value');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_rlp_encode_length_exactly_56() {
+    let mut input: ByteArray = Default::default();
+    let mut i = 0;
+    loop {
+        if i == 56 {
+            break;
+        }
+        input.append_byte(0x60);
+        i += 1;
+    };
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 58, 'wrong len');
+    assert(res[0] == 0xb8, 'wrong prefix');
+    assert(res[1] == 56, 'wrong string length');
+    let mut i = 2;
+    loop {
+        if i == 58 {
+            break;
+        }
+        assert(res[i] == 0x60, 'wrong value in sequence');
+        i += 1;
+    };
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_rlp_encode_length_greater_than_56() {
+    let mut input: ByteArray = Default::default();
+    let mut i = 0;
+    loop {
+        if i == 60 {
+            break;
+        }
+        input.append_byte(0x70);
+        i += 1;
+    };
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 62, 'wrong len');
+    assert(res[0] == 0xb8, 'wrong prefix');
+    assert(res[1] == 60, 'wrong length byte');
+    let mut i = 2;
+    loop {
+        if i == 62 {
+            break;
+        }
+        assert(res[i] == 0x70, 'wrong value in sequence');
+        i += 1;
+    }
+}
+
+#[test]
+#[available_gas(200000000)]
+fn test_rlp_encode_large_bytearray_inputs() {
+    let mut input: ByteArray = Default::default();
+    let mut i = 0;
+    loop {
+        if i == 500 {
+            break;
+        }
+        input.append_byte(0x70);
+        i += 1;
+    };
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 503, 'wrong len');
+    assert(res[0] == 0xb9, 'wrong prefix');
+    assert(res[1] == 0x01, 'wrong first length byte');
+    assert(res[2] == 0xF4, 'wrong second length byte');
+    let mut i = 3;
+    loop {
+        if i == 503 {
+            break;
+        }
+        assert(res[i] == 0x70, 'wrong value in sequence');
+        i += 1;
+    }
 }
 
 #[test]
@@ -48,7 +182,7 @@ fn test_rlp_decode_string() {
         let mut arr = ArrayTrait::new();
         arr.append(i);
 
-        let (res, len) = rlp_decode(arr.span()).unwrap();
+        let (res, len) = RLPTrait::decode(arr.span()).unwrap();
         assert(len == 1, 'Wrong len');
         assert(res == RLPItem::Bytes(arr.span()), 'Wrong value');
 
@@ -90,7 +224,7 @@ fn test_rlp_decode_short_string() {
         0xf7
     ];
 
-    let (res, len) = rlp_decode(arr.span()).unwrap();
+    let (res, len) = RLPTrait::decode(arr.span()).unwrap();
     assert(len == 1 + (0x9b - 0x80), 'Wrong len');
 
     // Remove the byte representing the data type
@@ -133,7 +267,7 @@ fn test_rlp_decode_short_string_input_too_short() {
         0x3b
     ];
 
-    let res = rlp_decode(arr.span());
+    let res = RLPTrait::decode(arr.span());
     assert(res.is_err(), 'should return an RLPError');
     assert(
         res.unwrap_err() == RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT),
@@ -209,7 +343,7 @@ fn test_rlp_decode_long_string_with_payload_len_on_1_byte() {
         0xd9
     ];
 
-    let (res, len) = rlp_decode(arr.span()).unwrap();
+    let (res, len) = RLPTrait::decode(arr.span()).unwrap();
     assert(len == 1 + (0xb8 - 0xb7) + 0x3c, 'Wrong len');
 
     // Remove the bytes representing the data type and their length
@@ -286,7 +420,7 @@ fn test_rlp_decode_long_string_with_input_too_short() {
         0x19,
     ];
 
-    let res = rlp_decode(arr.span());
+    let res = RLPTrait::decode(arr.span());
     assert(res.is_err(), 'should return an RLPError');
     assert(
         res.unwrap_err() == RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT),
@@ -561,7 +695,7 @@ fn test_rlp_decode_long_string_with_payload_len_on_2_bytes() {
         0x60
     ];
 
-    let (res, len) = rlp_decode(arr.span()).unwrap();
+    let (res, len) = RLPTrait::decode(arr.span()).unwrap();
     assert(len == 1 + (0xb9 - 0xb7) + 0x0102, 'Wrong len');
 
     // Remove the bytes representing the data type and their length
@@ -579,7 +713,7 @@ fn test_rlp_decode_long_string_with_payload_len_on_2_bytes() {
 fn test_rlp_decode_long_string_with_payload_len_too_short() {
     let mut arr = array![0xb9, 0x01,];
 
-    let res = rlp_decode(arr.span());
+    let res = RLPTrait::decode(arr.span());
     assert(res.is_err(), 'should return an RLPError');
     assert(
         res.unwrap_err() == RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT),
@@ -591,7 +725,7 @@ fn test_rlp_decode_long_string_with_payload_len_too_short() {
 #[available_gas(99999999999)]
 fn test_rlp_decode_short_list() {
     let mut arr = array![0xc9, 0x83, 0x35, 0x35, 0x89, 0x42, 0x83, 0x45, 0x38, 0x92];
-    let (res, len) = rlp_decode(arr.span()).unwrap();
+    let (res, len) = RLPTrait::decode(arr.span()).unwrap();
     assert(len == 1 + (0xc9 - 0xc0), 'Wrong len');
 
     let mut expected_0 = array![0x35, 0x35, 0x89];
@@ -609,7 +743,7 @@ fn test_rlp_decode_short_list() {
 fn test_rlp_decode_short_list_with_input_too_short() {
     let mut arr = array![0xc9, 0x83, 0x35, 0x35, 0x89, 0x42, 0x83, 0x45, 0x38];
 
-    let res = rlp_decode(arr.span());
+    let res = RLPTrait::decode(arr.span());
     assert(res.is_err(), 'should return an RLPError');
     assert(
         res.unwrap_err() == RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT),
@@ -1154,7 +1288,7 @@ fn test_rlp_decode_long_list() {
         0x5f,
         0x80
     ];
-    let (res, len) = rlp_decode(arr.span()).unwrap();
+    let (res, len) = RLPTrait::decode(arr.span()).unwrap();
     assert(len == 1 + (0xf9 - 0xf7) + 0x0211, 'Wrong len');
 
     let mut expected_0 = array![
@@ -1761,7 +1895,7 @@ fn test_rlp_decode_long_list_with_input_too_short() {
         0xb4
     ];
 
-    let res = rlp_decode(arr.span());
+    let res = RLPTrait::decode(arr.span());
     assert(res.is_err(), 'should return an RLPError');
     assert(
         res.unwrap_err() == RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT),
@@ -1774,7 +1908,7 @@ fn test_rlp_decode_long_list_with_input_too_short() {
 fn test_rlp_decode_long_list_with_len_too_short() {
     let mut arr = array![0xf9, 0x02,];
 
-    let res = rlp_decode(arr.span());
+    let res = RLPTrait::decode(arr.span());
     assert(res.is_err(), 'should return an RLPError');
     assert(
         res.unwrap_err() == RLPError::RlpInputTooShort(RLP_INPUT_TOO_SHORT),

--- a/crates/utils/src/tests/test_rlp.cairo
+++ b/crates/utils/src/tests/test_rlp.cairo
@@ -41,9 +41,12 @@ fn test_rlp_empty() {
 #[test]
 #[available_gas(20000000)]
 fn test_rlp_encode_string_empty_input() {
-    let input: ByteArray = Default::default();
-    let res = RLPTrait::encode_string(input);
-    assert(res.is_err(), 'should return error');
+    let mut input: ByteArray = Default::default();
+
+    let res = RLPTrait::encode_string(input).unwrap();
+
+    assert(res.len() == 1, 'wrong len');
+    assert(res[0] == 0x80, 'wrong encoded value');
 }
 
 #[test]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
- Refactored a bit how RLP is called introducing the RLPTrait
- Tiny improvements in RLP Type decoding by using __range checks only__ and not __range checks + equality checks__
- Implemented RLP string encoding.
- Added utils functions to know how many bytes a u32 uses and convert it to bytes
- Thoroughly tested the added utils and rlp_encoding
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #440

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
