### PR TITLE
fix: fix parsing of default value for int `0` from byte `[0x80]`

### DIFF
--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -121,8 +121,9 @@ impl RLPImpl of RLPTrait {
                 // checking for default value `0`
                 if (*input[0] == 0x80) {
                     output.append(RLPItem::String(array![0].span()));
+                } else {
+                    output.append(RLPItem::String(input.slice(offset, len)));
                 }
-                output.append(RLPItem::String(input.slice(offset, len)));
             },
             RLPType::List => {
                 if len > 0 {

--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -119,7 +119,7 @@ impl RLPImpl of RLPTrait {
         match rlp_type {
             RLPType::String => {
                 // checking for default value `0`
-                if (*input[0] == 0x80) {
+                if (len == 0) {
                     output.append(RLPItem::String(array![0].span()));
                 } else {
                     output.append(RLPItem::String(input.slice(offset, len)));

--- a/crates/utils/src/rlp.cairo
+++ b/crates/utils/src/rlp.cairo
@@ -26,7 +26,7 @@ impl RLPImpl of RLPTrait {
     /// the offset and the size of the RLPItem to decode
     /// # Errors
     /// * RLPError::EmptyInput - if the input is empty
-    /// * RLPError::InputTooShort - if the input is too short for a given 
+    /// * RLPError::InputTooShort - if the input is too short for a given
     fn decode_type(input: Span<u8>) -> Result<(RLPType, u32, u32), RLPError> {
         let input_len = input.len();
         if input_len == 0 {
@@ -105,7 +105,7 @@ impl RLPImpl of RLPTrait {
     /// # Returns
     /// * `Span<RLPItem>` - Span of RLPItem
     /// # Errors
-    /// * RLPError::InputTooShort - if the input is too short for a given 
+    /// * RLPError::InputTooShort - if the input is too short for a given
     fn decode(input: Span<u8>) -> Result<Span<RLPItem>, RLPError> {
         let mut output: Array<RLPItem> = Default::default();
         let input_len = input.len();
@@ -117,7 +117,13 @@ impl RLPImpl of RLPTrait {
         }
 
         match rlp_type {
-            RLPType::String => { output.append(RLPItem::String(input.slice(offset, len))); },
+            RLPType::String => {
+                // checking for default value `0`
+                if (*input[0] == 0x80) {
+                    output.append(RLPItem::String(array![0].span()));
+                }
+                output.append(RLPItem::String(input.slice(offset, len)));
+            },
             RLPType::List => {
                 if len > 0 {
                     let res = RLPTrait::decode(input.slice(offset, len))?;
@@ -137,4 +143,3 @@ impl RLPImpl of RLPTrait {
         Result::Ok(output.span())
     }
 }
-

--- a/crates/utils/src/tests/test_rlp.cairo
+++ b/crates/utils/src/tests/test_rlp.cairo
@@ -23,17 +23,6 @@ fn test_rlp_decode_type_byte() {
 
 #[test]
 #[available_gas(99999999)]
-fn test_rlp_decode_string_default_value() {
-    let mut arr = array![0x80];
-
-    let rlp_item = RLPTrait::decode(arr.span()).unwrap();
-    let expected = RLPItem::String(array![0].span());
-
-    assert(*rlp_item[0] == expected, 'default value not 0');
-}
-
-#[test]
-#[available_gas(99999999)]
 fn test_rlp_decode_type_short_string() {
     let mut arr = array![0x82];
 
@@ -237,6 +226,19 @@ fn test_rlp_encode_large_bytearray_inputs() {
         i += 1;
     }
 }
+
+#[test]
+#[available_gas(99999999)]
+fn test_rlp_decode_string_default_value() {
+    let mut arr = array![0x80];
+
+    let rlp_item = RLPTrait::decode(arr.span()).unwrap();
+    let expected = RLPItem::String(array![0].span());
+
+    assert(rlp_item.len() == 1, 'item length not 1');
+    assert(*rlp_item[0] == expected, 'default value not 0');
+}
+
 
 #[test]
 #[available_gas(99999999)]

--- a/crates/utils/src/tests/test_rlp.cairo
+++ b/crates/utils/src/tests/test_rlp.cairo
@@ -19,6 +19,17 @@ fn test_rlp_decode_type_byte() {
 
 #[test]
 #[available_gas(99999999)]
+fn test_rlp_decode_string_default_value() {
+    let mut arr = array![0x80];
+
+    let rlp_item = RLPTrait::decode(arr.span()).unwrap();
+    let expected = RLPItem::String(array![0].span());
+
+    assert(*rlp_item[0] == expected, 'default value not 0');
+}
+
+#[test]
+#[available_gas(99999999)]
 fn test_rlp_decode_type_short_string() {
     let mut arr = array![0x82];
 

--- a/crates/utils/src/tests/test_rlp.cairo
+++ b/crates/utils/src/tests/test_rlp.cairo
@@ -1,3 +1,7 @@
+use core::array::SpanTrait;
+use core::option::OptionTrait;
+use core::traits::Into;
+
 use result::ResultTrait;
 use utils::errors::{RLPError, RLP_EMPTY_INPUT, RLP_INPUT_TOO_SHORT};
 use utils::rlp::{RLPType, RLPTrait, RLPItem};
@@ -1967,7 +1971,8 @@ fn test_rlp_decode_long_list() {
         ]
             .span()
     );
-    let mut expected_16 = RLPItem::String(ArrayTrait::new().span());
+
+    let mut expected_16 = RLPItem::String(array![0].span());
 
     let mut expected = array![
         expected_0,
@@ -1988,6 +1993,7 @@ fn test_rlp_decode_long_list() {
         expected_15,
         expected_16
     ];
+
     let expected_item = RLPItem::List(expected.span());
 
     assert(res == array![expected_item].span(), 'Wrong value');


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When we encounter byte `[0x80]` we return `[]` i.e an empty slice, but we should return the default value `[0]` as per the spec.

Resolves: #499 

## What is the new behavior?

We return the default value `[0]` when we encounter the byte `[0x80]`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No