### PR TITLE
Feat: implement `decode` and is `legacy tx`

### DIFF
--- a/crates/utils/src/errors.cairo
+++ b/crates/utils/src/errors.cairo
@@ -54,5 +54,11 @@ enum EthTransactionError {
     ExpectedRLPItemToBeList,
     ExpectedRLPItemToBeString,
     RlpHelpersError: RLPHelpersError,
+    // the usize represents the encountered length of payload
+    TopLevelRlpListWrongLength: usize,
+    // the usize represents the encountered length of payload
+    LegacyTxWrongPayloadLength: usize,
+    // the usize represents the encountered length of payload
+    TypedTxWrongPayloadLength: usize,
     Other: felt252
 }

--- a/crates/utils/src/errors.cairo
+++ b/crates/utils/src/errors.cairo
@@ -53,6 +53,7 @@ enum EthTransactionError {
     RLPError: RLPError,
     ExpectedRLPItemToBeList,
     ExpectedRLPItemToBeString,
+    TransactionTypeError,
     RlpHelpersError: RLPHelpersError,
     // the usize represents the encountered length of payload
     TopLevelRlpListWrongLength: usize,

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -42,7 +42,9 @@ impl EthTransactionImpl of EthTransaction {
     /// # Arguments
     /// tx_data The raw transaction data
     /// tx_data is of the format: rlp![nonce, gasPrice, gasLimit, to , value, data, chainId, 0, 0]
-    fn decode_legacy_tx(tx_data: EncodedLegacyTransaction) -> Result<EthereumTransaction, EthTransactionError> {
+    fn decode_legacy_tx(
+        tx_data: EncodedLegacyTransaction
+    ) -> Result<EthereumTransaction, EthTransactionError> {
         let decoded_data = RLPTrait::decode(tx_data);
         let decoded_data = decoded_data.map_err()?;
 
@@ -100,7 +102,9 @@ impl EthTransactionImpl of EthTransaction {
     /// transaction data, which includes the chain ID as part of the transaction data itself.
     /// # Arguments
     /// tx_data The raw transaction data
-    fn decode_typed_tx(tx_data: EncodedTypedTransaction) -> Result<EthereumTransaction, EthTransactionError> {
+    fn decode_typed_tx(
+        tx_data: EncodedTypedTransaction
+    ) -> Result<EthereumTransaction, EthTransactionError> {
         let tx_type: u32 = (*tx_data.at(0)).into();
         let rlp_encoded_data = tx_data.slice(1, tx_data.len() - 1);
 

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -49,7 +49,7 @@ impl EthTransactionImpl of EthTransaction {
         let decoded_data = decoded_data.map_err()?;
 
         if (decoded_data.len() != 1) {
-            return Result::Err(EthTransactionError::Other('Length is not 1'));
+            return Result::Err(EthTransactionError::TopLevelRlpListWrongLength(decoded_data.len()));
         }
 
         let decoded_data = *decoded_data.at(0);
@@ -58,7 +58,7 @@ impl EthTransactionImpl of EthTransaction {
             RLPItem::String => { Result::Err(EthTransactionError::ExpectedRLPItemToBeList) },
             RLPItem::List(val) => {
                 if (val.len() != 9) {
-                    return Result::Err(EthTransactionError::Other('Length is not 9'));
+                    return Result::Err(EthTransactionError::LegacyTxWrongPayloadLength(val.len()));
                 }
 
                 let (
@@ -125,7 +125,7 @@ impl EthTransactionImpl of EthTransaction {
 
         let decoded_data = RLPTrait::decode(rlp_encoded_data).map_err()?;
         if (decoded_data.len() != 1) {
-            return Result::Err(EthTransactionError::Other('Length is not 1'));
+            return Result::Err(EthTransactionError::TopLevelRlpListWrongLength(decoded_data.len()));
         }
 
         let decoded_data = *decoded_data.at(0);
@@ -135,11 +135,11 @@ impl EthTransactionImpl of EthTransaction {
             RLPItem::List(val) => {
                 // total items in EIP 2930 (unsigned): 8
                 if (tx_type == 1 && val.len() != 8) {
-                    return Result::Err(EthTransactionError::Other('Length is not 8'));
+                    return Result::Err(EthTransactionError::TypedTxWrongPayloadLength(val.len()));
                 }
                 // total items in EIP 1559 (unsigned): 9
                 if (tx_type == 2 && val.len() != 9) {
-                    return Result::Err(EthTransactionError::Other('Length is not 9'));
+                    return Result::Err(EthTransactionError::TypedTxWrongPayloadLength(val.len()));
                 }
 
                 let chain_id = (*val.at(chain_idx)).parse_u128_from_string().map_err()?;

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -79,6 +79,7 @@ impl EncodedTransactionImpl of EncodedTransactionTrait {
     /// # Arguments
     /// * tx_data - The raw transaction data
     /// * tx_data - is of the format: rlp![nonce, gasPrice, gasLimit, to , value, data, chainId, 0, 0]
+    /// Note: this function assumes that tx_type has been checked to make sure it is a legacy transaction
     fn decode_legacy_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
         let decoded_data = RLPTrait::decode(tx_data);
         let decoded_data = decoded_data.map_err()?;
@@ -137,6 +138,7 @@ impl EncodedTransactionImpl of EncodedTransactionTrait {
     /// transaction data, which includes the chain ID as part of the transaction data itself.
     /// # Arguments
     /// * `tx_data` - The raw transaction data
+    /// Note: this function assumes that tx_type has been checked to make sure it is either EIP-2930 or EIP-1559 transaction
     fn decode_typed_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
         let tx_type: u32 = (*tx_data.at(0)).into();
         let rlp_encoded_data = tx_data.slice(1, tx_data.len() - 1);

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -26,6 +26,12 @@ struct EthereumTransaction {
     chain_id: u128,
 }
 
+
+/// represents an encoded legacy transaction, a Span<u8> should only best casted to this type if check for it being a legacy transaction has been done.
+type EncodedLegacyTransaction = Span<u8>;
+/// represents typed (EIP-2718) transaction, a Span<u8> should only best casted to this type if check for it being a typed transaction has been done.
+type EncodedTypedTransaction = Span<u8>;
+
 #[generate_trait]
 impl EthTransactionImpl of EthTransaction {
     /// Decode a legacy Ethereum transaction
@@ -36,11 +42,7 @@ impl EthTransactionImpl of EthTransaction {
     /// # Arguments
     /// tx_data The raw transaction data
     /// tx_data is of the format: rlp![nonce, gasPrice, gasLimit, to , value, data, chainId, 0, 0]
-    fn decode_legacy_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
-        if (!EthTransaction::is_legacy_tx(tx_data)) {
-            return Result::Err(EthTransactionError::Other('Not legacy transaction'));
-        }
-
+    fn decode_legacy_tx(tx_data: EncodedLegacyTransaction) -> Result<EthereumTransaction, EthTransactionError> {
         let decoded_data = RLPTrait::decode(tx_data);
         let decoded_data = decoded_data.map_err()?;
 
@@ -98,7 +100,7 @@ impl EthTransactionImpl of EthTransaction {
     /// transaction data, which includes the chain ID as part of the transaction data itself.
     /// # Arguments
     /// tx_data The raw transaction data
-    fn decode_typed_tx(tx_data: Span<u8>) -> Result<EthereumTransaction, EthTransactionError> {
+    fn decode_typed_tx(tx_data: EncodedTypedTransaction) -> Result<EthereumTransaction, EthTransactionError> {
         let tx_type: u32 = (*tx_data.at(0)).into();
         let rlp_encoded_data = tx_data.slice(1, tx_data.len() - 1);
 

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -79,130 +79,29 @@ fn test_decode_eip_1559_tx() {
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 }
 
-
 #[test]
-#[available_gas(200000000)]
-fn test_decode_eip_2930_tx() {
-    // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
-    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
-    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
-    // chain id used: 0x1
-    let data = eip_2930_encoded_tx();
+#[available_gas(2000000000)]
+fn test_is_legacy_tx_eip_155_tx() {
+    let tx_data = legacy_rlp_encoded_tx();
+    let result = EthTransactionImpl::is_legacy_tx(tx_data);
 
-    let tx = EthTransactionImpl::decode_tx(data).unwrap();
-
-    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
-    assert(tx.nonce == 0, 'nonce is not 0');
-    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
-    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
-    assert(
-        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
-        'destination is not 0x1f9840...'
-    );
-    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
-
-    let expected_calldata = 0xabcdef_u32.to_bytes();
-    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f,
-        'message hash it not 0x45...'
-    );
+    assert(result == true, 'is_legacy_tx expected true');
 }
 
-
 #[test]
-#[available_gas(200000000)]
-fn test_decode_eip_1559_tx() {
-    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
-    // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
-    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
-    // chain id used: 0x1
-    let data = eip_1559_encoded_tx();
+#[available_gas(2000000000)]
+fn test_is_legacy_tx_eip_1559_tx() {
+    let tx_data = eip_1559_encoded_tx();
+    let result = EthTransactionImpl::is_legacy_tx(tx_data);
 
-    let tx = EthTransactionImpl::decode_tx(data).unwrap();
-
-    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
-    assert(tx.nonce == 0, 'nonce is not 0');
-    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
-    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
-    assert(
-        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
-        'destination is not 0x1f9840...'
-    );
-    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
-
-    let expected_calldata = 0xabcdef_u32.to_bytes();
-    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f,
-        'message hash it not 0xe9...'
-    );
-    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
-
-    let expected_calldata = 0xabcdef_u32.to_bytes();
-    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+    assert(result == false, 'is_legacy_tx expected false');
 }
 
-
 #[test]
-#[available_gas(200000000)]
-fn test_decode_eip_2930_tx() {
-    // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
-    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
-    // message_hash: 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0
-    // chain id used: 0x1
-    let data = eip_2930_encoded_tx();
+#[available_gas(2000000000)]
+fn test_is_legacy_tx_eip_2930_tx() {
+    let tx_data = eip_2930_encoded_tx();
+    let result = EthTransactionImpl::is_legacy_tx(tx_data);
 
-    let tx = EthTransactionImpl::decode_tx(data).unwrap();
-
-    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
-    assert(tx.nonce == 0, 'nonce is not 0');
-    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
-    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
-    assert(
-        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
-        'destination is not 0x1f9840...'
-    );
-    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
-
-    let expected_calldata = 0xabcdef_u32.to_bytes();
-    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0,
-        'message hash it not 0xacc...'
-    );
-}
-
-
-#[test]
-#[available_gas(200000000)]
-fn test_decode_eip_1559_tx() {
-    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
-    // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
-    // message_hash: 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5
-    // chain id used: 0x1
-    let data = eip_1559_encoded_tx();
-
-    let tx = EthTransactionImpl::decode_tx(data).unwrap();
-
-    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
-    assert(tx.nonce == 0, 'nonce is not 0');
-    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
-    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
-    assert(
-        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
-        'destination is not 0x1f9840...'
-    );
-    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
-
-    let expected_calldata = 0xabcdef_u32.to_bytes();
-    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
-
-    assert(
-        tx.msg_hash == 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5,
-        'message hash it not 0x59...'
-    );
+    assert(result == false, 'is_legacy_tx expected false');
 }

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -151,7 +151,7 @@ fn test_decode_eip_1559_tx() {
 fn test_decode_eip_2930_tx() {
     // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
     // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
-    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // message_hash: 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0
     // chain id used: 0x1
     let data = eip_2930_encoded_tx();
 
@@ -171,8 +171,8 @@ fn test_decode_eip_2930_tx() {
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 
     assert(
-        tx.msg_hash == 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f,
-        'message hash it not 0x45...'
+        tx.msg_hash == 0xacc506973edb7b4024d1698a4e7b066728f9ebcee1af4d8ec93d4382e79a62f0,
+        'message hash it not 0xacc...'
     );
 }
 
@@ -182,7 +182,7 @@ fn test_decode_eip_2930_tx() {
 fn test_decode_eip_1559_tx() {
     // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
     // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
-    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // message_hash: 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5
     // chain id used: 0x1
     let data = eip_1559_encoded_tx();
 
@@ -202,7 +202,7 @@ fn test_decode_eip_1559_tx() {
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 
     assert(
-        tx.msg_hash == 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f,
-        'message hash it not 0xe9...'
+        tx.msg_hash == 0x598035333ab961ee2ff00db3f21703926c911a42f53222a1fc1757bd1e3c15f5,
+        'message hash it not 0x59...'
     );
 }

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -78,3 +78,131 @@ fn test_decode_eip_1559_tx() {
     let expected_calldata = 0xabcdef_u32.to_bytes();
     assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
 }
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_2930_tx() {
+    // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
+    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // chain id used: 0x1
+    let data = eip_2930_encoded_tx();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+
+    assert(
+        tx.msg_hash == 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f,
+        'message hash it not 0x45...'
+    );
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_1559_tx() {
+    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
+    // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
+    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // chain id used: 0x1
+    let data = eip_1559_encoded_tx();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+
+    assert(
+        tx.msg_hash == 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f,
+        'message hash it not 0xe9...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_2930_tx() {
+    // tx_format (EIP-2930, unsiged): 0x01  || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+    // expected rlp decoding:  [ '0x01', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', [], '0x', '0x14a38ea5e92fe6831b2137226418d03db2ab8cefd6f62bdfc0078787afa63f83', '0x6c89b2928b518445bef8d479167bb9aef73bab1871d1275fd8dcba3c1628a619']
+    // transaction_hash: 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f
+    // chain id used: 0x1
+    let data = eip_2930_encoded_tx();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+
+    assert(
+        tx.msg_hash == 0x4503d070b579775a52f1c9cf80a2814bb2de6129bcfe6150b3197397146d199f,
+        'message hash it not 0x45...'
+    );
+}
+
+
+#[test]
+#[available_gas(200000000)]
+fn test_decode_eip_1559_tx() {
+    // tx_format (EIP-1559, unsiged):  0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list)
+    // expected rlp decoding:   [ '0x01', '0x', '0x', '0x3b9aca00', '0x1e8480', '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', '0x016345785d8a0000', '0xabcdef', []]
+    // transaction_hash: 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f
+    // chain id used: 0x1
+    let data = eip_1559_encoded_tx();
+
+    let tx = EthTransactionImpl::decode_tx(data).unwrap();
+
+    assert(tx.chain_id == 0x1, 'chain id is not 0x1');
+    assert(tx.nonce == 0, 'nonce is not 0');
+    assert(tx.gas_price == 0x3b9aca00, 'gas_price is not 0x3b9aca00');
+    assert(tx.gas_limit == 0x1e8480, 'gas_limit is not 0x1e8480');
+    assert(
+        tx.destination.address == 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
+        'destination is not 0x1f9840...'
+    );
+    assert(tx.amount == 0x016345785d8a0000, 'amount is not 0x016345785d8...');
+
+    let expected_calldata = 0xabcdef_u32.to_bytes();
+    assert(tx.calldata == expected_calldata, 'calldata is not 0xabcdef');
+
+    assert(
+        tx.msg_hash == 0xe98fe6e52ed72dc79a35bd2410031157ba7eaa609c9ee4384f029e6fc809f86f,
+        'message hash it not 0xe9...'
+    );
+}

--- a/crates/utils/src/tests/test_eth_transaction.cairo
+++ b/crates/utils/src/tests/test_eth_transaction.cairo
@@ -1,6 +1,7 @@
-use utils::eth_transaction::{EthTransactionImpl};
+use utils::eth_transaction::{EthTransaction, EncodedTransactionTrait, EncodedTransaction};
 use utils::helpers::{U32Trait};
 use utils::tests::test_data::{legacy_rlp_encoded_tx, eip_2930_encoded_tx, eip_1559_encoded_tx};
+
 
 #[test]
 #[available_gas(200000000)]
@@ -11,7 +12,11 @@ fn test_decode_legacy_tx() {
     // chain id used: 0x1
     let data = legacy_rlp_encoded_tx();
 
-    let tx = EthTransactionImpl::decode_legacy_tx(data).unwrap();
+    let encoded_tx: Option<EncodedTransaction> = data.try_into();
+    let encoded_tx = encoded_tx.unwrap();
+    assert(encoded_tx == EncodedTransaction::Legacy(data), 'encoded_tx is not Legacy');
+
+    let tx = encoded_tx.decode().expect('decode failed');
 
     assert(tx.chain_id == 0x1, 'chain id is not 0x1');
     assert(tx.nonce == 0, 'nonce is not 0');
@@ -37,7 +42,11 @@ fn test_decode_eip_2930_tx() {
     // chain id used: 0x1
     let data = eip_2930_encoded_tx();
 
-    let tx = EthTransactionImpl::decode_typed_tx(data).unwrap();
+    let encoded_tx: Option<EncodedTransaction> = data.try_into();
+    let encoded_tx = encoded_tx.unwrap();
+    assert(encoded_tx == EncodedTransaction::EIP2930(data), 'encoded_tx is not Eip2930');
+
+    let tx = encoded_tx.decode().expect('decode failed');
 
     assert(tx.chain_id == 0x1, 'chain id is not 0x1');
     assert(tx.nonce == 0, 'nonce is not 0');
@@ -63,7 +72,11 @@ fn test_decode_eip_1559_tx() {
     // chain id used: 0x1
     let data = eip_1559_encoded_tx();
 
-    let tx = EthTransactionImpl::decode_typed_tx(data).unwrap();
+    let encoded_tx: Option<EncodedTransaction> = data.try_into();
+    let encoded_tx = encoded_tx.unwrap();
+    assert(encoded_tx == EncodedTransaction::EIP1559(data), 'encoded_tx is not EIP1559');
+
+    let tx = encoded_tx.decode().expect('decode failed');
 
     assert(tx.chain_id == 0x1, 'chain id is not 0x1');
     assert(tx.nonce == 0, 'nonce is not 0');
@@ -83,7 +96,7 @@ fn test_decode_eip_1559_tx() {
 #[available_gas(2000000000)]
 fn test_is_legacy_tx_eip_155_tx() {
     let tx_data = legacy_rlp_encoded_tx();
-    let result = EthTransactionImpl::is_legacy_tx(tx_data);
+    let result = EncodedTransactionTrait::is_legacy_tx(tx_data);
 
     assert(result == true, 'is_legacy_tx expected true');
 }
@@ -92,7 +105,7 @@ fn test_is_legacy_tx_eip_155_tx() {
 #[available_gas(2000000000)]
 fn test_is_legacy_tx_eip_1559_tx() {
     let tx_data = eip_1559_encoded_tx();
-    let result = EthTransactionImpl::is_legacy_tx(tx_data);
+    let result = EncodedTransactionTrait::is_legacy_tx(tx_data);
 
     assert(result == false, 'is_legacy_tx expected false');
 }
@@ -101,7 +114,7 @@ fn test_is_legacy_tx_eip_1559_tx() {
 #[available_gas(2000000000)]
 fn test_is_legacy_tx_eip_2930_tx() {
     let tx_data = eip_2930_encoded_tx();
-    let result = EthTransactionImpl::is_legacy_tx(tx_data);
+    let result = EncodedTransactionTrait::is_legacy_tx(tx_data);
 
     assert(result == false, 'is_legacy_tx expected false');
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

Implement `decode` and is `legacy tx` for [EthTransaction](implement `decode` and is `legacy tx`) utlils.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

These methods are not implemented.

Resolves: #530 

## What is the new behavior?


-` decode` and is `legacy tx` are implemented

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
