### PR TITLE
feat: add eip-2718 tx decode

### DIFF
--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -7,9 +7,9 @@ use utils::errors::RLPErrorTrait;
 
 use utils::errors::{EthTransactionError, RLPErrorImpl, RLPHelpersErrorImpl, RLPHelpersErrorTrait};
 use utils::helpers::ByteArrayExTrait;
+use utils::helpers::U256Trait;
 
 use utils::helpers::{U256Impl, ByteArrayExt};
-use utils::helpers::{U256Trait, compute_msg_hash};
 
 use utils::rlp::RLPItem;
 use utils::rlp::{RLPTrait, RLPHelpersTrait};

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -1,3 +1,4 @@
+use core::array::SpanTrait;
 use core::option::OptionTrait;
 use core::traits::TryInto;
 
@@ -128,9 +129,12 @@ impl EthTransactionImpl of EthTransaction {
             RLPItem::String => { Result::Err(EthTransactionError::ExpectedRLPItemToBeList) },
             RLPItem::List(val) => {
                 // total items in EIP 2930 (unsigned): 8
+                if (tx_type == 1 && val.len() != 8) {
+                    return Result::Err(EthTransactionError::Other('Length is not 8'));
+                }
                 // total items in EIP 1559 (unsigned): 9
-                if (val.len() != 8 && val.len() != 9) {
-                    return Result::Err(EthTransactionError::Other('Length is not 8 or 9'));
+                if (tx_type == 2 && val.len() != 9) {
+                    return Result::Err(EthTransactionError::Other('Length is not 9'));
                 }
 
                 let chain_id = (*val.at(chain_idx)).parse_u128_from_string().map_err()?;

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -144,7 +144,7 @@ impl EthTransactionImpl of EthTransaction {
         let result: Result<EthereumTransaction, EthTransactionError> = match decoded_data {
             RLPItem::String => { Result::Err(EthTransactionError::ExpectedRLPItemToBeList) },
             RLPItem::List(val) => {
-                // total items in EIP 2930 (unsgined): 8
+                // total items in EIP 2930 (unsigned): 8
                 // total items in EIP 1559 (unsigned): 9
                 if (val.len() != 8 && val.len() != 9) {
                     return Result::Err(EthTransactionError::Other('Length is not 8 or 9'));

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -93,7 +93,7 @@ impl EthTransactionImpl of EthTransaction {
     /// transaction data, which includes the chain ID as part of the transaction data itself.
     /// # Arguments
     /// tx_data The raw transaction data
-    fn decode_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
+    fn decode_typed_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
         let tx_type: u32 = (*tx_data.at(0)).into();
         let rlp_encoded_data = tx_data.slice(1, tx_data.len() - 1);
 

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -23,7 +23,6 @@ struct EthereumTransaction {
     amount: u256,
     calldata: Span<u8>,
     chain_id: u128,
-    msg_hash: u256,
 }
 
 #[generate_trait]
@@ -74,20 +73,11 @@ impl EthTransactionImpl of EthTransaction {
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
                 let chain_id = (*val.at(chain_id_idx)).parse_u128_from_string().map_err()?;
 
-                let msg_hash = compute_msg_hash(tx_data);
-
                 let destination: EthAddress = to.into();
 
                 Result::Ok(
                     EthereumTransaction {
-                        nonce,
-                        gas_price,
-                        gas_limit,
-                        destination,
-                        amount,
-                        calldata,
-                        msg_hash,
-                        chain_id
+                        nonce, gas_price, gas_limit, destination, amount, calldata, chain_id
                     }
                 )
             }
@@ -151,7 +141,6 @@ impl EthTransactionImpl of EthTransaction {
                 let amount = (*val.at(value_idx)).parse_u256_from_string().map_err()?;
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
 
-                let msg_hash = compute_msg_hash(tx_data);
                 let destination: EthAddress = to.into();
 
                 Result::Ok(
@@ -163,7 +152,6 @@ impl EthTransactionImpl of EthTransaction {
                         destination,
                         amount,
                         calldata,
-                        msg_hash
                     }
                 )
             }

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -7,9 +7,9 @@ use utils::errors::RLPErrorTrait;
 
 use utils::errors::{EthTransactionError, RLPErrorImpl, RLPHelpersErrorImpl, RLPHelpersErrorTrait};
 use utils::helpers::ByteArrayExTrait;
-use utils::helpers::U256Trait;
 
 use utils::helpers::{U256Impl, ByteArrayExt};
+use utils::helpers::{U256Trait, compute_msg_hash};
 
 use utils::rlp::RLPItem;
 use utils::rlp::{RLPTrait, RLPHelpersTrait};
@@ -74,14 +74,7 @@ impl EthTransactionImpl of EthTransaction {
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
                 let chain_id = (*val.at(chain_id_idx)).parse_u128_from_string().map_err()?;
 
-                let mut transaction_data_byte_array = ByteArrayExt::from_bytes(tx_data);
-                let (mut keccak_input, last_input_word, last_input_num_bytes) =
-                    transaction_data_byte_array
-                    .to_u64_words();
-                let msg_hash = cairo_keccak(
-                    ref keccak_input, :last_input_word, :last_input_num_bytes
-                )
-                    .reverse_endianness();
+                let msg_hash = compute_msg_hash(tx_data);
 
                 let destination: EthAddress = to.into();
 
@@ -158,15 +151,7 @@ impl EthTransactionImpl of EthTransaction {
                 let amount = (*val.at(value_idx)).parse_u256_from_string().map_err()?;
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
 
-                let mut transaction_data_byte_array = ByteArrayExt::from_bytes(tx_data);
-                let (mut keccak_input, last_input_word, last_input_num_bytes) =
-                    transaction_data_byte_array
-                    .to_u64_words();
-                let msg_hash = cairo_keccak(
-                    ref keccak_input, :last_input_word, :last_input_num_bytes
-                )
-                    .reverse_endianness();
-
+                let msg_hash = compute_msg_hash(tx_data);
                 let destination: EthAddress = to.into();
 
                 Result::Ok(

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -124,6 +124,8 @@ impl EthTransactionImpl of EthTransaction {
             return Result::Err(EthTransactionError::Other('transaction type not supported'));
         }
 
+        // tx_format (EIP-2930, unsiged):  0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+        // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list])
         let chain_idx = 0;
         let nonce_idx = 1;
         let gas_price_idx = tx_type + nonce_idx;

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -112,7 +112,7 @@ impl EthTransactionImpl of EthTransaction {
     /// tx_data The raw transaction data
     fn decode_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
         let tx_type: u32 = (*tx_data.at(0)).into();
-        let tx_data = tx_data.slice(1, tx_data.len() - 1);
+        let rlp_encoded_data = tx_data.slice(1, tx_data.len() - 1);
 
         // EIP 2718:
         // TransactionType is a positive unsigned 8-bit number between 0 and 0x7f
@@ -132,7 +132,7 @@ impl EthTransactionImpl of EthTransaction {
         let value_idx = to_idx + 1;
         let calldata_idx = value_idx + 1;
 
-        let decoded_data = RLPTrait::decode(tx_data).map_err()?;
+        let decoded_data = RLPTrait::decode(rlp_encoded_data).map_err()?;
         if (decoded_data.len() != 1) {
             return Result::Err(EthTransactionError::Other('Length is not 1'));
         }

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -521,6 +521,20 @@ impl SpanExtension<T, +Copy<T>, +Drop<T>> of SpanExtTrait<T> {
 }
 
 #[generate_trait]
+impl BytesImpl of BytesTrait {
+    // keccack256 on a bytes message
+    fn compute_keccak256_hash(self: Span<u8>) -> u256 {
+        let mut msg_byte_array = ByteArrayExt::from_bytes(self);
+        let (mut keccak_input, last_input_word, last_input_num_bytes) = msg_byte_array
+            .to_u64_words();
+        let msg_hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
+            .reverse_endianness();
+
+        msg_hash
+    }
+}
+
+#[generate_trait]
 impl U32Impl of U32Trait {
     /// Packs 4 bytes into a u32
     /// # Arguments
@@ -870,15 +884,6 @@ fn compute_starknet_address(
     normalized_address
 }
 
-// keccack256 on a bytes message
-fn compute_msg_hash(msg: Span<u8>) -> u256 {
-    let mut msg_byte_array = ByteArrayExt::from_bytes(msg);
-    let (mut keccak_input, last_input_word, last_input_num_bytes) = msg_byte_array.to_u64_words();
-    let msg_hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
-        .reverse_endianness();
-
-    msg_hash
-}
 
 #[generate_trait]
 impl EthAddressExtTrait of EthAddressExt {

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -4,7 +4,7 @@ use core::pedersen::{HashState, PedersenTrait};
 
 use integer::U32TryIntoNonZero;
 use integer::u32_as_non_zero;
-use keccak::u128_split;
+use keccak::{cairo_keccak, u128_split};
 use starknet::{EthAddress, EthAddressIntoFelt252, ContractAddress, ClassHash};
 use traits::DivRem;
 use utils::constants::{
@@ -868,6 +868,16 @@ fn compute_starknet_address(
     let normalized_address: ContractAddress = (hash.into() & MAX_ADDRESS).try_into().unwrap();
     // We know this unwrap is safe, because of the above bitwise AND on 2 ** 251
     normalized_address
+}
+
+// keccack256 on a bytes message
+fn compute_msg_hash(msg: Span<u8>) -> u256 {
+    let mut msg_byte_array = ByteArrayExt::from_bytes(msg);
+    let (mut keccak_input, last_input_word, last_input_num_bytes) = msg_byte_array.to_u64_words();
+    let msg_hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
+        .reverse_endianness();
+
+    msg_hash
 }
 
 #[generate_trait]

--- a/crates/utils/src/tests/test_data.cairo
+++ b/crates/utils/src/tests/test_data.cairo
@@ -116,7 +116,7 @@ fn eip_2930_encoded_tx() -> Span<u8> {
 }
 
 fn eip_1559_encoded_tx() -> Span<u8> {
-    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
+    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list])
     // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
     // message_hash: 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5
     // chain id used: 0x1

--- a/crates/utils/src/tests/test_data.cairo
+++ b/crates/utils/src/tests/test_data.cairo
@@ -60,7 +60,7 @@ fn legacy_rlp_encoded_tx() -> Span<u8> {
 fn eip_2930_encoded_tx() -> Span<u8> {
     // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
     // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
-    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // message_hash: 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0
     // chain id used: 0x1
     array![
         1,
@@ -118,7 +118,7 @@ fn eip_2930_encoded_tx() -> Span<u8> {
 fn eip_1559_encoded_tx() -> Span<u8> {
     // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
     // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
-    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // message_hash: 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5
     // chain id used: 0x1
     array![
         2,

--- a/crates/utils/src/tests/test_data.cairo
+++ b/crates/utils/src/tests/test_data.cairo
@@ -1,4 +1,8 @@
 fn legacy_rlp_encoded_tx() -> Span<u8> {
+    // tx_format (EIP-155, unsigned): [nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]
+    // expected rlp decoding:  [ '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', '0x01', '0x', '0x' ]
+    // message_hash: 0x89d3071d2bcc98141b16317ec8d912a76271ec052c2884674ddcd752b5ea91fe
+    // chain id used: 0x1
     array![
         239,
         128,
@@ -48,6 +52,124 @@ fn legacy_rlp_encoded_tx() -> Span<u8> {
         1,
         128,
         128
+    ]
+        .span()
+}
+
+
+fn eip_2930_encoded_tx() -> Span<u8> {
+    // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
+    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // chain id used: 0x1
+    array![
+        1,
+        238,
+        1,
+        128,
+        132,
+        59,
+        154,
+        202,
+        0,
+        131,
+        30,
+        132,
+        128,
+        148,
+        31,
+        152,
+        64,
+        168,
+        93,
+        90,
+        245,
+        191,
+        29,
+        23,
+        98,
+        249,
+        37,
+        189,
+        173,
+        220,
+        66,
+        1,
+        249,
+        132,
+        136,
+        1,
+        99,
+        69,
+        120,
+        93,
+        138,
+        0,
+        0,
+        131,
+        171,
+        205,
+        239,
+        192
+    ]
+        .span()
+}
+
+fn eip_1559_encoded_tx() -> Span<u8> {
+    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
+    // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
+    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // chain id used: 0x1
+    array![
+        2,
+        239,
+        1,
+        128,
+        128,
+        132,
+        59,
+        154,
+        202,
+        0,
+        131,
+        30,
+        132,
+        128,
+        148,
+        31,
+        152,
+        64,
+        168,
+        93,
+        90,
+        245,
+        191,
+        29,
+        23,
+        98,
+        249,
+        37,
+        189,
+        173,
+        220,
+        66,
+        1,
+        249,
+        132,
+        136,
+        1,
+        99,
+        69,
+        120,
+        93,
+        138,
+        0,
+        0,
+        131,
+        171,
+        205,
+        239,
+        192
     ]
         .span()
 }

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -25,11 +25,6 @@ fn test_decode_legacy_tx() {
 
     let expected_calldata = 0xabcdef_u32.to_bytes();
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0x89d3071d2bcc98141b16317ec8d912a76271ec052c2884674ddcd752b5ea91fe,
-        'message hash it not 0x89d3...'
-    );
 }
 
 
@@ -56,11 +51,6 @@ fn test_decode_eip_2930_tx() {
 
     let expected_calldata = 0xabcdef_u32.to_bytes();
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0,
-        'message hash it not 0xacc...'
-    );
 }
 
 
@@ -87,9 +77,4 @@ fn test_decode_eip_1559_tx() {
 
     let expected_calldata = 0xabcdef_u32.to_bytes();
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5,
-        'message hash it not 0x59...'
-    );
 }

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -38,7 +38,7 @@ fn test_decode_legacy_tx() {
 fn test_decode_eip_2930_tx() {
     // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
     // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
-    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // message_hash: 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0
     // chain id used: 0x1
     let data = eip_2930_encoded_tx();
 
@@ -58,8 +58,8 @@ fn test_decode_eip_2930_tx() {
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 
     assert(
-        tx.msg_hash == 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f,
-        'message hash it not 0x45...'
+        tx.msg_hash == 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0,
+        'message hash it not 0xacc...'
     );
 }
 
@@ -69,7 +69,7 @@ fn test_decode_eip_2930_tx() {
 fn test_decode_eip_1559_tx() {
     // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
     // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
-    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // message_hash: 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5
     // chain id used: 0x1
     let data = eip_1559_encoded_tx();
 
@@ -89,7 +89,7 @@ fn test_decode_eip_1559_tx() {
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 
     assert(
-        tx.msg_hash == 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f,
-        'message hash it not 0xe9...'
+        tx.msg_hash == 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5,
+        'message hash it not 0x59...'
     );
 }

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -1,6 +1,6 @@
 use utils::eth_transaction::{EthTransactionImpl};
 use utils::helpers::{U32Trait};
-use utils::tests::test_data::legacy_rlp_encoded_tx;
+use utils::tests::test_data::{legacy_rlp_encoded_tx, eip_2930_encoded_tx, eip_1559_encoded_tx};
 
 #[test]
 #[available_gas(200000000)]
@@ -13,6 +13,7 @@ fn test_decode_legacy_tx() {
 
     let tx = EthTransactionImpl::decode_legacy_tx(data).unwrap();
 
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
     assert(tx.nonce == 0, 'nonce is not 0');
     assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
     assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
@@ -23,12 +24,72 @@ fn test_decode_legacy_tx() {
     assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
 
     let expected_calldata = 0xabcdef_u32.to_bytes();
-    assert(tx.calldata == expected_calldata, 'payload is not 0xabcdef');
-
-    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 
     assert(
         tx.msg_hash == 0x89d3071d2bcc98141b16317ec8d912a76271ec052c2884674ddcd752b5ea91fe,
         'message hash it not 0x89d3...'
+    );
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_2930_tx() {
+    // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
+    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // chain id used: 0x1
+    let data = eip_2930_encoded_tx();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+
+    assert(
+        tx.msg_hash == 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f,
+        'message hash it not 0x45...'
+    );
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_1559_tx() {
+    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
+    // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
+    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // chain id used: 0x1
+    let data = eip_1559_encoded_tx();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+
+    assert(
+        tx.msg_hash == 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f,
+        'message hash it not 0xe9...'
     );
 }

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -67,7 +67,7 @@ fn test_decode_eip_2930_tx() {
 #[test]
 #[available_gas(200000000)]
 fn test_decode_eip_1559_tx() {
-    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
+    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list])
     // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
     // message_hash: 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5
     // chain id used: 0x1

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -37,7 +37,7 @@ fn test_decode_eip_2930_tx() {
     // chain id used: 0x1
     let data = eip_2930_encoded_tx();
 
-    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+    let tx = EthTransactionImpl::decode_typed_tx(data).unwrap();
 
     assert(tx.chain_id == 0x1, 'chain id is not 0x1');
     assert(tx.nonce == 0, 'nonce is not 0');
@@ -63,7 +63,7 @@ fn test_decode_eip_1559_tx() {
     // chain id used: 0x1
     let data = eip_1559_encoded_tx();
 
-    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+    let tx = EthTransactionImpl::decode_typed_tx(data).unwrap();
 
     assert(tx.chain_id == 0x1, 'chain id is not 0x1');
     assert(tx.nonce == 0, 'nonce is not 0');

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -1,5 +1,5 @@
 use utils::helpers::{
-    SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, U32Trait
+    SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, U32Trait, BytesTrait
 };
 use utils::helpers::{ByteArrayExTrait};
 use utils::helpers;
@@ -440,23 +440,10 @@ fn test_bytearray_deserialize() {
 
 #[test]
 #[available_gas(20000000)]
-fn test_bytearray_serialize() {
-    let byte_arr = ByteArray {
-        data: array![
-            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.try_into().unwrap()
-        ],
-        pending_word_len: 3,
-        pending_word: 0xabcdef
-    };
-    let mut serialized: Array<felt252> = Default::default();
-    byte_arr.serialize(ref serialized);
+fn test_compute_msg_hash() {
+    let msg = 0xabcdef_u32.to_bytes();
+    let expected_hash = 0x800d501693feda2226878e1ec7869eef8919dbc5bd10c2bcd031b94d73492860_u256;
+    let hash = msg.compute_keccak256_hash();
 
-    // One extra element encodes the length of the pending word
-    assert(serialized.len() == 3, 'len mismatch');
-    assert(*serialized[0] == 3, 'pending_word_len mismatch');
-    assert(*serialized[1] == 0xabcdef, 'pending_word mismatch');
-    assert(
-        *serialized[2] == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
-        'full_word mismatch'
-    );
+    assert(hash == expected_hash, 'msg_hash is incorrect');
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

PR adds support for decoding EIP-2718 txns + improves testing for legacy decoding of transaction.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Decoding for EIP-2718 transactions is not supported.

Resolves: #406 

## What is the new behavior?

Decoding for EIP-2718 transactions is not supported.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
