### PR TITLE
feat: final pc should trigger stop

### DIFF
--- a/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
@@ -18,6 +18,15 @@ impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
     /// # Specification: https://www.evm.codes/#00?fork=shanghai
     fn exec_stop(ref self: Machine) -> Result<(), EVMError> {
         self.set_stopped();
+
+        // In our architecture, when finalizing a subcontext,
+        // we write its `return_data` field to its parent `return_data` field.
+        // As STOP does not allow `return_data` to be written to the execution summary,
+        // We simply erase the `return_data` field.
+        let mut current_ctx = self.current_ctx.unbox();
+        current_ctx.return_data = Default::default().span();
+        self.current_ctx = BoxTrait::new(current_ctx);
+
         Result::Ok(())
     }
 

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -70,9 +70,13 @@ impl EVMInterpreterImpl of EVMInterpreterTrait {
         let bytecode = machine.call_ctx().bytecode();
         let bytecode_len = bytecode.len();
 
-        // Check if PC is not out of bounds.
-        if pc >= bytecode_len {
+        if pc > bytecode_len {
             return Result::Err(EVMError::InvalidProgramCounter(PC_OUT_OF_BOUNDS));
+        }
+        // If the PC has reached the end of the bytecode length, and there are no STOP, RETURN nor REVERT opcode
+        // Halt the execution successfully
+        if pc == bytecode_len {
+            return machine.exec_stop();
         }
 
         let opcode: u8 = *bytecode.at(pc);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

- added logic to STOP when PC reaches the end bytecode,
- open to challenges about: 
    - maybe pc reaching the end index should not trigger exec_stop but rather execute the logic of STOP.
    - should we wipe return_data field? I think so, especially considering #458 

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

when a PC reaches the end of a bytecode sequence, without any STOP, RETURN or REVERT, then it errors out. We need to change the behaviour so that it gracefully exits.

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #446 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- when reaching the final pc (pc == bytecode.len()), the execution context should halt successfully, without returning anything

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
