### PR TITLE
refactor: account model

### DIFF
--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -1,6 +1,7 @@
 use contracts::kakarot_core::kakarot::StoredAccountType;
 use starknet::{ContractAddress, EthAddress, ClassHash};
 use utils::traits::ByteArraySerde;
+use evm::model::AccountType;
 
 #[starknet::interface]
 trait IKakarotCore<TContractState> {
@@ -28,11 +29,10 @@ trait IKakarotCore<TContractState> {
     /// Using its EVM address as salt, and KakarotCore as deployer.
     fn compute_starknet_address(self: @TContractState, evm_address: EthAddress) -> ContractAddress;
 
-    /// Checks into KakarotCore storage if an EOA or a CA has been deployed for a
-    /// Checks into KakarotCore storage if an EOA or a CA has been deployed for a
-    /// particular EVM address and if so, returns its corresponding Starknet Address.
-    /// Otherwise, returns 0
-    fn address_registry(self: @TContractState, evm_address: EthAddress) -> StoredAccountType;
+    /// Checks into KakarotCore storage if an EOA or a CA has been deployed for
+    /// a particular EVM address and if so, returns its corresponding type with
+    /// its starknet address.  Otherwise, returns Option::None.
+    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<AccountType>;
 
 
     /// Gets the nonce associated to a contract account
@@ -128,10 +128,10 @@ trait IExtendedKakarotCore<TContractState> {
     /// Using its EVM address as salt, and KakarotCore as deployer.
     fn compute_starknet_address(self: @TContractState, evm_address: EthAddress) -> ContractAddress;
 
-    /// Checks into KakarotCore storage if an EOA or a CA has been deployed for a
-    /// Checks into KakarotCore storage if an EOA or a CA has been deployed for a
-    /// particular EVM address and if so, returns its corresponding Starknet Address
-    fn address_registry(self: @TContractState, evm_address: EthAddress) -> StoredAccountType;
+    /// Checks into KakarotCore storage if an EOA or a CA has been deployed for
+    /// a particular EVM address and if so, returns its corresponding type with
+    /// its starknet address.  Otherwise, returns Option::None.
+    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<AccountType>;
 
     /// Gets the nonce associated to a contract account
     fn contract_account_nonce(self: @TContractState, evm_address: EthAddress) -> u64;

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -1,7 +1,7 @@
 use contracts::kakarot_core::kakarot::StoredAccountType;
+use evm::model::AccountType;
 use starknet::{ContractAddress, EthAddress, ClassHash};
 use utils::traits::ByteArraySerde;
-use evm::model::AccountType;
 
 #[starknet::interface]
 trait IKakarotCore<TContractState> {

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -28,7 +28,7 @@ mod KakarotCore {
     use evm::model::account::{Account, AccountType, AccountTrait};
     use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
     use evm::model::eoa::{EOA, EOATrait};
-    use evm::model::{ExecutionResult, Address};
+    use evm::model::{ExecutionResult, Address, AddressTrait};
     use starknet::{
         EthAddress, ContractAddress, ClassHash, get_tx_info, get_contract_address, deploy_syscall
     };
@@ -188,11 +188,10 @@ mod KakarotCore {
         }
 
         fn account_balance(self: @ContractState, evm_address: EthAddress) -> u256 {
-            let maybe_account = AccountTrait::fetch(evm_address).expect('Fetching account failed');
-            match maybe_account {
-                Option::Some(account) => account.balance().unwrap(),
-                Option::None => 0
-            }
+            let address = Address {
+                evm: evm_address, starknet: self.compute_starknet_address(evm_address)
+            };
+            address.balance().unwrap()
         }
 
         fn contract_account_storage_at(

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -188,8 +188,7 @@ mod KakarotCore {
         }
 
         fn account_balance(self: @ContractState, evm_address: EthAddress) -> u256 {
-            let maybe_account = AccountTrait::fetch(evm_address)
-                .expect('Fetching account failed');
+            let maybe_account = AccountTrait::fetch(evm_address).expect('Fetching account failed');
             match maybe_account {
                 Option::Some(account) => account.balance().unwrap(),
                 Option::None => 0

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -188,7 +188,7 @@ mod KakarotCore {
         }
 
         fn account_balance(self: @ContractState, evm_address: EthAddress) -> u256 {
-            let maybe_account = AccountTrait::account_type_at(evm_address)
+            let maybe_account = AccountTrait::fetch(evm_address)
                 .expect('Fetching account failed');
             match maybe_account {
                 Option::Some(account) => account.balance().unwrap(),

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -12,8 +12,8 @@ use contracts::tests::test_upgradeable::{
 use contracts::tests::test_utils as contract_utils;
 use contracts::uninitialized_account::UninitializedAccount;
 use evm::machine::Status;
-use evm::model::{AccountType, Address, EOA, ContractAccount};
 use evm::model::contract_account::ContractAccountTrait;
+use evm::model::{AccountType, Address, EOA, ContractAccount};
 use evm::tests::test_utils;
 use starknet::{testing, contract_address_const, ContractAddress, ClassHash};
 use utils::helpers::u256_to_bytes_array;

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -240,7 +240,7 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         let evm_address = self.stack.pop_eth_address()?;
 
         let account = self.state.get_account(evm_address)?;
-        if (account.is_precompile() || (account.account_type.is_ca() && account.nonce == 0)) {
+        if (account.is_precompile() || (account.is_ca() && account.nonce == 0)) {
             return self.stack.push(0);
         }
         let bytecode = account.code;

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -3,14 +3,17 @@ mod contract_account;
 mod eoa;
 
 use contracts::kakarot_core::{KakarotCore, IKakarotCore};
-use evm::errors::EVMError;
+use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::execution::Status;
 use evm::model::account::{Account, AccountTrait};
 use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
 use evm::model::eoa::{EOA, EOATrait};
 use evm::state::State;
+use openzeppelin::token::erc20::interface::{
+    IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait
+};
 use starknet::{EthAddress, get_contract_address, ContractAddress};
-use utils::helpers::ByteArrayExTrait;
+use utils::helpers::{ResultExTrait, ByteArrayExTrait};
 use utils::traits::{EthAddressDefault, ContractAddressDefault};
 
 /// The struct representing an EVM event.
@@ -26,6 +29,17 @@ struct Address {
     starknet: ContractAddress,
 }
 
+#[generate_trait]
+impl AddressImpl of AddressTrait {
+    fn balance(self: @Address) -> Result<u256, EVMError> {
+        let kakarot_state = KakarotCore::unsafe_new_contract_state();
+        let native_token_address = kakarot_state.native_token();
+        let native_token = IERC20CamelSafeDispatcher { contract_address: native_token_address };
+        native_token
+            .balanceOf(*self.starknet)
+            .map_err(EVMError::SyscallFailed(CONTRACT_SYSCALL_FAILED))
+    }
+}
 
 /// A struct to save native token transfers to be made when finalizing
 /// a tx

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -51,7 +51,7 @@ struct ExecutionResult {
 /// account is identified by an Ethereum address.  It has a corresponding
 /// Starknet Address - The corresponding Starknet Contract for EOAs, and the
 /// KakarotCore address for ContractAccounts.
-#[derive(Copy, Drop, PartialEq)]
+#[derive(Copy, Drop, PartialEq, Serde)]
 enum AccountType {
     EOA: EOA,
     ContractAccount: ContractAccount,

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -223,14 +223,8 @@ impl AccountImpl of AccountTrait {
 
     /// Returns the bytecode of the EVM account (EOA or CA)
     #[inline(always)]
-    fn bytecode(self: @Account) -> Result<Span<u8>, EVMError> {
-        match self.account_type {
-            AccountType::EOA(_) => Result::Ok(Default::default().span()),
-            AccountType::ContractAccount(ca) => {
-                let bytecode = ca.load_bytecode()?;
-                Result::Ok(bytecode)
-            }
-        }
+    fn bytecode(self: @Account) -> Span<u8> {
+       *self.code
     }
 
     /// Reads the value stored at the given key for the corresponding account.

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -224,7 +224,7 @@ impl AccountImpl of AccountTrait {
     /// Returns the bytecode of the EVM account (EOA or CA)
     #[inline(always)]
     fn bytecode(self: @Account) -> Span<u8> {
-       *self.code
+        *self.code
     }
 
     /// Reads the value stored at the given key for the corresponding account.

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -93,13 +93,13 @@ impl AccountImpl of AccountTrait {
     }
 
     /// Returns whether an account should be deployed or not.  If the nonce is
-    /// not 0, the account should be deployed - provided it's not already
+    /// not 0 and it has code, the account should be deployed - provided it's not already
     /// deployed yet.
     // If the nonce is 0, the account is just "touched" (e.g.
     // balance transfer) and is not set for deployment.
     #[inline(always)]
     fn should_deploy(self: @Account) -> bool {
-        if (self.is_ca() && *self.nonce != 0) {
+        if self.is_ca() && (*self.nonce != 0 || !(*self.code).is_empty()) {
             return true;
         };
         false

--- a/crates/evm/src/model/contract_account.cairo
+++ b/crates/evm/src/model/contract_account.cairo
@@ -124,22 +124,6 @@ impl ContractAccountImpl of ContractAccountTrait {
         }
     }
 
-    /// Retrieves the contract account content stored at address `evm_address`.
-    /// # Arguments
-    /// * `evm_address` - The EVM address of the contract account
-    /// # Returns
-    /// * The corresponding Account instance
-    fn fetch(self: @ContractAccount) -> Result<Account, EVMError> {
-        Result::Ok(
-            Account {
-                account_type: AccountType::ContractAccount(*self),
-                code: self.load_bytecode()?,
-                nonce: self.nonce()?,
-                selfdestruct: false
-            }
-        )
-    }
-
     /// Returns the nonce of a contract account.
     /// # Arguments
     /// * `self` - The contract account instance

--- a/crates/evm/src/model/eoa.cairo
+++ b/crates/evm/src/model/eoa.cairo
@@ -14,7 +14,6 @@ use openzeppelin::token::erc20::interface::{
 use starknet::{EthAddress, ContractAddress, get_contract_address, deploy_syscall};
 use utils::helpers::ResultExTrait;
 
-
 #[derive(Copy, Drop, PartialEq, Serde)]
 struct EOA {
     evm_address: EthAddress,
@@ -61,10 +60,6 @@ impl EOAImpl of EOATrait {
     }
 
 
-    /// Retrieves the EOA content stored at address `evm_address`.
-    /// There is no way to access the nonce of an EOA currently But putting 1
-    /// shouldn't have any impact and is safer than 0 since has_code_or_nonce is
-    /// used in some places to trigger collision
     /// # Arguments
     /// * `evm_address` - The EVM address of the eoa
     /// # Returns

--- a/crates/evm/src/model/eoa.cairo
+++ b/crates/evm/src/model/eoa.cairo
@@ -30,8 +30,8 @@ impl EOAImpl of EOATrait {
     /// * `evm_address` - The EVM address of the EOA to deploy.
     fn deploy(evm_address: EthAddress) -> Result<EOA, EVMError> {
         // Unlike CAs, there is not check for the existence of an EOA prealably to calling `EOATrait::deploy` - therefore, we need to check that there is no collision.
-        let mut maybe_acc = AccountTrait::account_type_at(evm_address)?;
-        if maybe_acc.is_some() {
+        let mut is_deployed = AccountTrait::is_deployed(evm_address);
+        if is_deployed {
             return Result::Err(EVMError::DeployError(EOA_EXISTS));
         }
 

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -1,10 +1,13 @@
 use contracts::kakarot_core::{IKakarotCore, KakarotCore};
+use debug::PrintTrait;
 use evm::errors::{
     EVMError, WRITE_SYSCALL_FAILED, READ_SYSCALL_FAILED, INSUFFICIENT_BALANCE, BALANCE_OVERFLOW
 };
 use evm::model::account::{AccountTrait};
 use evm::model::contract_account::ContractAccountTrait;
-use evm::model::{Event, Transfer, Account, ContractAccount, EOA, AccountType, Address};
+use evm::model::{
+    Event, Transfer, Account, ContractAccount, EOA, AccountType, Address, AddressTrait
+};
 use hash::{HashStateTrait, HashStateExTrait};
 use integer::{u256_overflow_sub, u256_overflowing_add};
 use nullable::{match_nullable, FromNullableResult};
@@ -280,7 +283,9 @@ impl StateImpl of StateTrait {
         match self.balances.read(evm_address.into()) {
             Option::Some(value) => { Result::Ok(value) },
             Option::None => {
-                //TODO(optimize): Don't fetch an account's bytecode just to read an account's balance.
+                //TODO this function should compute the deterministic address of the evm_address's corresponding starknet contract to perform value transfers. However, the test runner doesn't deterministically calculate the starknet address from the evm address, so we can't test this yet. In the meantime, we'll use `fetch_or_create` - which is unoptimized as we don't want to load a CA's bytecode to perform value transfers.
+                // let kakarot_state = KakarotCore::unsafe_new_contract_state();
+                // let starknet_address = kakarot_state.compute_starknet_address(evm_address);
                 let account = AccountTrait::fetch_or_create(evm_address)?;
                 let balance = account.balance()?;
                 self.write_balance(evm_address, balance);

--- a/crates/evm/src/tests.cairo
+++ b/crates/evm/src/tests.cairo
@@ -1,29 +1,19 @@
-#[cfg(test)]
 mod test_create_helpers;
 
-#[cfg(test)]
 mod test_execution;
 
-#[cfg(test)]
 mod test_execution_context;
 
-#[cfg(test)]
 mod test_instructions;
 
-#[cfg(test)]
 mod test_machine;
 
-#[cfg(test)]
 mod test_memory;
 
-#[cfg(test)]
 mod test_model;
 
-#[cfg(test)]
 mod test_stack;
 
-#[cfg(test)]
 mod test_state;
 
-#[cfg(test)]
 mod test_utils;

--- a/crates/evm/src/tests/test_execution.cairo
+++ b/crates/evm/src/tests/test_execution.cairo
@@ -5,6 +5,40 @@ use evm::model::eoa::EOATrait;
 use evm::state::StateTrait;
 use evm::tests::test_utils::{evm_address, other_evm_address};
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
+use starknet::testing::set_nonce;
+
+#[test]
+#[available_gas(20000000)]
+fn test_execute_load_origin_nonce() {
+    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
+    // Transfer native tokens to sender
+    let sender = EOATrait::deploy(evm_address()).expect('sender deploy failed');
+    let recipient = EOATrait::deploy(other_evm_address()).expect('recipient deploy failed');
+    set_nonce(1337);
+    // When
+    let mut exec_result = execute(
+        origin: sender.address(),
+        target: recipient.address(),
+        bytecode: Default::default().span(),
+        calldata: Default::default().span(),
+        value: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        read_only: false,
+    );
+    match exec_result.error {
+        Option::Some(error) => panic_with_felt252(error.to_string()),
+        Option::None => {}
+    }
+
+    let origin_account = exec_result
+        .state
+        .get_account(sender.address().evm)
+        .expect('couldnt get origin account');
+
+    assert(origin_account.nonce == 1337, 'wrong origin nonce');
+}
+
 
 #[test]
 #[available_gas(20000000)]

--- a/crates/evm/src/tests/test_execution.cairo
+++ b/crates/evm/src/tests/test_execution.cairo
@@ -1,4 +1,5 @@
 use contracts::tests::test_utils as contract_utils;
+use evm::errors::EVMErrorTrait;
 use evm::execution::execute;
 use evm::model::eoa::EOATrait;
 use evm::state::StateTrait;
@@ -25,6 +26,10 @@ fn test_execute_value_transfer() {
         gas_limit: 0,
         read_only: false,
     );
+    match exec_result.error {
+        Option::Some(error) => panic_with_felt252(error.to_string()),
+        Option::None => {}
+    }
     // `commit_state` is applied in `eth_send_tx` only - to test that `execute` worked correctly, we manually apply it here.
     exec_result.state.commit_state();
 

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -3,7 +3,9 @@ mod test_eoa;
 use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::tests::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
 use evm::model::account::AccountTrait;
-use evm::model::{Account, ContractAccountTrait, AccountType, EOA, ContractAccount, EOATrait};
+use evm::model::{
+    Account, ContractAccountTrait, AccountType, EOA, ContractAccount, EOATrait, AddressTrait
+};
 use evm::tests::test_utils::{evm_address};
 use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use starknet::testing::set_contract_address;
@@ -61,9 +63,9 @@ fn test_is_deployed_undeployed() {
 fn test_account_balance_eoa() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let eoa = kakarot_core.deploy_eoa(evm_address());
+    let eoa = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
 
-    fund_account_with_native_token(eoa, native_token, 0x1);
+    fund_account_with_native_token(eoa.starknet_address, native_token, 0x1);
 
     // When
     set_contract_address(kakarot_core.contract_address);
@@ -71,23 +73,63 @@ fn test_account_balance_eoa() {
     let balance = account.balance().unwrap();
 
     // Then
-    assert(balance == native_token.balanceOf(eoa), 'wrong balance');
+    assert(balance == native_token.balanceOf(eoa.starknet_address), 'wrong balance');
 }
 
-// TODO: implement balance once contracts accounts can be deployed
+#[test]
+#[available_gas(5000000)]
+fn test_address_balance_eoa() {
+    // Given
+    let (native_token, kakarot_core) = setup_contracts_for_testing();
+    let eoa = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
+
+    fund_account_with_native_token(eoa.starknet_address, native_token, 0x1);
+
+    // When
+    set_contract_address(kakarot_core.contract_address);
+    let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
+    let balance = account.address().balance().unwrap();
+
+    // Then
+    assert(balance == native_token.balanceOf(eoa.starknet_address), 'wrong balance');
+}
+
+
 #[ignore]
 #[test]
 #[available_gas(5000000)]
 fn test_account_balance_contract_account() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    // TODO: deploy contract account
-    // and fund it
+    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span())
+        .expect('failed deploy contract account',);
+
+    fund_account_with_native_token(ca.starknet_address, native_token, 0x1);
 
     // When
     let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
     let balance = account.balance().unwrap();
 
     // Then
-    panic_with_felt252('Not implemented yet');
+    assert(balance == native_token.balanceOf(ca.starknet_address), 'wrong balance');
+}
+
+#[ignore]
+#[test]
+#[available_gas(5000000)]
+fn test_address_balance_contract_account() {
+    // Given
+    let (native_token, kakarot_core) = setup_contracts_for_testing();
+    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span())
+        .expect('failed deploy contract account',);
+
+    fund_account_with_native_token(ca.starknet_address, native_token, 0x1);
+
+    // When
+    let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
+    let balance = account.address().balance().unwrap();
+
+    // Then
+    // Then
+    assert(balance == native_token.balanceOf(ca.starknet_address), 'wrong balance');
 }

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -15,7 +15,6 @@ use starknet::testing::set_contract_address;
 fn test_is_deployed_eoa_exists() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let (native_token, kakarot_core) = setup_contracts_for_testing();
     let eoa = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
 
     // When

--- a/crates/evm/src/tests/test_model/test_contract_account.cairo
+++ b/crates/evm/src/tests/test_model/test_contract_account.cairo
@@ -5,6 +5,7 @@ use contracts::tests::test_data::counter_evm_bytecode;
 use contracts::tests::test_utils as contract_utils;
 use contracts::tests::test_utils::constants::EVM_ADDRESS;
 use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
+use evm::model::{AccountType};
 use evm::tests::test_utils;
 use starknet::testing::set_contract_address;
 
@@ -44,12 +45,11 @@ fn test_at_contract_account_deployed() {
     assert(maybe_ca.is_some(), 'contract account should exist');
     let mut ca = maybe_ca.unwrap();
     assert(ca.evm_address == evm_address, 'evm_address incorrect');
-    let sn_address = match kakarot_core.address_registry(evm_address) {
-        StoredAccountType::UninitializedAccount => panic_with_felt252('should be initialized'),
-        StoredAccountType::EOA(_) => panic_with_felt252('should no be EOA'),
-        StoredAccountType::ContractAccount(address) => address,
+    let registered_ca = match kakarot_core.address_registry(evm_address).expect('should be in registry') {
+        AccountType::EOA(_) => panic_with_felt252('should no be EOA'),
+        AccountType::ContractAccount(address) => address,
     };
-    assert(ca.starknet_address == sn_address, 'starknet_address mismatch');
+    assert(ca == registered_ca, 'starknet_address mismatch');
 }
 
 

--- a/crates/evm/src/tests/test_model/test_contract_account.cairo
+++ b/crates/evm/src/tests/test_model/test_contract_account.cairo
@@ -45,7 +45,8 @@ fn test_at_contract_account_deployed() {
     assert(maybe_ca.is_some(), 'contract account should exist');
     let mut ca = maybe_ca.unwrap();
     assert(ca.evm_address == evm_address, 'evm_address incorrect');
-    let registered_ca = match kakarot_core.address_registry(evm_address).expect('should be in registry') {
+    let registered_ca =
+        match kakarot_core.address_registry(evm_address).expect('should be in registry') {
         AccountType::EOA(_) => panic_with_felt252('should no be EOA'),
         AccountType::ContractAccount(address) => address,
     };

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -1,4 +1,3 @@
-use core::debug::PrintTrait;
 use utils::eth_transaction::{EthTransactionImpl};
 
 #[test]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Refactors the account model and the way we interact with accounts to

- Make it safer by avoiding direct accesses to SN state
- Make it more consistent with the account model updates

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Prevents deployment of all undeployed accounts during commitment phase - First step for #519 is to check if the account must be deployed
- `StoredAccountType` is an internal type to the KakarotCore contract and is only used to check whether there is an account at a certain address, and what its actual type is. 
- `AccountType` methods disappeared in favour of `Account` methods. Eventually `AccountType` will disappear from the `Account` model - as we want to keep it as it's done in the EVM.
- Loads the Starknet Nonce of the origin into its evm account representation to correctly  call `create` with the correct nonce as the salt. Resolves #518

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
