### PR TITLE
feat: add decoding for EIP-2718 txn types

### DIFF
--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -39,8 +39,7 @@ impl EthTransactionImpl of EthTransaction {
     /// tx_data The raw transaction data
     /// tx_data is of the format: rlp![nonce, gasPrice, gasLimit, to , value, data, v, r, s]
     fn decode_legacy_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
-        let decoded_data = RLPTrait::decode(tx_data);
-        let decoded_data = decoded_data.map_err()?;
+        let decoded_data = RLPTrait::decode(tx_data).map_err()?;
 
         if (decoded_data.len() != 1) {
             return Result::Err(EthTransactionError::Other('Length is not 1'));
@@ -114,8 +113,84 @@ impl EthTransactionImpl of EthTransaction {
     /// # Arguments
     /// tx_data The raw transaction data
     fn decode_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
-        // todo
-        panic_with_felt252('decode_tx unimplemented')
+        let tx_type: u32 = (*tx_data.at(0)).into();
+        let tx_data = tx_data.slice(1, tx_data.len() - 1);
+
+        // EIP 2718:
+        // TransactionType is a positive unsigned 8-bit number between 0 and 0x7f
+        if (tx_type == 0 || tx_type >= 0x7f) {
+            return Result::Err(EthTransactionError::Other('Not EIP-2718 transaction'));
+        }
+        // Only EIP-1559 and EIP 2930 are supported
+        if (tx_type != 1 && tx_type != 2) {
+            return Result::Err(EthTransactionError::Other('transaction type not supported'));
+        }
+
+        let nonce_idx = 1;
+        let gas_price_idx = tx_type + nonce_idx;
+        let gas_limit_idx = gas_price_idx + 1;
+        let to_idx = gas_limit_idx + 1;
+        let value_idx = to_idx + 1;
+        let data_idx = value_idx + 1;
+        let v_idx = tx_type + 7;
+        let r_idx = v_idx + 1;
+        let s_idx = r_idx + 1;
+
+        let decoded_data = RLPTrait::decode(tx_data).map_err()?;
+        if (decoded_data.len() != 1) {
+            return Result::Err(EthTransactionError::Other('Length is not 1'));
+        }
+
+        let decoded_data = *decoded_data.at(0);
+
+        let result: Result<EthereumTransaction, EthTransactionError> = match decoded_data {
+            RLPItem::String => { Result::Err(EthTransactionError::ExpectedRLPItemToBeList) },
+            RLPItem::List(val) => {
+                // total items in EIP 2930: 11
+                // total items in EIP 1559: 12
+                if (val.len() != 11 && val.len() != 12) {
+                    return Result::Err(EthTransactionError::Other('Length is not 11 or 12'));
+                }
+
+                let nonce = (*val.at(nonce_idx)).parse_u128_from_string().map_err()?;
+                let gas_price = (*val.at(gas_price_idx)).parse_u128_from_string().map_err()?;
+                let gas_limit = (*val.at(gas_limit_idx)).parse_u128_from_string().map_err()?;
+                let to = (*val.at(to_idx)).parse_u256_from_string().map_err()?;
+                let value = (*val.at(value_idx)).parse_u256_from_string().map_err()?;
+                let data = (*val.at(data_idx)).parse_bytes_felt252_from_string().map_err()?;
+                let v = (*val.at(v_idx)).parse_u128_from_string().map_err()?;
+                let r = (*val.at(r_idx)).parse_u256_from_string().map_err()?;
+                let s = (*val.at(s_idx)).parse_u256_from_string().map_err()?;
+
+                let mut transaction_data_byte_array = ByteArrayExt::from_bytes(tx_data);
+                let (mut keccak_input, last_input_word, last_input_num_bytes) =
+                    transaction_data_byte_array
+                    .to_u64_words();
+                let tx_hash = cairo_keccak(
+                    ref keccak_input, :last_input_word, :last_input_num_bytes
+                )
+                    .reverse_endianness();
+
+                let address: EthAddress = to.into();
+
+                Result::Ok(
+                    EthereumTransaction {
+                        nonce: nonce,
+                        gas_price: gas_price,
+                        gas_limit: gas_limit,
+                        destination: address,
+                        amount: value,
+                        payload: data,
+                        v: v,
+                        r: r,
+                        s: s,
+                        tx_hash: tx_hash
+                    }
+                )
+            }
+        };
+
+        result
     }
 
     /// Check if a raw transaction is a legacy Ethereum transaction

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -870,6 +870,21 @@ fn compute_starknet_address(
     normalized_address
 }
 
+fn bytes_to_felt252_array(bytes: Span<u8>) -> Span<felt252> {
+    let mut result: Array<felt252> = array![];
+
+    let mut i = 0;
+    loop {
+        if (i == bytes.len()) {
+            break ();
+        }
+        result.append((*bytes.at(i)).into());
+        i += 1;
+    };
+
+    result.span()
+}
+
 #[generate_trait]
 impl EthAddressExtTrait of EthAddressExt {
     fn to_bytes(self: EthAddress) -> Span<u8> {

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -1,22 +1,28 @@
 use core::debug::PrintTrait;
+use core::to_byte_array::FormatAsByteArray;
+use core::traits::Destruct;
 use utils::eth_transaction::{EthTransactionImpl};
+use utils::helpers::{U32Trait, bytes_to_felt252_array};
 
 #[test]
 #[available_gas(200000000)]
 fn test_decode_legacy_tx() {
-    // tx_format (EIP-155): [nonce, gasPrice, gasLimit, to, value, data, v, r, s]
-    // expected rlp decoding: [ '0x', '0x3b9aca00', '0x', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0x', '0x1c', '0x91e283d61077eb36340a1109a03bdbd6c0c4ea4c3d74537bc42f672095bcf5a1', '0x6b93acdc99dea855d15c75f7f6bdf4250784ef01ebc70642f45cdf044e0e2623']
-    // transaction_hash: 0x567fd100cfbb0f781df1c98e84ae57de817684536abe34deb8957eaafd9f417a
+    // tx_format (EIP-155): rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+    // expected rlp decoding:  [ '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', '0x25', '0x9f0140cbb368e853402d4a06ff1f9d1c40f90055fcda4ad357c750685042e342', '0x30da91d1bc8c89719bc4f22110f18ee9e79e60ab1bdfe8a3997a354670fb47bd']
+    // transaction_hash: 0x63ff39fd8f15bcd883a9e11a8a823f110f54911b2666ac67016b15fd244415b9
     // chain id used: 0x1
     let data = array![
         248,
-        105,
+        111,
         128,
         132,
         59,
         154,
         202,
         0,
+        131,
+        30,
+        132,
         128,
         148,
         31,
@@ -48,74 +54,77 @@ fn test_decode_legacy_tx() {
         138,
         0,
         0,
-        128,
-        28,
-        160,
-        145,
-        226,
         131,
-        214,
-        16,
-        119,
-        235,
-        54,
-        52,
-        10,
-        17,
-        9,
-        160,
-        59,
-        219,
-        214,
-        192,
-        196,
-        234,
-        76,
-        61,
-        116,
-        83,
-        123,
-        196,
-        47,
-        103,
-        32,
-        149,
-        188,
-        245,
-        161,
-        160,
-        107,
-        147,
-        172,
-        220,
-        153,
-        222,
-        168,
-        85,
-        209,
-        92,
-        117,
-        247,
-        246,
-        189,
-        244,
-        37,
-        7,
-        132,
+        171,
+        205,
         239,
+        37,
+        160,
+        159,
         1,
-        235,
-        199,
+        64,
+        203,
+        179,
+        104,
+        232,
+        83,
+        64,
+        45,
+        74,
         6,
+        255,
+        31,
+        157,
+        28,
+        64,
+        249,
+        0,
+        85,
+        252,
+        218,
+        74,
+        211,
+        87,
+        199,
+        80,
+        104,
+        80,
         66,
-        244,
-        92,
+        227,
+        66,
+        160,
+        48,
+        218,
+        145,
+        209,
+        188,
+        140,
+        137,
+        113,
+        155,
+        196,
+        242,
+        33,
+        16,
+        241,
+        142,
+        233,
+        231,
+        158,
+        96,
+        171,
+        27,
         223,
-        4,
-        78,
-        14,
-        38,
-        35
+        232,
+        163,
+        153,
+        122,
+        53,
+        70,
+        112,
+        251,
+        71,
+        189
     ]
         .span();
 
@@ -123,24 +132,345 @@ fn test_decode_legacy_tx() {
 
     assert(tx.nonce == 0, 'nonce is not 0');
     assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
-    assert(tx.gas_limit == 0, 'gas_limit is not 0');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
     assert(
         tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
         'destination is not 0x1f9840...'
     );
     assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
-    assert(tx.v == 0x1c, 'v is not 0x1c');
+
+    let expected_payload = bytes_to_felt252_array(0xabcdef_u32.to_bytes());
+    assert(tx.payload == expected_payload, 'payload is not 0xabcdef');
+
+    assert(tx.v == 0x25, 'v is not 0x25');
     assert(
-        tx.r == 0x91e283d61077eb36340a1109a03bdbd6c0c4ea4c3d74537bc42f672095bcf5a1,
-        'r is not 0x91e283d610...'
+        tx.r == 0x9f0140cbb368e853402d4a06ff1f9d1c40f90055fcda4ad357c750685042e342,
+        'r is not 0x9f0140c...'
     );
     assert(
-        tx.s == 0x6b93acdc99dea855d15c75f7f6bdf4250784ef01ebc70642f45cdf044e0e2623,
-        's is not 0x6b93acdc99...'
+        tx.s == 0x30da91d1bc8c89719bc4f22110f18ee9e79e60ab1bdfe8a3997a354670fb47bd,
+        's is not 0x30da91d1...'
     );
 
     assert(
-        tx.tx_hash == 0x567fd100cfbb0f781df1c98e84ae57de817684536abe34deb8957eaafd9f417a,
-        'transaction hash it not 0x56...'
+        tx.tx_hash == 0x63ff39fd8f15bcd883a9e11a8a823f110f54911b2666ac67016b15fd244415b9,
+        'transaction hash it not 0x63...'
+    );
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_2930_tx() {
+    // tx_format (EIP-2930): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, signatureYParity, signatureR, signatureS])
+    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
+    // transaction_hash: 0xfa4e6c015d94c219c4105cb2a8f4d2bfc9bad127ebbafbfcceab1b9a744ebcdb
+    // chain id used: 0x1
+    let data = array![
+        1,
+        248,
+        113,
+        1,
+        128,
+        132,
+        59,
+        154,
+        202,
+        0,
+        131,
+        30,
+        132,
+        128,
+        148,
+        31,
+        152,
+        64,
+        168,
+        93,
+        90,
+        245,
+        191,
+        29,
+        23,
+        98,
+        249,
+        37,
+        189,
+        173,
+        220,
+        66,
+        1,
+        249,
+        132,
+        136,
+        1,
+        99,
+        69,
+        120,
+        93,
+        138,
+        0,
+        0,
+        131,
+        171,
+        205,
+        239,
+        192,
+        128,
+        160,
+        20,
+        163,
+        142,
+        165,
+        233,
+        47,
+        230,
+        131,
+        27,
+        33,
+        55,
+        34,
+        100,
+        24,
+        208,
+        61,
+        178,
+        171,
+        140,
+        239,
+        214,
+        246,
+        43,
+        223,
+        192,
+        7,
+        135,
+        135,
+        175,
+        166,
+        63,
+        131,
+        160,
+        108,
+        137,
+        178,
+        146,
+        139,
+        81,
+        132,
+        69,
+        190,
+        248,
+        212,
+        121,
+        22,
+        123,
+        185,
+        174,
+        247,
+        59,
+        171,
+        24,
+        113,
+        209,
+        39,
+        95,
+        216,
+        220,
+        186,
+        60,
+        22,
+        40,
+        166,
+        25
+    ]
+        .span();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_payload = bytes_to_felt252_array(0xabcdef_u32.to_bytes());
+    assert(tx.payload == expected_payload, 'payload is not 0xabcdef');
+
+    assert(tx.v == 0x0, 'v is not 0x0');
+    assert(
+        tx.r == 0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83,
+        'r is not 0x14a38ea...'
+    );
+    assert(
+        tx.s == 0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619,
+        's is not 0x6c89b2...'
+    );
+
+    assert(
+        tx.tx_hash == 0xfa4e6c015d94c219c4105cb2a8f4d2bfc9bad127ebbafbfcceab1b9a744ebcdb,
+        'transaction hash it not 0xfa...'
+    );
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_1559_tx() {
+    // tx_format (EIP-1559): 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s])
+    // expected rlp decoding:    [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x81f7eca8b0db688d69efa4283149b715b87714170d7e671b3d5ec449998fe30a', '0x320c159d81ed83c26abbcfe428b4036dd6e1af778069437a9512bda223104b95']
+    // transaction_hash: 0x7aabed1aa625aca3e573189906dc22c1993be09236167057fe78e6d8b13269d1
+    // chain id used: 0x1
+    let data = array![
+        2,
+        248,
+        114,
+        1,
+        128,
+        128,
+        132,
+        59,
+        154,
+        202,
+        0,
+        131,
+        30,
+        132,
+        128,
+        148,
+        31,
+        152,
+        64,
+        168,
+        93,
+        90,
+        245,
+        191,
+        29,
+        23,
+        98,
+        249,
+        37,
+        189,
+        173,
+        220,
+        66,
+        1,
+        249,
+        132,
+        136,
+        1,
+        99,
+        69,
+        120,
+        93,
+        138,
+        0,
+        0,
+        131,
+        171,
+        205,
+        239,
+        192,
+        128,
+        160,
+        129,
+        247,
+        236,
+        168,
+        176,
+        219,
+        104,
+        141,
+        105,
+        239,
+        164,
+        40,
+        49,
+        73,
+        183,
+        21,
+        184,
+        119,
+        20,
+        23,
+        13,
+        126,
+        103,
+        27,
+        61,
+        94,
+        196,
+        73,
+        153,
+        143,
+        227,
+        10,
+        160,
+        50,
+        12,
+        21,
+        157,
+        129,
+        237,
+        131,
+        194,
+        106,
+        187,
+        207,
+        228,
+        40,
+        180,
+        3,
+        109,
+        214,
+        225,
+        175,
+        119,
+        128,
+        105,
+        67,
+        122,
+        149,
+        18,
+        189,
+        162,
+        35,
+        16,
+        75,
+        149
+    ]
+        .span();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_payload = bytes_to_felt252_array(0xabcdef_u32.to_bytes());
+    assert(tx.payload == expected_payload, 'payload is not 0xabcdef');
+
+    assert(tx.v == 0x0, 'v is not 0x0');
+    assert(
+        tx.r == 0x81f7eca8b0db688d69efa4283149b715b87714170d7e671b3d5ec449998fe30a,
+        'r is not 0x81f7eca8b0...'
+    );
+    assert(
+        tx.s == 0x320c159d81ed83c26abbcfe428b4036dd6e1af778069437a9512bda223104b95,
+        's is not 0x320c159d81ed...'
+    );
+
+    assert(
+        tx.tx_hash == 0x7aabed1aa625aca3e573189906dc22c1993be09236167057fe78e6d8b13269d1,
+        'transaction hash it not 0x7a...'
     );
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

PR adds support for decoding EIP-2718 txns + improves testing for legacy decoding of transaction.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Decoding for EIP-2718 transactions is not supported.

Resolves: #406 

## What is the new behavior?

Decoding for EIP-2718 transactions is not supported.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
