### PR TITLE
dev: Added new #[abi(embed_v0)] notation

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -135,7 +135,7 @@ mod KakarotCore {
         self.chain_id.write(chain_id);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl KakarotCoreImpl of interface::IKakarotCore<ContractState> {
         fn set_native_token(ref self: ContractState, native_token: ContractAddress) {
             self.ownable.assert_only_owner();

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -160,11 +160,10 @@ fn test_kakarot_core_compute_starknet_address() {
 
     let class_hash = UninitializedAccount::TEST_CLASS_HASH; // used to get the hash using the LSP
     let expected_starknet_address: ContractAddress = contract_address_const::<
-        0x3e11d847f1b0cde4d03be7ddce8e4cb825e51a4a85aeda91d5add37aa8ff142
+        0x681ab6ad6ed3fd3f3b6b82588dcd7bb928aa636bf2e0ed536379ef712786f4a
     >();
 
     let eoa_starknet_address = kakarot_core.compute_starknet_address(evm_address);
-
     assert(eoa_starknet_address == expected_starknet_address, 'wrong starknet address');
 }
 

--- a/crates/contracts/src/tests/test_upgradeable.cairo
+++ b/crates/contracts/src/tests/test_upgradeable.cairo
@@ -33,7 +33,7 @@ mod MockContractUpgradeableV0 {
         UpgradeableEvent: upgradeable_component::Event
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl MockContractUpgradeableImpl of IMockContractUpgradeable<ContractState> {
         fn version(self: @ContractState) -> felt252 {
             0

--- a/crates/contracts/src/tests/test_upgradeable.cairo
+++ b/crates/contracts/src/tests/test_upgradeable.cairo
@@ -59,7 +59,7 @@ mod MockContractUpgradeableV1 {
         upgradeableEvent: upgradeable_component::Event
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl MockContractUpgradeableImpl of IMockContractUpgradeable<ContractState> {
         fn version(self: @ContractState) -> felt252 {
             1

--- a/crates/contracts/src/uninitialized_account/uninitialized_account.cairo
+++ b/crates/contracts/src/uninitialized_account/uninitialized_account.cairo
@@ -34,7 +34,7 @@ mod UninitializedAccount {
         self.evm_address.write(evm_address);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl UninitializedAccountImpl of IUninitializedAccount<ContractState> {
         fn initialize(ref self: ContractState, new_class_hash: ClassHash) {
             assert(

--- a/crates/eoa/src/externally_owned_account.cairo
+++ b/crates/eoa/src/externally_owned_account.cairo
@@ -48,7 +48,7 @@ mod ExternallyOwnedAccount {
         self.evm_address.write(evm_address);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ExternallyOwnedAccount of super::IExternallyOwnedAccount<ContractState> {
         fn kakarot_core_address(self: @ContractState) -> ContractAddress {
             self.kakarot_core_address.read()
@@ -65,7 +65,7 @@ mod ExternallyOwnedAccount {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl AccountContractImpl of AccountContract<ContractState> {
         fn __validate__(ref self: ContractState, calls: Array<Call>) -> felt252 {
             assert(get_caller_address().is_zero(), 'Caller not zero');


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Resolves: #488 

## What is the new behavior?

- Updated `#[external(v0)]` to `#[abi(embed_v0)]` for contracts that implement interfaces

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Comments

- `[external(v0)]` is not updated (don't think we should) in the `openzeppelin` crate,
- I didn't use the new notation `#[abi(per_item)]`, I don't feel like it's much applicable in the codebase since we have concrete interfaces for every contracts. I can use it if we maybe wrap the constructors into `impl` blocks, for example:
```rust
    #[abi(per_item)]
    #[generate_trait]
    impl KakarotCoreConstructorImpl of KakarotCoreConstructor {
        #[constructor]
        fn constructor(
        // ...
        }
    }
}
```