### PR TITLE
fix: fix chain id inconsistency

### DIFF
--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -19,6 +19,9 @@ trait IKakarotCore<TContractState> {
     /// Get the deploy fee
     fn deploy_fee(self: @TContractState) -> u128;
 
+    /// Get the chain id
+    fn chain_id(self: @TContractState) -> u128;
+
     /// Deterministically computes a Starknet address for an given EVM address
     /// The address is computed as the Starknet address corresponding to the deployment of an EOA,
     /// Using its EVM address as salt, and KakarotCore as deployer.
@@ -98,6 +101,9 @@ trait IExtendedKakarotCore<TContractState> {
     /// Get the deploy fee
     fn deploy_fee(self: @TContractState) -> u128;
 
+    /// Get the chain id
+    fn chain_id(self: @TContractState) -> u128;
+
     /// Deterministically computes a Starknet address for an given EVM address
     /// The address is computed as the Starknet address corresponding to the deployment of an EOA,
     /// Using its EVM address as salt, and KakarotCore as deployer.
@@ -142,4 +148,3 @@ trait IExtendedKakarotCore<TContractState> {
     fn transfer_ownership(ref self: TContractState, new_owner: ContractAddress);
     fn renounce_ownership(ref self: TContractState);
 }
-

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -121,6 +121,11 @@ mod KakarotCore {
             self.deploy_fee.read()
         }
 
+        /// Get the chain id
+        fn chain_id(self: @ContractState) -> u128 {
+            self.chain_id.read()
+        }
+
         /// Deterministically computes a Starknet address for an given EVM address
         /// The address is computed as the Starknet address corresponding to the deployment of an EOA,
         /// Using its EVM address as salt, and KakarotCore as deployer.

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -47,6 +47,13 @@ fn test_kakarot_core_deploy_fee() {
 
 #[test]
 #[available_gas(20000000)]
+fn test_kakarot_core_chain_id() {
+    let kakarot_core = utils::deploy_kakarot_core(test_utils::native_token());
+    assert(kakarot_core.chain_id() == utils::chain_id(), 'wrong chain id');
+}
+
+#[test]
+#[available_gas(20000000)]
 fn test_kakarot_core_set_deploy_fee() {
     let kakarot_core = utils::deploy_kakarot_core(test_utils::native_token());
     assert(kakarot_core.deploy_fee() == utils::deploy_fee(), 'wrong deploy_fee');

--- a/crates/evm/src/instructions/block_information.cairo
+++ b/crates/evm/src/instructions/block_information.cairo
@@ -1,5 +1,7 @@
 //! Block Information.
 
+use contracts::kakarot_core::{KakarotCore, IKakarotCore};
+
 use evm::errors::{EVMError, BLOCK_HASH_SYSCALL_FAILED};
 use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::model::{AccountTrait, Account};
@@ -8,7 +10,6 @@ use evm::stack::StackTrait;
 // Corelib imports
 use starknet::info::{get_block_number, get_block_timestamp, get_block_info};
 use starknet::{get_block_hash_syscall};
-use utils::constants::CHAIN_ID;
 
 #[generate_trait]
 impl BlockInformation of BlockInformationTrait {
@@ -77,10 +78,9 @@ impl BlockInformation of BlockInformationTrait {
     /// Get the chain ID.
     /// # Specification: https://www.evm.codes/#46?fork=shanghai
     fn exec_chainid(ref self: Machine) -> Result<(), EVMError> {
-        // CHAIN_ID = KKRT (0x4b4b5254) in ASCII
-        // TODO: Replace the hardcoded value by a value set in kakarot main contract constructor
-        // Push the chain ID to stack
-        self.stack.push(CHAIN_ID)
+        let kakarot_state = KakarotCore::unsafe_new_contract_state();
+        let chain_id = kakarot_state.chain_id();
+        self.stack.push(chain_id.into())
     }
 
     /// 0x47 - SELFBALANCE

--- a/crates/evm/src/tests/test_instructions/test_block_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_block_information.cairo
@@ -1,4 +1,7 @@
-use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
+use contracts::kakarot_core::interface::{
+    IExtendedKakarotCoreDispatcher, IExtendedKakarotCoreDispatcherTrait
+};
+
 use contracts::tests::utils::{
     deploy_kakarot_core, deploy_native_token, fund_account_with_native_token
 };
@@ -7,7 +10,6 @@ use evm::stack::StackTrait;
 use evm::tests::test_utils::{setup_machine, evm_address};
 use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use starknet::testing::{set_block_timestamp, set_block_number, set_contract_address};
-use utils::constants::CHAIN_ID;
 
 /// 0x40 - BLOCKHASH
 #[test]
@@ -187,12 +189,19 @@ fn test_basefee() {
 #[test]
 #[available_gas(20000000)]
 fn test_chainid_should_push_chain_id_to_stack() {
+    let native_token = deploy_native_token();
+    let kakarot = deploy_kakarot_core(native_token.contract_address);
+
+    set_contract_address(kakarot.contract_address);
+
     // Given
     let mut machine = setup_machine();
 
-    // CHAIN_ID = KKRT (0x4b4b5254) in ASCII
-    // TODO: Replace the hardcoded value by a value set in kakarot main contract constructor
-    let chain_id: u256 = CHAIN_ID;
+    let chain_id: u256 = IExtendedKakarotCoreDispatcher {
+        contract_address: kakarot.contract_address
+    }
+        .chain_id()
+        .into();
 
     // When
     machine.exec_chainid();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We are using the constant `CHAIN_ID` in place of the storage variable for chain id from kakarot core.

Resolves: #451 

## What is the new behavior?

- a getter for `chain_id` storage variable
- using `chain_id` storage variable in the EVM rather than the constant

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
