### PR TITLE
feat: fetch account from SN

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -185,7 +185,7 @@ mod KakarotCore {
 
         /// Gets the balance associated to a contract account
         fn account_balance(self: @ContractState, evm_address: EthAddress) -> u256 {
-            let maybe_account = AccountTrait::account_at(evm_address).unwrap();
+            let maybe_account = AccountTrait::account_type_at(evm_address).unwrap();
             match maybe_account {
                 Option::Some(account) => account.balance().unwrap(),
                 Option::None => 0

--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -70,7 +70,7 @@ impl MachineCallHelpersImpl of MachineCallHelpers {
 
         // Case 2: `to` address is not a precompile
         // We enter the standard flow
-        let maybe_account = AccountTrait::account_at(call_args.to)?;
+        let maybe_account = AccountTrait::account_type_at(call_args.to)?;
         let bytecode = match maybe_account {
             Option::Some(acc) => acc.bytecode()?,
             Option::None => Default::default().span(),

--- a/crates/evm/src/instructions/block_information.cairo
+++ b/crates/evm/src/instructions/block_information.cairo
@@ -104,7 +104,7 @@ impl BlockInformation of BlockInformationTrait {
     fn exec_selfbalance(ref self: Machine) -> Result<(), EVMError> {
         let evm_address = self.evm_address();
 
-        let maybe_account = AccountTrait::account_at(evm_address)?;
+        let maybe_account = AccountTrait::account_type_at(evm_address)?;
         let balance: u256 = match maybe_account {
             Option::Some(acc) => acc.balance()?,
             Option::None => 0

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -68,7 +68,7 @@ impl SystemOperations of SystemOperationsTrait {
         // If sender_balance < value, return early, pushing
         // 0 on the stack to indicate call failure.
         let caller_address = self.evm_address();
-        let maybe_account = AccountTrait::account_at(caller_address)?;
+        let maybe_account = AccountTrait::account_type_at(caller_address)?;
         let sender_balance = match maybe_account {
             Option::Some(account) => account.balance()?,
             Option::None => 0,

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -5,13 +5,25 @@ use evm::errors::EVMError;
 use evm::execution::Status;
 use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
 use evm::model::eoa::{EOA, EOATrait};
+use evm::storage_journal::{Journal, JournalTrait};
 use starknet::{EthAddress, get_contract_address, ContractAddress};
 use utils::helpers::ByteArrayExTrait;
 
+/// The struct representing an EVM event.
 #[derive(Drop)]
 struct Event {
     keys: Array<u256>,
     data: Array<u8>,
+}
+
+
+/// A struct to save Starknet native ETH transfers to be made when finalizing a
+/// tx
+#[derive(Copy, Drop)]
+struct Transfer {
+    sender: EthAddress,
+    recipient: EthAddress,
+    amount: u256
 }
 
 struct ExecutionResult {
@@ -29,14 +41,60 @@ struct ExecutionResult {
 /// Starknet Address - The corresponding Starknet Contract for EOAs, and the
 /// KakarotCore address for ContractAccounts.
 #[derive(Copy, Drop)]
-enum Account {
+enum AccountType {
     EOA: EOA,
-    ContractAccount: ContractAccount
+    ContractAccount: ContractAccount,
+}
+
+struct Account {
+    account_type: AccountType,
+    code: Span<u8>,
+    storage: Journal,
+    nonce: u64,
+    selfdestruct: bool,
 }
 
 #[generate_trait]
 impl AccountImpl of AccountTrait {
-    /// Returns the Account corresponding to an Ethereum address.
+    /// Fetches an account from Starknet
+    /// An non-deployed account is just an empty account.
+    /// # Arguments
+    /// * `address` - The address of the account to fetch`
+    ///
+    /// # Returns
+    /// The fetched account if it existed, otherwise an empty account.
+    fn fetch_or_create(address: EthAddress) -> Result<Account, EVMError> {
+        let maybe_acc = AccountImpl::account_type_at(address)?;
+
+        match maybe_acc {
+            Option::Some(account_type) => {
+                match account_type {
+                    AccountType::EOA(eoa) => { eoa.fetch() },
+                    AccountType::ContractAccount(ca) => { ca.fetch() },
+                }
+            },
+            Option::None => {
+                return Result::Ok(
+                    // If no account exists at `address`, then
+                    // we are trying to access an undeployed contract account
+                    Account {
+                        account_type: AccountType::ContractAccount(
+                            ContractAccount {
+                                evm_address: address, starknet_address: get_contract_address()
+                            }
+                        ),
+                        code: Default::default().span(),
+                        storage: Default::default(),
+                        nonce: 0,
+                        selfdestruct: false,
+                    }
+                );
+            }
+        }
+    }
+
+
+    /// Returns the AccountType corresponding to an Ethereum address.
     /// If the address is not an EOA or a Contract Account (meaning that it is not deployed), returns None.
     ///
     /// # Arguments
@@ -45,58 +103,57 @@ impl AccountImpl of AccountTrait {
     ///
     /// # Returns
     ///
-    /// A `Result` containing an `Option` of the corresponding `Account` or an `EVMError` if there was an error.
+    /// A `Result` containing an `Option` of the corresponding `AccountType` or an `EVMError` if there was an error.
     ///
     /// # Errors
     ///
     /// Returns an `EVMError` if there was an error while retrieving the nonce account of the account contract using the read_syscall.
-    fn account_at(address: EthAddress) -> Result<Option<Account>, EVMError> {
+    fn account_type_at(address: EthAddress) -> Result<Option<AccountType>, EVMError> {
         let maybe_eoa = EOATrait::at(address)?;
         if maybe_eoa.is_some() {
-            return Result::Ok(Option::Some(Account::EOA(maybe_eoa.unwrap())));
+            return Result::Ok(Option::Some(AccountType::EOA(maybe_eoa.unwrap())));
         };
 
         let maybe_ca = ContractAccountTrait::at(address)?;
         match maybe_ca {
-            Option::Some(ca) => { Result::Ok(Option::Some(Account::ContractAccount(ca))) },
+            Option::Some(ca) => { Result::Ok(Option::Some(AccountType::ContractAccount(ca))) },
             Option::None => { Result::Ok(Option::None) }
         }
     }
 
     /// Returns `true` if the account is an Externally Owned Account (EOA).
     #[inline(always)]
-    fn is_eoa(self: @Account) -> bool {
+    fn is_eoa(self: @AccountType) -> bool {
         match self {
-            Account::EOA => true,
-            Account::ContractAccount => false
+            AccountType::EOA => true,
+            AccountType::ContractAccount => false
         }
     }
 
     /// Returns `true` if the account is a Contract Account (CA).
     #[inline(always)]
-    fn is_ca(self: @Account) -> bool {
+    fn is_ca(self: @AccountType) -> bool {
         match self {
-            Account::EOA => false,
-            Account::ContractAccount => true
+            AccountType::EOA => false,
+            AccountType::ContractAccount => true
         }
     }
-
 
     /// Returns the balance in native token for a given EVM account (EOA or CA)
     /// This is equivalent to checking the balance in native coin, i.e. ETHER of an account in Ethereum
     #[inline(always)]
-    fn balance(self: @Account) -> Result<u256, EVMError> {
+    fn balance(self: @AccountType) -> Result<u256, EVMError> {
         match self {
-            Account::EOA(eoa) => { eoa.balance() },
-            Account::ContractAccount(ca) => { ca.balance() }
+            AccountType::EOA(eoa) => { eoa.balance() },
+            AccountType::ContractAccount(ca) => { ca.balance() }
         }
     }
 
     /// Returns the bytecode of the EVM account (EOA or CA)
-    fn bytecode(self: @Account) -> Result<Span<u8>, EVMError> {
+    fn bytecode(self: @AccountType) -> Result<Span<u8>, EVMError> {
         match self {
-            Account::EOA(_) => Result::Ok(Default::default().span()),
-            Account::ContractAccount(ca) => {
+            AccountType::EOA(_) => Result::Ok(Default::default().span()),
+            AccountType::ContractAccount(ca) => {
                 let bytecode = ca.load_bytecode()?;
                 Result::Ok(bytecode.into_bytes())
             }

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -17,12 +17,18 @@ struct Event {
 }
 
 
-/// A struct to save Starknet native ETH transfers to be made when finalizing a
-/// tx
+#[derive(Copy, Drop)]
+struct Address {
+    evm: EthAddress,
+    starknet: ContractAddress,
+}
+
+/// A struct to save native token transfers to be made when finalizing
+/// a tx
 #[derive(Copy, Drop)]
 struct Transfer {
-    sender: EthAddress,
-    recipient: EthAddress,
+    sender: Address,
+    recipient: Address,
     amount: u256
 }
 

--- a/crates/evm/src/model/eoa.cairo
+++ b/crates/evm/src/model/eoa.cairo
@@ -1,5 +1,6 @@
 use contracts::kakarot_core::{IKakarotCore, KakarotCore};
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED, EOA_EXISTS};
+use evm::model::{Account, AccountType};
 use integer::BoundedInt;
 use openzeppelin::token::erc20::interface::{
     IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait
@@ -42,6 +43,26 @@ impl EOAImpl of EOATrait {
         //     Result::Err(err) => panic(err)
         // }
         panic_with_felt252('unimplemented')
+    }
+
+    /// Retrieves the EOA content stored at address `evm_address`.
+    /// There is no way to access the nonce of an EOA currently But putting 1
+    /// shouldn't have any impact and is safer than 0 since has_code_or_nonce is
+    /// used in some places to trigger collision
+    /// # Arguments
+    /// * `evm_address` - The EVM address of the eoa
+    /// # Returns
+    /// * The corresponding Account instance
+    fn fetch(self: @EOA) -> Result<Account, EVMError> {
+        Result::Ok(
+            Account {
+                account_type: AccountType::EOA(*self),
+                code: Default::default().span(),
+                storage: Default::default(),
+                nonce: 1,
+                selfdestruct: false
+            }
+        )
     }
 
     fn at(evm_address: EthAddress) -> Result<Option<EOA>, EVMError> {

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -19,7 +19,7 @@ fn test_account_at_eoa() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let account = AccountTrait::account_at(evm_address()).unwrap().unwrap();
+    let account = AccountTrait::account_type_at(evm_address()).unwrap().unwrap();
 
     // Then
     assert(account.is_eoa(), 'wrong account type');
@@ -38,7 +38,7 @@ fn test_account_at_ca_exists() {
         .expect('failed deploy contract account',);
 
     // When
-    let account = AccountTrait::account_at(evm_address()).unwrap().unwrap();
+    let account = AccountTrait::account_type_at(evm_address()).unwrap().unwrap();
 
     // Then
     assert(account.is_ca(), 'wrong account type');
@@ -54,7 +54,7 @@ fn test_account_at_undeployed() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let maybe_account = AccountTrait::account_at(evm_address()).unwrap();
+    let maybe_account = AccountTrait::account_type_at(evm_address()).unwrap();
 
     // Then
     assert(maybe_account.is_none(), 'account should be None');
@@ -73,7 +73,7 @@ fn test_balance_eoa() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let account = AccountTrait::account_at(evm_address()).unwrap().unwrap();
+    let account = AccountTrait::account_type_at(evm_address()).unwrap().unwrap();
     let balance = account.balance().unwrap();
 
     // Then
@@ -93,7 +93,7 @@ fn test_balance_contract_account() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let account = AccountTrait::account_at(evm_address()).unwrap().unwrap();
+    let account = AccountTrait::account_type_at(evm_address()).unwrap().unwrap();
     let balance = account.balance().unwrap();
 
     // Then


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- fetch an account from SN storage and return a memory representation of it
 - CA accounts load the nonce and byecode from storage
 - EOA accounts simply return a struct with nonce=1
 - If an account can't be fetched at address `address`, it means that it's an undeployed CA - it's instantiated empty in memory with a 0 nonce
 - This means we have to refactor the way of knowing whether an account is a CA or an EOA or undeployed, #477 
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
