### PR TITLE
Refactor/account model

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,11 +2,11 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.17.1
+  version: 1.17.2
 plugins:
   sources:
     - id: trunk
-      ref: v1.2.4
+      ref: v1.2.6
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
@@ -32,18 +32,18 @@ lint:
     - actionlint@1.6.26
     - bandit@1.7.5
     - black@23.9.1
-    - checkov@2.4.9
+    - checkov@3.0.29
     - git-diff-check
     - isort@5.12.0
     - markdownlint@0.37.0
-    - oxipng@8.0.0
+    - oxipng@9.0.0
     - prettier@3.0.3
-    - ruff@0.0.291
+    - ruff@0.1.5
     - shellcheck@0.9.0
     - shfmt@3.6.0
     - taplo@0.8.1
-    - trivy@0.45.1
-    - trufflehog@3.57.0
+    - trivy@0.47.0
+    - trufflehog@3.62.1
     - yamllint@1.32.0
 actions:
   disabled:

--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -43,7 +43,7 @@ trait IContractAccount<TContractState> {
 
     /// Checks if for a specific offset, i.e. if  bytecode at index `offset`, bytecode[offset] == 0x5B && is part of a PUSH opcode input.
     /// Prevents false positive checks in JUMP opcode of the type: jump destination opcode == JUMPDEST in appearance, but is a PUSH opcode bytecode slice.
-    fn is_false_jumpdest(self: @TContractState, offset: usize) -> bool;
+    fn is_false_positive_jumpdest(self: @TContractState, offset: usize) -> bool;
 
     fn set_false_positive_jumpdest(ref self: TContractState, offset: usize);
 
@@ -223,7 +223,7 @@ mod ContractAccount {
             Store::<u64>::write(0, storage_address, nonce + 1).expect(NONCE_WRITE_ERROR)
         }
 
-        fn is_false_jumpdest(self: @ContractState, offset: usize) -> bool {
+        fn is_false_positive_jumpdest(self: @ContractState, offset: usize) -> bool {
             panic_with_felt252('unimplemented')
         }
 

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -32,7 +32,7 @@ trait IKakarotCore<TContractState> {
     /// Checks into KakarotCore storage if an EOA or a CA has been deployed for
     /// a particular EVM address and if so, returns its corresponding type with
     /// its starknet address.  Otherwise, returns Option::None.
-    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<AccountType>;
+    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<(AccountType, ContractAddress)>;
 
 
     /// Gets the nonce associated to a contract account
@@ -131,7 +131,7 @@ trait IExtendedKakarotCore<TContractState> {
     /// Checks into KakarotCore storage if an EOA or a CA has been deployed for
     /// a particular EVM address and if so, returns its corresponding type with
     /// its starknet address.  Otherwise, returns Option::None.
-    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<AccountType>;
+    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<(AccountType, ContractAddress)>;
 
     /// Gets the nonce associated to a contract account
     fn contract_account_nonce(self: @TContractState, evm_address: EthAddress) -> u64;

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -32,7 +32,9 @@ trait IKakarotCore<TContractState> {
     /// Checks into KakarotCore storage if an EOA or a CA has been deployed for
     /// a particular EVM address and if so, returns its corresponding type with
     /// its starknet address.  Otherwise, returns Option::None.
-    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<(AccountType, ContractAddress)>;
+    fn address_registry(
+        self: @TContractState, evm_address: EthAddress
+    ) -> Option<(AccountType, ContractAddress)>;
 
 
     /// Gets the nonce associated to a contract account
@@ -131,7 +133,9 @@ trait IExtendedKakarotCore<TContractState> {
     /// Checks into KakarotCore storage if an EOA or a CA has been deployed for
     /// a particular EVM address and if so, returns its corresponding type with
     /// its starknet address.  Otherwise, returns Option::None.
-    fn address_registry(self: @TContractState, evm_address: EthAddress) -> Option<(AccountType, ContractAddress)>;
+    fn address_registry(
+        self: @TContractState, evm_address: EthAddress
+    ) -> Option<(AccountType, ContractAddress)>;
 
     /// Gets the nonce associated to a contract account
     fn contract_account_nonce(self: @TContractState, evm_address: EthAddress) -> u64;

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -18,6 +18,7 @@ enum StoredAccountType {
 mod KakarotCore {
     use contracts::components::ownable::{ownable_component};
     use contracts::components::upgradeable::{IUpgradeable, upgradeable_component};
+    use contracts::contract_account::{IContractAccountDispatcher, IContractAccountDispatcherTrait};
     use contracts::kakarot_core::interface::IKakarotCore;
     use contracts::kakarot_core::interface;
     use core::starknet::SyscallResultTrait;
@@ -186,7 +187,10 @@ mod KakarotCore {
             let ca_address = ContractAccountTrait::at(evm_address)
                 .expect('Fetching CA failed')
                 .expect('No CA found');
-            ca_address.fetch_nonce().unwrap()
+            let contract_account = IContractAccountDispatcher {
+                contract_address: ca_address.starknet
+            };
+            contract_account.nonce()
         }
 
         fn account_balance(self: @ContractState, evm_address: EthAddress) -> u256 {
@@ -202,14 +206,20 @@ mod KakarotCore {
             let ca_address = ContractAccountTrait::at(evm_address)
                 .expect('Fetching CA failed')
                 .expect('No CA found');
-            ca_address.fetch_storage(key).unwrap()
+            let contract_account = IContractAccountDispatcher {
+                contract_address: ca_address.starknet
+            };
+            contract_account.storage_at(key)
         }
 
         fn contract_account_bytecode(self: @ContractState, evm_address: EthAddress) -> Span<u8> {
             let ca_address = ContractAccountTrait::at(evm_address)
                 .expect('Fetching CA failed')
                 .expect('No CA found');
-            ca_address.fetch_bytecode().unwrap()
+            let contract_account = IContractAccountDispatcher {
+                contract_address: ca_address.starknet
+            };
+            contract_account.bytecode()
         }
 
         fn contract_account_false_positive_jumpdest(
@@ -218,7 +228,10 @@ mod KakarotCore {
             let ca_address = ContractAccountTrait::at(evm_address)
                 .expect('Fetching CA failed')
                 .expect('No CA found');
-            ca_address.is_false_positive_jumpdest(offset).unwrap()
+            let contract_account = IContractAccountDispatcher {
+                contract_address: ca_address.starknet
+            };
+            contract_account.is_false_positive_jumpdest(offset)
         }
 
         fn deploy_eoa(ref self: ContractState, evm_address: EthAddress) -> ContractAddress {

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -27,7 +27,7 @@ mod KakarotCore {
     use evm::execution::execute;
     use evm::model::account::{Account, AccountType, AccountTrait};
     use evm::model::contract_account::{ContractAccountTrait};
-    use evm::model::eoa::{EOA, EOATrait};
+    use evm::model::eoa::{EOATrait};
     use evm::model::{ExecutionResult, Address, AddressTrait};
     use starknet::{
         EthAddress, ContractAddress, ClassHash, get_tx_info, get_contract_address, deploy_syscall
@@ -222,7 +222,7 @@ mod KakarotCore {
         }
 
         fn deploy_eoa(ref self: ContractState, evm_address: EthAddress) -> ContractAddress {
-            EOATrait::deploy(evm_address).expect('EOA Deployment failed').starknet_address
+            EOATrait::deploy(evm_address).expect('EOA Deployment failed').starknet
         }
 
         fn eth_call(

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -354,6 +354,7 @@ mod KakarotCore {
                     let bytecode = data;
                     // TODO: compute_evm_address
                     // HASH(RLP(deployer_address, deployer_nonce))[0..20]
+                    //TODO manually set target account type to CA in state
                     panic_with_felt252('deploy tx flow unimplemented')
                 },
             }

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -13,7 +13,7 @@ use contracts::tests::test_utils as contract_utils;
 use contracts::uninitialized_account::UninitializedAccount;
 use evm::machine::Status;
 use evm::model::contract_account::ContractAccountTrait;
-use evm::model::{AccountType, Address, EOA};
+use evm::model::{AccountType, Address};
 use evm::tests::test_utils;
 use starknet::{testing, contract_address_const, ContractAddress, ClassHash};
 use utils::helpers::u256_to_bytes_array;

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -13,7 +13,7 @@ use contracts::tests::test_utils as contract_utils;
 use contracts::uninitialized_account::UninitializedAccount;
 use evm::machine::Status;
 use evm::model::contract_account::ContractAccountTrait;
-use evm::model::{AccountType, Address, EOA, ContractAccount};
+use evm::model::{AccountType, Address, EOA};
 use evm::tests::test_utils;
 use starknet::{testing, contract_address_const, ContractAddress, ClassHash};
 use utils::helpers::u256_to_bytes_array;
@@ -113,21 +113,13 @@ fn test_kakarot_core_eoa_mapping() {
     let expected_eoa_starknet_address = kakarot_core.deploy_eoa(test_utils::evm_address());
 
     // When
-    let eoa_starknet_address = kakarot_core.address_registry(test_utils::evm_address());
+    let (account_type, address) = kakarot_core
+        .address_registry(test_utils::evm_address())
+        .expect('should be in registry');
 
     // Then
-    assert(
-        eoa_starknet_address
-            .expect(
-                'should be in registry'
-            ) == AccountType::EOA(
-                EOA {
-                    evm_address: test_utils::evm_address(),
-                    starknet_address: expected_eoa_starknet_address
-                }
-            ),
-        'wrong starknet address'
-    );
+    assert(account_type == AccountType::EOA, 'wrong account_type address');
+    assert(address == expected_eoa_starknet_address, 'wrong address');
 
     let another_sn_address: ContractAddress = 0xbeef.try_into().unwrap();
 
@@ -137,16 +129,11 @@ fn test_kakarot_core_eoa_mapping() {
             test_utils::evm_address(), StoredAccountType::EOA(another_sn_address)
         );
 
-    assert(
-        kakarot_core
-            .address_registry(test_utils::evm_address())
-            .expect(
-                'should be in registry'
-            ) == AccountType::EOA(
-                EOA { evm_address: test_utils::evm_address(), starknet_address: another_sn_address }
-            ),
-        'wrong registry address'
-    );
+    let (account_type, address) = kakarot_core
+        .address_registry(test_utils::evm_address())
+        .expect('should be in registry');
+    assert(account_type == AccountType::EOA, 'wrong registry address2');
+    assert(address == another_sn_address, 'wrong address2');
 }
 
 #[test]

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -101,7 +101,7 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
         }
 
         target_account.set_nonce(1);
-        target_account.account_type = AccountType::ContractAccount;
+        target_account.set_type(AccountType::ContractAccount);
         target_account
             .address = Address { evm: target_address.evm, starknet: target_address.starknet };
         self.state.set_account(target_account);

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -165,13 +165,6 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
             },
             // Failure
             Status::Reverted => {
-                //TODO(accounts) (ENSURE THIS IS CORRECT)
-                // Reverts changes brought to cache in `init_create_sub_ctx`
-                // by reverting the nonce and the type
-                let mut account = self.state.get_account(account_address)?;
-                account.set_nonce(0);
-                account.set_type(AccountType::Unknown);
-                self.state.set_account(account);
                 self.return_to_parent_ctx();
                 self.stack.push(0)
             },

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -161,7 +161,6 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
                     account.account_type == AccountType::ContractAccount,
                     'type should be CA in finalize'
                 );
-                account.set_type(AccountType::ContractAccount);
                 self.state.set_account(account);
                 self.return_to_parent_ctx();
                 self.stack.push(account_address.into())

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -104,8 +104,7 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
 
         target_account.set_nonce(1);
         target_account.set_type(AccountType::ContractAccount);
-        target_account
-            .address = Address { evm: target_address.evm, starknet: target_address.starknet };
+        target_account.address = target_address;
         self.state.set_account(target_account);
 
         let call_ctx = CallContextTrait::new(
@@ -158,6 +157,10 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
 
                 let mut account = self.state.get_account(account_address)?;
                 account.set_code(return_data);
+                assert(
+                    account.account_type == AccountType::ContractAccount,
+                    'type should be CA in finalize'
+                );
                 account.set_type(AccountType::ContractAccount);
                 self.state.set_account(account);
                 self.return_to_parent_ctx();

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -242,12 +242,9 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         let account = self.state.get_account(evm_address)?;
         // UnknownAccount can either be
         // -> Undeployed CAs that might be deployed later, but currently don't
-        // exist
+        // exist and have only been touched for value transfers
         // -> Undeployed EOAs
-        // If a CA has a nonce equal to 0, it means that it has been selfdestructed in the same transaction.
-        if account.is_precompile()
-            || (account.account_type == AccountType::Unknown)
-            || (account.is_ca() && account.nonce == 0) {
+        if account.is_precompile() || (account.account_type == AccountType::Unknown) {
             return self.stack.push(0);
         }
         let bytecode = account.code;

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -240,7 +240,14 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         let evm_address = self.stack.pop_eth_address()?;
 
         let account = self.state.get_account(evm_address)?;
-        if (account.is_precompile() || (account.is_ca() && account.nonce == 0)) {
+        // UnknownAccount can either be
+        // -> Undeployed CAs that might be deployed later, but currently don't
+        // exist
+        // -> Undeployed EOAs
+        // If a CA has a nonce equal to 0, it means that it has been selfdestructed in the same transaction.
+        if account.is_precompile()
+            || (account.account_type == AccountType::Unknown)
+            || (account.is_ca() && account.nonce == 0) {
             return self.stack.push(0);
         }
         let bytecode = account.code;

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -7,6 +7,7 @@ use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::execution::Status;
 use evm::model::account::{Account, AccountTrait};
 use evm::model::contract_account::{ContractAccountTrait};
+use evm::model::eoa::EOATrait;
 use evm::state::State;
 use openzeppelin::token::erc20::interface::{
     IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -6,7 +6,7 @@ use contracts::kakarot_core::{KakarotCore, IKakarotCore};
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::execution::Status;
 use evm::model::account::{Account, AccountTrait};
-use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
+use evm::model::contract_account::{ContractAccountTrait};
 use evm::model::eoa::{EOA, EOATrait};
 use evm::state::State;
 use openzeppelin::token::erc20::interface::{
@@ -67,6 +67,7 @@ struct ExecutionResult {
 /// KakarotCore address for ContractAccounts.
 #[derive(Copy, Drop, PartialEq, Serde)]
 enum AccountType {
-    EOA: EOA,
-    ContractAccount: ContractAccount,
+    EOA,
+    ContractAccount,
+    Unknown
 }

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -31,6 +31,15 @@ struct Address {
 
 #[generate_trait]
 impl AddressImpl of AddressTrait {
+    fn is_registered(evm_address: EthAddress) -> bool {
+        let mut kakarot_state = KakarotCore::unsafe_new_contract_state();
+        let maybe_account = kakarot_state.address_registry(evm_address);
+        match maybe_account {
+            Option::Some(_) => true,
+            Option::None => false
+        }
+    }
+
     fn balance(self: @Address) -> Result<u256, EVMError> {
         let kakarot_state = KakarotCore::unsafe_new_contract_state();
         let native_token_address = kakarot_state.native_token();

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -7,7 +7,6 @@ use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::execution::Status;
 use evm::model::account::{Account, AccountTrait};
 use evm::model::contract_account::{ContractAccountTrait};
-use evm::model::eoa::{EOA, EOATrait};
 use evm::state::State;
 use openzeppelin::token::erc20::interface::{
     IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -93,7 +93,7 @@ impl AccountImpl of AccountTrait {
                             }
                         )
                     },
-                    AccountType::Unknown(_) => Option::None,
+                    AccountType::Unknown => Option::None,
                 }
             },
             Option::None => Option::None,

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -1,15 +1,19 @@
 use contracts::kakarot_core::kakarot::StoredAccountType;
 use contracts::kakarot_core::{KakarotCore, IKakarotCore};
-use evm::errors::{EVMError};
-use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
+use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
+use evm::model::contract_account::{ContractAccountTrait};
 use evm::model::eoa::{EOA, EOATrait};
 use evm::model::{Address, AccountType};
 use starknet::{ContractAddress, EthAddress, get_contract_address};
-use utils::helpers::{ByteArrayExTrait, compute_starknet_address};
+use utils::helpers::{ResultExTrait, ByteArrayExTrait, compute_starknet_address};
+use openzeppelin::token::erc20::interface::{
+    IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait
+};
 
 #[derive(Copy, Drop, PartialEq)]
 struct Account {
     account_type: AccountType,
+    address: Address,
     code: Span<u8>,
     nonce: u64,
     selfdestruct: bool,
@@ -39,9 +43,8 @@ impl AccountImpl of AccountTrait {
                     // Therefore, we're sure that only contract accounts are
                     // undeployed.
                     Account {
-                        account_type: AccountType::ContractAccount(
-                            ContractAccount { evm_address, starknet_address }
-                        ),
+                        account_type: AccountType::Unknown,
+                        address: Address { starknet: starknet_address, evm: evm_address, },
                         code: Default::default().span(),
                         nonce: 0,
                         selfdestruct: false,
@@ -65,26 +68,32 @@ impl AccountImpl of AccountTrait {
         let mut kakarot_state = KakarotCore::unsafe_new_contract_state();
         let maybe_stored_account = kakarot_state.address_registry(evm_address);
         let mut account = match maybe_stored_account {
-            Option::Some(account_type) => {
+            Option::Some((
+                account_type, starknet_address
+            )) => {
                 match account_type {
-                    AccountType::EOA(eoa) => Option::Some(
+                    AccountType::EOA => Option::Some(
                         Account {
-                            account_type: AccountType::EOA(eoa),
+                            account_type: AccountType::EOA,
+                            address: Address { evm: evm_address, starknet: starknet_address },
                             code: Default::default().span(),
                             nonce: 1,
                             selfdestruct: false,
                         }
                     ),
-                    AccountType::ContractAccount(ca) => {
+                    AccountType::ContractAccount => {
+                        let address = Address { evm: evm_address, starknet: starknet_address };
                         Option::Some(
                             Account {
-                                account_type: AccountType::ContractAccount(ca),
-                                code: ca.load_bytecode()?,
-                                nonce: ca.nonce()?,
+                                account_type: AccountType::ContractAccount,
+                                address,
+                                code: ContractAccountTrait::fetch_bytecode(@address)?,
+                                nonce: ContractAccountTrait::fetch_nonce(@address)?,
                                 selfdestruct: false,
                             }
                         )
-                    }
+                    },
+                    AccountType::Unknown(_) => Option::None,
                 }
             },
             Option::None => Option::None,
@@ -126,14 +135,15 @@ impl AccountImpl of AccountTrait {
                     // no - op
                     Result::Ok(())
                 },
-                AccountType::ContractAccount(ca) => {
-                    let mut ca = *ca;
+                AccountType::ContractAccount => {
+                    let mut ca_address = self.address();
                     if *self.selfdestruct {
-                        return ca.selfdestruct();
+                        return ca_address.selfdestruct();
                     }
-                    ca.set_nonce(*self.nonce)
+                    ca_address.store_nonce(*self.nonce)
                 //Storage is handled outside of the account and must be commited after all accounts are commited.
-                }
+                },
+                AccountType::Unknown => { Result::Ok(()) }
             }
         } else if self.should_deploy() {
             //Case new account
@@ -141,8 +151,8 @@ impl AccountImpl of AccountTrait {
             if (*self.selfdestruct == true) {
                 return Result::Ok(());
             };
-            let mut ca = ContractAccountTrait::deploy(self.address().evm, *self.code)?;
-            ca.set_nonce(*self.nonce)
+            let mut ca_address = ContractAccountTrait::deploy(self.address().evm, *self.code)?;
+            ca_address.store_nonce(*self.nonce)
         //Storage is handled outside of the account and must be commited after all accounts are commited.
         } else {
             Result::Ok(())
@@ -151,10 +161,7 @@ impl AccountImpl of AccountTrait {
 
     #[inline(always)]
     fn address(self: @Account) -> Address {
-        match self.account_type {
-            AccountType::EOA(eoa) => { eoa.address() },
-            AccountType::ContractAccount(ca) => { ca.address() }
-        }
+        *self.address
     }
 
     #[inline(always)]
@@ -185,40 +192,33 @@ impl AccountImpl of AccountTrait {
         }
     }
 
-    /// Returns `true` if the account is an Externally Owned Account (EOA).
-    #[inline(always)]
-    fn is_eoa(self: @Account) -> bool {
-        match self.account_type {
-            AccountType::EOA => true,
-            AccountType::ContractAccount => false
-        }
-    }
-
     /// Returns `true` if the account is a Contract Account (CA).
     #[inline(always)]
     fn is_ca(self: @Account) -> bool {
         match self.account_type {
             AccountType::EOA => false,
-            AccountType::ContractAccount => true
+            AccountType::ContractAccount => true,
+            AccountType::Unknown => false
         }
     }
 
     #[inline(always)]
     fn evm_address(self: @Account) -> EthAddress {
-        match self.account_type {
-            AccountType::EOA(eoa) => { eoa.evm_address() },
-            AccountType::ContractAccount(ca) => { ca.evm_address() }
-        }
+        self.address().evm
     }
 
     /// Returns the balance in native token for a given EVM account (EOA or CA)
     /// This is equivalent to checking the balance in native coin, i.e. ETHER of an account in Ethereum
     #[inline(always)]
     fn balance(self: @Account) -> Result<u256, EVMError> {
-        match self.account_type {
-            AccountType::EOA(eoa) => { eoa.balance() },
-            AccountType::ContractAccount(ca) => { ca.balance() }
-        }
+        let kakarot_state = KakarotCore::unsafe_new_contract_state();
+        let native_token_address = kakarot_state.native_token();
+        let native_token = IERC20CamelSafeDispatcher { contract_address: native_token_address };
+        //Note: Starknet OS doesn't allow error management of failed syscalls yet.
+        // If this call fails, the entire transaction will revert.
+        native_token
+            .balanceOf(self.address().starknet)
+            .map_err(EVMError::SyscallFailed(CONTRACT_SYSCALL_FAILED))
     }
 
     /// Returns the bytecode of the EVM account (EOA or CA)
@@ -240,9 +240,15 @@ impl AccountImpl of AccountTrait {
     #[inline(always)]
     fn read_storage(self: @Account, key: u256) -> Result<u256, EVMError> {
         match self.account_type {
-            AccountType::EOA(eoa) => Result::Ok(0),
-            AccountType::ContractAccount(ca) => ca.storage_at(key),
+            AccountType::EOA => Result::Ok(0),
+            AccountType::ContractAccount => self.address().fetch_storage(key),
+            AccountType::Unknown(_) => Result::Ok(0),
         }
+    }
+
+    #[inline(always)]
+    fn set_type(ref self: Account, account_type: AccountType) {
+        self.account_type = account_type;
     }
 
     /// Sets the nonce of the Account

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -2,13 +2,12 @@ use contracts::kakarot_core::kakarot::StoredAccountType;
 use contracts::kakarot_core::{KakarotCore, IKakarotCore};
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::model::contract_account::{ContractAccountTrait};
-use evm::model::eoa::{EOA, EOATrait};
 use evm::model::{Address, AccountType};
-use starknet::{ContractAddress, EthAddress, get_contract_address};
-use utils::helpers::{ResultExTrait, ByteArrayExTrait, compute_starknet_address};
 use openzeppelin::token::erc20::interface::{
     IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait
 };
+use starknet::{ContractAddress, EthAddress, get_contract_address};
+use utils::helpers::{ResultExTrait, ByteArrayExTrait, compute_starknet_address};
 
 #[derive(Copy, Drop, PartialEq)]
 struct Account {

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -1,3 +1,4 @@
+use contracts::kakarot_core::kakarot::KakarotCore::KakarotCoreInternal;
 use contracts::kakarot_core::kakarot::StoredAccountType;
 use contracts::kakarot_core::{KakarotCore, IKakarotCore};
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
@@ -136,6 +137,11 @@ impl AccountImpl of AccountTrait {
                 AccountType::ContractAccount => {
                     let mut ca_address = self.address();
                     if *self.selfdestruct {
+                        let mut kakarot_state = KakarotCore::unsafe_new_contract_state();
+                        kakarot_state
+                            .set_address_registry(
+                                ca_address.evm, StoredAccountType::UnexistingAccount
+                            );
                         return ca_address.selfdestruct();
                     }
                     ca_address.store_nonce(*self.nonce)

--- a/crates/evm/src/model/contract_account.cairo
+++ b/crates/evm/src/model/contract_account.cairo
@@ -21,8 +21,7 @@ use evm::errors::{
     CONTRACT_ACCOUNT_EXISTS, CONTRACT_SYSCALL_FAILED
 };
 use evm::execution::execute;
-use evm::model::account::{Address, Account, AccountTrait};
-use evm::model::{AccountType};
+use evm::model::{Address, AccountType};
 use hash::{HashStateTrait, HashStateExTrait};
 use openzeppelin::token::erc20::interface::{
     IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait

--- a/crates/evm/src/model/eoa.cairo
+++ b/crates/evm/src/model/eoa.cairo
@@ -10,12 +10,6 @@ use evm::model::{AccountType, Address};
 use integer::BoundedInt;
 use starknet::{EthAddress, ContractAddress, get_contract_address, deploy_syscall};
 
-#[derive(Copy, Drop, PartialEq, Serde)]
-struct EOA {
-    evm_address: EthAddress,
-    starknet_address: ContractAddress
-}
-
 #[generate_trait]
 impl EOAImpl of EOATrait {
     /// Deploys a new EOA contract.
@@ -23,7 +17,7 @@ impl EOAImpl of EOATrait {
     /// # Arguments
     ///
     /// * `evm_address` - The EVM address of the EOA to deploy.
-    fn deploy(evm_address: EthAddress) -> Result<EOA, EVMError> {
+    fn deploy(evm_address: EthAddress) -> Result<Address, EVMError> {
         // Unlike CAs, there is not check for the existence of an EOA prealably to calling `EOATrait::deploy` - therefore, we need to check that there is no collision.
         let mut is_deployed = AccountTrait::is_deployed(evm_address);
         if is_deployed {
@@ -49,21 +43,9 @@ impl EOAImpl of EOATrait {
                 kakarot_state
                     .set_address_registry(evm_address, StoredAccountType::EOA(starknet_address));
                 kakarot_state.emit(EOADeployed { evm_address, starknet_address });
-                Result::Ok(EOA { evm_address, starknet_address })
+                Result::Ok(Address { evm: evm_address, starknet: starknet_address })
             },
             Result::Err(err) => panic(err)
         }
-    }
-
-    fn address(self: @EOA) -> Address {
-        Address { evm: *self.evm_address, starknet: *self.starknet_address }
-    }
-
-    fn evm_address(self: @EOA) -> EthAddress {
-        *self.evm_address
-    }
-
-    fn starknet_address(self: @EOA) -> ContractAddress {
-        *self.starknet_address
     }
 }

--- a/crates/evm/src/model/eoa.cairo
+++ b/crates/evm/src/model/eoa.cairo
@@ -5,9 +5,7 @@ use contracts::uninitialized_account::{
     IUninitializedAccountDispatcher, IUninitializedAccountDispatcherTrait
 };
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED, EOA_EXISTS};
-use evm::model::account::{Account, AccountTrait};
-use evm::model::{AccountType, Address};
-use integer::BoundedInt;
+use evm::model::{Address, AddressTrait};
 use starknet::{EthAddress, ContractAddress, get_contract_address, deploy_syscall};
 
 #[generate_trait]
@@ -19,7 +17,7 @@ impl EOAImpl of EOATrait {
     /// * `evm_address` - The EVM address of the EOA to deploy.
     fn deploy(evm_address: EthAddress) -> Result<Address, EVMError> {
         // Unlike CAs, there is not check for the existence of an EOA prealably to calling `EOATrait::deploy` - therefore, we need to check that there is no collision.
-        let mut is_deployed = AccountTrait::is_deployed(evm_address);
+        let mut is_deployed = AddressTrait::is_registered(evm_address);
         if is_deployed {
             return Result::Err(EVMError::DeployError(EOA_EXISTS));
         }

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -5,7 +5,7 @@ use evm::errors::{
 };
 use evm::model::account::{AccountTrait};
 use evm::model::contract_account::ContractAccountTrait;
-use evm::model::{Event, Transfer, Account, EOA, AccountType, Address, AddressTrait};
+use evm::model::{Event, Transfer, Account, AccountType, Address, AddressTrait};
 use hash::{HashStateTrait, HashStateExTrait};
 use integer::{u256_overflow_sub, u256_overflowing_add};
 use nullable::{match_nullable, FromNullableResult};

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -1,5 +1,4 @@
 use contracts::kakarot_core::{IKakarotCore, KakarotCore};
-use debug::PrintTrait;
 use evm::errors::{
     EVMError, WRITE_SYSCALL_FAILED, READ_SYSCALL_FAILED, INSUFFICIENT_BALANCE, BALANCE_OVERFLOW
 };

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -350,7 +350,7 @@ impl StateInternalImpl of StateInternalTrait {
                                     panic_with_felt252('EOA account commitment')
                                 },
                                 AccountType::ContractAccount => {
-                                    account.address().store_storage(key, value);
+                                    account.store_storage(key, value);
                                 },
                                 AccountType::Unknown(_) => {
                                     panic_with_felt252('Unknown account commitment')

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -5,9 +5,7 @@ use evm::errors::{
 };
 use evm::model::account::{AccountTrait};
 use evm::model::contract_account::ContractAccountTrait;
-use evm::model::{
-    Event, Transfer, Account, ContractAccount, EOA, AccountType, Address, AddressTrait
-};
+use evm::model::{Event, Transfer, Account, EOA, AccountType, Address, AddressTrait};
 use hash::{HashStateTrait, HashStateExTrait};
 use integer::{u256_overflow_sub, u256_overflowing_add};
 use nullable::{match_nullable, FromNullableResult};
@@ -349,10 +347,15 @@ impl StateInternalImpl of StateInternalTrait {
                             let account_type = account.account_type;
                             match account_type {
                                 //this shouldn't ever happen
-                                AccountType::EOA(_) => { panic_with_felt252('EOA storagechange') },
-                                AccountType::ContractAccount(mut ca) => {
-                                    ca.set_storage_at(key, value);
+                                AccountType::EOA => {
+                                    panic_with_felt252('EOA account commitment')
                                 },
+                                AccountType::ContractAccount => {
+                                    account.address().store_storage(key, value);
+                                },
+                                AccountType::Unknown(_) => {
+                                    panic_with_felt252('Unknown account commitment')
+                                }
                             }
                         },
                         Result::Err(err) => { break Result::Err(err); }

--- a/crates/evm/src/tests.cairo
+++ b/crates/evm/src/tests.cairo
@@ -1,19 +1,19 @@
-// mod test_create_helpers;
+mod test_create_helpers;
 
-// mod test_execution;
+mod test_execution;
 
-// mod test_execution_context;
+mod test_execution_context;
 
 mod test_instructions;
 
-// mod test_machine;
+mod test_machine;
 
-// mod test_memory;
+mod test_memory;
 
-// mod test_model;
+mod test_model;
 
-// mod test_stack;
+mod test_stack;
 
-// mod test_state;
+mod test_state;
 
 mod test_utils;

--- a/crates/evm/src/tests.cairo
+++ b/crates/evm/src/tests.cairo
@@ -1,19 +1,19 @@
-mod test_create_helpers;
+// mod test_create_helpers;
 
-mod test_execution;
+// mod test_execution;
 
-mod test_execution_context;
+// mod test_execution_context;
 
 mod test_instructions;
 
-mod test_machine;
+// mod test_machine;
 
-mod test_memory;
+// mod test_memory;
 
-mod test_model;
+// mod test_model;
 
-mod test_stack;
+// mod test_stack;
 
-mod test_state;
+// mod test_state;
 
 mod test_utils;

--- a/crates/evm/src/tests/test_execution.cairo
+++ b/crates/evm/src/tests/test_execution.cairo
@@ -17,8 +17,8 @@ fn test_execute_load_origin_nonce() {
     set_nonce(1337);
     // When
     let mut exec_result = execute(
-        origin: sender.address(),
-        target: recipient.address(),
+        origin: sender,
+        target: recipient,
         bytecode: Default::default().span(),
         calldata: Default::default().span(),
         value: 0,
@@ -33,7 +33,7 @@ fn test_execute_load_origin_nonce() {
 
     let origin_account = exec_result
         .state
-        .get_account(sender.address().evm)
+        .get_account(sender.evm)
         .expect('couldnt get origin account');
 
     assert(origin_account.nonce == 1337, 'wrong origin nonce');
@@ -48,11 +48,11 @@ fn test_execute_value_transfer() {
     let sender = EOATrait::deploy(evm_address()).expect('sender deploy failed');
     let recipient = EOATrait::deploy(other_evm_address()).expect('recipient deploy failed');
     // Transfer native tokens to sender
-    contract_utils::fund_account_with_native_token(sender.starknet_address, native_token, 10000);
+    contract_utils::fund_account_with_native_token(sender.starknet, native_token, 10000);
     // When
     let mut exec_result = execute(
-        origin: sender.address(),
-        target: recipient.address(),
+        origin: sender,
+        target: recipient,
         bytecode: Default::default().span(),
         calldata: Default::default().span(),
         value: 2000,
@@ -67,8 +67,8 @@ fn test_execute_value_transfer() {
     // `commit_state` is applied in `eth_send_tx` only - to test that `execute` worked correctly, we manually apply it here.
     exec_result.state.commit_state();
 
-    let sender_balance = native_token.balanceOf(sender.starknet_address);
-    let recipient_balance = native_token.balanceOf(recipient.starknet_address);
+    let sender_balance = native_token.balanceOf(sender.starknet);
+    let recipient_balance = native_token.balanceOf(recipient.starknet);
 
     assert(sender_balance == 8000, 'wrong sender balance');
     assert(recipient_balance == 2000, 'wrong recipient balance');

--- a/crates/evm/src/tests/test_instructions.cairo
+++ b/crates/evm/src/tests/test_instructions.cairo
@@ -1,12 +1,12 @@
-// mod test_block_information;
-// mod test_comparison_operations;
-// mod test_duplication_operations;
+mod test_block_information;
+mod test_comparison_operations;
+mod test_duplication_operations;
 mod test_environment_information;
-// mod test_exchange_operations;
-// mod test_logging_operations;
-// mod test_memory_operations;
-// mod test_push_operations;
-// mod test_sha3;
-// mod test_stop_and_arithmetic_operations;
-// mod test_system_operations;
+mod test_exchange_operations;
+mod test_logging_operations;
+mod test_memory_operations;
+mod test_push_operations;
+mod test_sha3;
+mod test_stop_and_arithmetic_operations;
+mod test_system_operations;
 

--- a/crates/evm/src/tests/test_instructions.cairo
+++ b/crates/evm/src/tests/test_instructions.cairo
@@ -1,11 +1,12 @@
-mod test_block_information;
-mod test_comparison_operations;
-mod test_duplication_operations;
+// mod test_block_information;
+// mod test_comparison_operations;
+// mod test_duplication_operations;
 mod test_environment_information;
-mod test_exchange_operations;
-mod test_logging_operations;
-mod test_memory_operations;
-mod test_push_operations;
-mod test_sha3;
-mod test_stop_and_arithmetic_operations;
-mod test_system_operations;
+// mod test_exchange_operations;
+// mod test_logging_operations;
+// mod test_memory_operations;
+// mod test_push_operations;
+// mod test_sha3;
+// mod test_stop_and_arithmetic_operations;
+// mod test_system_operations;
+

--- a/crates/evm/src/tests/test_instructions/test_block_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_block_information.cairo
@@ -4,6 +4,7 @@ use contracts::kakarot_core::interface::{
 
 use contracts::tests::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
 use evm::instructions::BlockInformationTrait;
+use evm::model::contract_account::ContractAccountTrait;
 use evm::stack::StackTrait;
 use evm::tests::test_utils::{setup_machine, evm_address};
 use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
@@ -146,17 +147,15 @@ fn test_exec_selfbalance_zero() {
     assert(machine.stack.peek().unwrap() == 0x00, 'wrong balance');
 }
 
-// TODO: implement balance once contracts accounts can be deployed
-#[ignore]
 #[test]
 #[available_gas(5000000)]
 fn test_exec_selfbalance_contract_account() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    // TODO: deploy contract account
-    // and fund it
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
+        .expect('failed deploy contract account',);
 
-    // And
+    fund_account_with_native_token(ca_address.starknet, native_token, 0x1);
     let mut machine = setup_machine();
 
     // When
@@ -164,7 +163,7 @@ fn test_exec_selfbalance_contract_account() {
     machine.exec_selfbalance();
 
     // Then
-    panic_with_felt252('Not implemented yet');
+    assert(machine.stack.peek().unwrap() == 0x1, 'wrong balance');
 }
 
 

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -7,6 +7,7 @@ use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::memory::{InternalMemoryTrait, MemoryTrait};
 use evm::model::contract_account::ContractAccountTrait;
 use evm::stack::StackTrait;
+use evm::state::StateTrait;
 use evm::tests::test_utils::{
     setup_machine, setup_machine_with_calldata, setup_machine_with_bytecode, evm_address, callvalue,
     setup_machine_with_nested_execution_context, return_from_subcontext, native_token, other_address
@@ -959,6 +960,7 @@ fn test_exec_extcodehash_eoa() {
     );
 }
 
+
 #[test]
 #[available_gas(20000000)]
 fn test_exec_extcodehash_ca_empty() {
@@ -986,7 +988,7 @@ fn test_exec_extcodehash_ca_empty() {
 
 #[test]
 #[available_gas(20000000)]
-fn test_exec_extcodehash_ca_uninitialized() {
+fn test_exec_extcodehash_unknown_account() {
     // Given
     let evm_address = evm_address();
     let mut machine = setup_machine();

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -924,7 +924,7 @@ fn test_exec_extcodehash_selfdestructed() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode remains empty, and we expect the empty hash in return
-    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
+    let mut ca_address = ContractAccountTrait::deploy(evm_address, array![].span())
         .expect('CA deployment failed');
     ca_address.selfdestruct().expect('CA selfdestruct failed');
 
@@ -934,7 +934,13 @@ fn test_exec_extcodehash_selfdestructed() {
     machine.exec_extcodehash().unwrap();
 
     // Then
-    assert(machine.stack.peek().unwrap() == 0, 'expected 0');
+    assert(
+        machine
+            .stack
+            .peek()
+            .unwrap() == 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
+        'expected empty hash'
+    );
 }
 
 #[test]

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -577,7 +577,7 @@ fn test_exec_extcodesize_ca_empty() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode remains empty, and we expect the empty hash in return
-    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span());
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span());
 
     machine.stack.push(evm_address.into());
 
@@ -598,7 +598,7 @@ fn test_exec_extcodesize_ca_with_bytecode() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode stored is the bytecode of a Counter.sol smart contract
-    let mut ca = ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
+    ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
 
     machine.stack.push(evm_address.into());
     // When
@@ -622,7 +622,7 @@ fn test_exec_extcodecopy_ca() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode stored is the bytecode of a Counter.sol smart contract
-    let mut ca = ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
+    ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
 
     // size
     machine.stack.push(50).unwrap();
@@ -653,7 +653,7 @@ fn test_exec_extcodecopy_ca_offset_out_of_bounds() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode stored is the bytecode of a Counter.sol smart contract
-    let mut ca = ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
+    ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
 
     // size
     machine.stack.push(5);
@@ -923,9 +923,9 @@ fn test_exec_extcodehash_selfdestructed() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode remains empty, and we expect the empty hash in return
-    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span())
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
         .expect('CA deployment failed');
-    ca.selfdestruct().expect('CA selfdestruct failed');
+    ca_address.selfdestruct().expect('CA selfdestruct failed');
 
     machine.stack.push(evm_address.into());
 
@@ -967,7 +967,7 @@ fn test_exec_extcodehash_ca_empty() {
     let mut machine = setup_machine();
     let (native_token, kakarot_core) = setup_contracts_for_testing();
     // The bytecode remains empty, and we expect the empty hash in return
-    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span());
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span());
 
     machine.stack.push(evm_address.into());
 
@@ -1011,7 +1011,7 @@ fn test_exec_extcodehash_ca_with_bytecode() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // The bytecode stored is the bytecode of a Counter.sol smart contract
-    let mut ca = ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), counter_evm_bytecode());
 
     machine.stack.push(evm_address.into());
     // When

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -6,6 +6,7 @@ use evm::instructions::EnvironmentInformationTrait;
 use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::memory::{InternalMemoryTrait, MemoryTrait};
 use evm::model::contract_account::ContractAccountTrait;
+use evm::model::{Account, AccountType};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
 use evm::tests::test_utils::{
@@ -926,7 +927,14 @@ fn test_exec_extcodehash_selfdestructed() {
     // The bytecode remains empty, and we expect the empty hash in return
     let mut ca_address = ContractAccountTrait::deploy(evm_address, array![].span())
         .expect('CA deployment failed');
-    ca_address.selfdestruct().expect('CA selfdestruct failed');
+    let account = Account {
+        account_type: AccountType::ContractAccount,
+        address: ca_address,
+        code: array![].span(),
+        nonce: 1,
+        selfdestruct: false
+    };
+    account.selfdestruct().expect('CA selfdestruct failed');
 
     machine.stack.push(evm_address.into());
 

--- a/crates/evm/src/tests/test_instructions/test_environment_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_environment_information.cairo
@@ -87,15 +87,15 @@ fn test_exec_balance_zero() {
     assert(machine.stack.peek().unwrap() == 0x00, 'wrong balance');
 }
 
-// TODO: implement balance once contracts accounts can be deployed
-#[ignore]
 #[test]
 #[available_gas(5000000)]
 fn test_exec_balance_contract_account() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    // TODO: deploy contract account
-    // and fund it
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
+        .expect('failed deploy contract account',);
+
+    fund_account_with_native_token(ca_address.starknet, native_token, 0x1);
 
     // And
     let mut machine = setup_machine();
@@ -106,7 +106,7 @@ fn test_exec_balance_contract_account() {
     machine.exec_balance();
 
     // Then
-    panic_with_felt252('Not implemented yet');
+    assert(machine.stack.peek().unwrap() == 0x1, 'wrong balance');
 }
 
 

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -3,7 +3,7 @@ use evm::errors::{EVMError, STACK_UNDERFLOW, INVALID_DESTINATION, WRITE_IN_STATI
 use evm::instructions::{MemoryOperationTrait, EnvironmentInformationTrait};
 use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::memory::{InternalMemoryTrait, MemoryTrait};
-use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
+use evm::model::contract_account::{ContractAccountTrait};
 use evm::stack::StackTrait;
 use evm::state::{StateTrait, StateInternalTrait, compute_storage_address};
 use evm::tests::test_utils::{
@@ -525,10 +525,11 @@ fn test_exec_sload_from_storage() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
     let mut machine = setup_machine();
-    let mut ca = ContractAccountTrait::deploy(machine.address().evm, array![].span()).unwrap();
+    let mut ca_address = ContractAccountTrait::deploy(machine.address().evm, array![].span())
+        .unwrap();
     let key: u256 = 0x100000000000000000000000000000001;
     let value: u256 = 0xABDE1E11A5;
-    ca.set_storage_at(key, value);
+    ca_address.store_storage(key, value);
 
     machine.stack.push(key.into());
 
@@ -588,7 +589,7 @@ fn test_exec_sstore_finalized() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
     let mut machine = setup_machine();
     // Deploys the contract account to be able to commit storage changes.
-    let ca = ContractAccountTrait::deploy(machine.address().evm, array![].span()).unwrap();
+    let ca_address = ContractAccountTrait::deploy(machine.address().evm, array![].span()).unwrap();
     let key: u256 = 0x100000000000000000000000000000001;
     let value: u256 = 0xABDE1E11A5;
     machine.stack.push(value);
@@ -600,7 +601,7 @@ fn test_exec_sstore_finalized() {
     machine.state.commit_storage();
 
     // Then
-    assert(ca.storage_at(key).unwrap() == value, 'wrong value in journal')
+    assert(ca_address.fetch_storage(key).unwrap() == value, 'wrong value in journal')
 }
 
 #[test]

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -4,6 +4,7 @@ use evm::instructions::{MemoryOperationTrait, EnvironmentInformationTrait};
 use evm::machine::{Machine, MachineCurrentContextTrait};
 use evm::memory::{InternalMemoryTrait, MemoryTrait};
 use evm::model::contract_account::{ContractAccountTrait};
+use evm::model::{Account, AccountType};
 use evm::stack::StackTrait;
 use evm::state::{StateTrait, StateInternalTrait, compute_storage_address};
 use evm::tests::test_utils::{
@@ -527,9 +528,16 @@ fn test_exec_sload_from_storage() {
     let mut machine = setup_machine();
     let mut ca_address = ContractAccountTrait::deploy(machine.address().evm, array![].span())
         .unwrap();
+    let account = Account {
+        account_type: AccountType::ContractAccount,
+        address: ca_address,
+        code: array![0xab, 0xcd, 0xef].span(),
+        nonce: 1,
+        selfdestruct: false
+    };
     let key: u256 = 0x100000000000000000000000000000001;
     let value: u256 = 0xABDE1E11A5;
-    ca_address.store_storage(key, value);
+    account.store_storage(key, value);
 
     machine.stack.push(key.into());
 
@@ -590,6 +598,13 @@ fn test_exec_sstore_finalized() {
     let mut machine = setup_machine();
     // Deploys the contract account to be able to commit storage changes.
     let ca_address = ContractAccountTrait::deploy(machine.address().evm, array![].span()).unwrap();
+    let account = Account {
+        account_type: AccountType::ContractAccount,
+        address: ca_address,
+        code: array![].span(),
+        nonce: 1,
+        selfdestruct: false
+    };
     let key: u256 = 0x100000000000000000000000000000001;
     let value: u256 = 0xABDE1E11A5;
     machine.stack.push(value);
@@ -601,7 +616,7 @@ fn test_exec_sstore_finalized() {
     machine.state.commit_storage();
 
     // Then
-    assert(ca_address.fetch_storage(key).unwrap() == value, 'wrong value in journal')
+    assert(account.fetch_storage(key).unwrap() == value, 'wrong value in journal')
 }
 
 #[test]

--- a/crates/evm/src/tests/test_instructions/test_system_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_system_operations.cairo
@@ -404,7 +404,7 @@ fn test_exec_create2() {
         .expect('failed deploying CA');
 
     let mut ctx = machine.current_ctx.unbox();
-    ctx.address = contract_address.address();
+    ctx.address = contract_address;
     ctx.ctx_type = ExecutionContextType::Create(ctx.id());
     machine.current_ctx = BoxTrait::new(ctx);
 

--- a/crates/evm/src/tests/test_instructions/test_system_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_system_operations.cairo
@@ -392,9 +392,6 @@ fn test_exec_create2() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
-    let evm_address = evm_address();
-    let eoa = kakarot_core.deploy_eoa(evm_address);
-
     let mut machine = setup_machine_with_nested_execution_context();
     let mut interpreter = EVMInterpreterTrait::new();
 

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -92,7 +92,6 @@ fn test_address_balance_eoa() {
 }
 
 
-#[ignore]
 #[test]
 #[available_gas(5000000)]
 fn test_account_balance_contract_account() {
@@ -111,7 +110,6 @@ fn test_account_balance_contract_account() {
     assert(balance == native_token.balanceOf(ca_address.starknet), 'wrong balance');
 }
 
-#[ignore]
 #[test]
 #[available_gas(5000000)]
 fn test_address_balance_contract_account() {

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -85,7 +85,7 @@ fn test_address_balance_eoa() {
     // When
     set_contract_address(kakarot_core.contract_address);
     let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
-    let balance = account.address().balance().unwrap();
+    let balance = account.balance().unwrap();
 
     // Then
     assert(balance == native_token.balanceOf(eoa_address.starknet), 'wrong balance');
@@ -167,7 +167,7 @@ fn test_address_balance_contract_account() {
 
     // When
     let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
-    let balance = account.address().balance().unwrap();
+    let balance = account.balance().unwrap();
 
     // Then
     // Then

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -3,9 +3,7 @@ mod test_eoa;
 use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::tests::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
 use evm::model::account::AccountTrait;
-use evm::model::{
-    Account, ContractAccountTrait, AccountType, EOA, ContractAccount, EOATrait, AddressTrait
-};
+use evm::model::{Account, ContractAccountTrait, AccountType, EOA, EOATrait, AddressTrait};
 use evm::tests::test_utils::{evm_address};
 use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use starknet::testing::set_contract_address;
@@ -32,7 +30,7 @@ fn test_is_deployed_eoa_exists() {
 fn test_is_deployed_ca_exists() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let ca = ContractAccountTrait::deploy(evm_address(), array![].span())
+    ContractAccountTrait::deploy(evm_address(), array![].span())
         .expect('failed deploy contract account',);
 
     // When
@@ -100,17 +98,17 @@ fn test_address_balance_eoa() {
 fn test_account_balance_contract_account() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span())
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
         .expect('failed deploy contract account',);
 
-    fund_account_with_native_token(ca.starknet_address, native_token, 0x1);
+    fund_account_with_native_token(ca_address.starknet, native_token, 0x1);
 
     // When
     let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
     let balance = account.balance().unwrap();
 
     // Then
-    assert(balance == native_token.balanceOf(ca.starknet_address), 'wrong balance');
+    assert(balance == native_token.balanceOf(ca_address.starknet), 'wrong balance');
 }
 
 #[ignore]
@@ -119,10 +117,10 @@ fn test_account_balance_contract_account() {
 fn test_address_balance_contract_account() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let mut ca = ContractAccountTrait::deploy(evm_address(), array![].span())
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
         .expect('failed deploy contract account',);
 
-    fund_account_with_native_token(ca.starknet_address, native_token, 0x1);
+    fund_account_with_native_token(ca_address.starknet, native_token, 0x1);
 
     // When
     let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
@@ -130,5 +128,5 @@ fn test_address_balance_contract_account() {
 
     // Then
     // Then
-    assert(balance == native_token.balanceOf(ca.starknet_address), 'wrong balance');
+    assert(balance == native_token.balanceOf(ca_address.starknet), 'wrong balance');
 }

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -10,7 +10,7 @@ use starknet::testing::set_contract_address;
 
 #[test]
 #[available_gas(20000000)]
-fn test_is_deployed_eoa_exists() {
+fn test_is_registered_eoa_exists() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
     let eoa_address = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
@@ -19,39 +19,39 @@ fn test_is_deployed_eoa_exists() {
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let is_deployed = AccountTrait::is_deployed(evm_address());
+    let is_registered = AddressTrait::is_registered(evm_address());
 
     // Then
-    assert(is_deployed, 'account should be deployed');
+    assert(is_registered, 'account should be deployed');
 }
 
 #[test]
 #[available_gas(20000000)]
-fn test_is_deployed_ca_exists() {
+fn test_is_registered_ca_exists() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
     ContractAccountTrait::deploy(evm_address(), array![].span())
         .expect('failed deploy contract account',);
 
     // When
-    let is_deployed = AccountTrait::is_deployed(evm_address());
+    let is_registered = AddressTrait::is_registered(evm_address());
 
     // Then
-    assert(is_deployed, 'account should be deployed');
+    assert(is_registered, 'account should be deployed');
 }
 
 #[test]
 #[available_gas(20000000)]
-fn test_is_deployed_undeployed() {
+fn test_is_registered_undeployed() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
 
     // When
     set_contract_address(kakarot_core.contract_address);
-    let is_deployed = AccountTrait::is_deployed(evm_address());
+    let is_registered = AddressTrait::is_registered(evm_address());
 
     // Then
-    assert(!is_deployed, 'account should be undeployed');
+    assert(!is_registered, 'account should be undeployed');
 }
 
 
@@ -89,6 +89,51 @@ fn test_address_balance_eoa() {
 
     // Then
     assert(balance == native_token.balanceOf(eoa_address.starknet), 'wrong balance');
+}
+
+
+#[test]
+#[available_gas(5000000)]
+fn test_account_is_deployed_eoa() {
+    // Given
+    let (native_token, kakarot_core) = setup_contracts_for_testing();
+    let mut eoa_address = EOATrait::deploy(evm_address()).expect('failed deploy eoa',);
+
+    // When
+    let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
+
+    // Then
+    assert(account.is_deployed() == true, 'account should be deployed');
+}
+
+
+#[test]
+#[available_gas(5000000)]
+fn test_account_is_deployed_contract_account() {
+    // Given
+    let (native_token, kakarot_core) = setup_contracts_for_testing();
+    let mut ca_address = ContractAccountTrait::deploy(evm_address(), array![].span())
+        .expect('failed deploy contract account',);
+
+    // When
+    let account = AccountTrait::fetch(evm_address()).unwrap().unwrap();
+
+    // Then
+    assert(account.is_deployed() == true, 'account should be deployed');
+}
+
+
+#[test]
+#[available_gas(5000000)]
+fn test_account_is_deployed_undeployed() {
+    // Given
+    let (native_token, kakarot_core) = setup_contracts_for_testing();
+
+    // When
+    let account = AccountTrait::fetch_or_create(evm_address()).unwrap();
+
+    // Then
+    assert(account.is_deployed() == false, 'account should be deployed');
 }
 
 

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -3,7 +3,7 @@ mod test_eoa;
 use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::tests::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
 use evm::model::account::AccountTrait;
-use evm::model::{Account, ContractAccountTrait, AccountType, EOA, EOATrait, AddressTrait};
+use evm::model::{Account, ContractAccountTrait, AccountType, EOATrait, AddressTrait};
 use evm::tests::test_utils::{evm_address};
 use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use starknet::testing::set_contract_address;
@@ -13,7 +13,7 @@ use starknet::testing::set_contract_address;
 fn test_is_deployed_eoa_exists() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let eoa = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
+    let eoa_address = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
 
     // When
 
@@ -60,9 +60,9 @@ fn test_is_deployed_undeployed() {
 fn test_account_balance_eoa() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let eoa = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
+    let eoa_address = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
 
-    fund_account_with_native_token(eoa.starknet_address, native_token, 0x1);
+    fund_account_with_native_token(eoa_address.starknet, native_token, 0x1);
 
     // When
     set_contract_address(kakarot_core.contract_address);
@@ -70,7 +70,7 @@ fn test_account_balance_eoa() {
     let balance = account.balance().unwrap();
 
     // Then
-    assert(balance == native_token.balanceOf(eoa.starknet_address), 'wrong balance');
+    assert(balance == native_token.balanceOf(eoa_address.starknet), 'wrong balance');
 }
 
 #[test]
@@ -78,9 +78,9 @@ fn test_account_balance_eoa() {
 fn test_address_balance_eoa() {
     // Given
     let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let eoa = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
+    let eoa_address = EOATrait::deploy(evm_address()).expect('failed deploy contract account',);
 
-    fund_account_with_native_token(eoa.starknet_address, native_token, 0x1);
+    fund_account_with_native_token(eoa_address.starknet, native_token, 0x1);
 
     // When
     set_contract_address(kakarot_core.contract_address);
@@ -88,7 +88,7 @@ fn test_address_balance_eoa() {
     let balance = account.address().balance().unwrap();
 
     // Then
-    assert(balance == native_token.balanceOf(eoa.starknet_address), 'wrong balance');
+    assert(balance == native_token.balanceOf(eoa_address.starknet), 'wrong balance');
 }
 
 

--- a/crates/evm/src/tests/test_model/test_contract_account.cairo
+++ b/crates/evm/src/tests/test_model/test_contract_account.cairo
@@ -4,7 +4,7 @@ use contracts::kakarot_core::kakarot::StoredAccountType;
 use contracts::tests::test_data::counter_evm_bytecode;
 use contracts::tests::test_utils as contract_utils;
 use contracts::tests::test_utils::constants::EVM_ADDRESS;
-use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
+use evm::model::contract_account::{ContractAccountTrait};
 use evm::model::{AccountType};
 use evm::tests::test_utils;
 use starknet::testing::set_contract_address;
@@ -22,15 +22,15 @@ fn test_contract_account_deploy() {
     set_contract_address(kakarot_core.contract_address);
 
     let bytecode = counter_evm_bytecode();
-    let ca = ContractAccountTrait::deploy(test_utils::evm_address(), bytecode).unwrap();
+    let ca_address = ContractAccountTrait::deploy(test_utils::evm_address(), bytecode).unwrap();
     let event = contract_utils::pop_log::<
         KakarotCore::ContractAccountDeployed
     >(kakarot_core.contract_address)
         .unwrap();
-    assert(ca.evm_address == event.evm_address, 'wrong evm address');
+    assert(ca_address.evm == event.evm_address, 'wrong evm address');
     assert(event.evm_address == test_utils::evm_address(), 'wrong event address');
-    assert(ca.nonce().unwrap() == 1, 'initial nonce not 1');
-    assert(ca.load_bytecode().unwrap() == bytecode, 'wrong bytecode');
+    assert(ca_address.fetch_nonce().unwrap() == 1, 'initial nonce not 1');
+    assert(ca_address.fetch_bytecode().unwrap() == bytecode, 'wrong bytecode');
 }
 
 #[test]
@@ -41,16 +41,16 @@ fn test_at_contract_account_deployed() {
 
     let ca = ContractAccountTrait::deploy(evm_address, Default::default().span()).unwrap();
 
-    let maybe_ca = ContractAccountTrait::at(evm_address).unwrap();
-    assert(maybe_ca.is_some(), 'contract account should exist');
-    let mut ca = maybe_ca.unwrap();
-    assert(ca.evm_address == evm_address, 'evm_address incorrect');
-    let registered_ca =
-        match kakarot_core.address_registry(evm_address).expect('should be in registry') {
-        AccountType::EOA(_) => panic_with_felt252('should no be EOA'),
-        AccountType::ContractAccount(address) => address,
-    };
-    assert(ca == registered_ca, 'starknet_address mismatch');
+    let ca_address = ContractAccountTrait::at(evm_address)
+        .unwrap()
+        .expect('contract account should exist');
+    assert(ca_address.evm == evm_address, 'evm_address incorrect');
+    let (registered_type, registered_address) = kakarot_core
+        .address_registry(evm_address)
+        .expect('should be in registry');
+
+    assert(registered_type == AccountType::ContractAccount, 'is not CA');
+    assert(ca_address.starknet == registered_address, 'starknet_address mismatch');
 }
 
 
@@ -60,20 +60,6 @@ fn test_at_contract_account_undeployed() {
     let evm_address = EVM_ADDRESS();
     let maybe_ca = ContractAccountTrait::at(evm_address).unwrap();
     assert(maybe_ca.is_none(), 'contract account shouldnt exist');
-}
-
-#[test]
-#[available_gas(200000000000)]
-fn test_balance() {
-    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
-
-    let evm_address = EVM_ADDRESS();
-    let mut ca = ContractAccountTrait::deploy(test_utils::evm_address(), array![].span()).unwrap();
-    assert(ca.balance().expect('failed to get balance') == 0, 'initial balance not 0');
-
-    contract_utils::fund_account_with_native_token(ca.starknet_address, native_token, 0x1);
-
-    assert(ca.balance().expect('failed to get new balance') == 1, 'balance not incremented');
 }
 //TODO add a test with huge amount of bytecode - using SNFoundry and loading data from txt
 

--- a/crates/evm/src/tests/test_model/test_eoa.cairo
+++ b/crates/evm/src/tests/test_model/test_eoa.cairo
@@ -3,7 +3,7 @@ use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::tests::test_utils as contract_utils;
 use contracts::tests::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
 use evm::errors::EVMErrorTrait;
-use evm::model::eoa::{EOA, EOATrait};
+use evm::model::eoa::{EOATrait};
 use evm::tests::test_utils;
 use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use starknet::testing::set_contract_address;
@@ -15,15 +15,12 @@ fn test_eoa_deploy() {
     let (native_token, kakarot_core) = setup_contracts_for_testing();
     contract_utils::drop_event(kakarot_core.contract_address);
 
-    let maybe_eoa = EOATrait::deploy(test_utils::evm_address());
-    let eoa = match maybe_eoa {
-        Result::Ok(eoa) => eoa,
-        Result::Err(err) => panic_with_felt252(err.to_string())
-    };
+    let eoa_address = EOATrait::deploy(test_utils::evm_address())
+        .expect('deployment of EOA failed');
 
     let event = contract_utils::pop_log::<KakarotCore::EOADeployed>(kakarot_core.contract_address)
         .unwrap();
 
     assert(event.evm_address == test_utils::evm_address(), 'wrong evm address');
-    assert(event.starknet_address.into() == eoa.starknet_address, 'wrong starknet address');
+    assert(event.starknet_address.into() == eoa_address.starknet, 'wrong starknet address');
 }

--- a/crates/evm/src/tests/test_model/test_eoa.cairo
+++ b/crates/evm/src/tests/test_model/test_eoa.cairo
@@ -27,22 +27,3 @@ fn test_eoa_deploy() {
     assert(event.evm_address == test_utils::evm_address(), 'wrong evm address');
     assert(event.starknet_address.into() == eoa.starknet_address, 'wrong starknet address');
 }
-
-
-#[test]
-#[available_gas(5000000)]
-fn test_eoa_balance() {
-    // Given
-    let (native_token, kakarot_core) = setup_contracts_for_testing();
-    let sn_address = kakarot_core.deploy_eoa(test_utils::evm_address());
-
-    fund_account_with_native_token(sn_address, native_token, 0x1);
-
-    // When
-    set_contract_address(kakarot_core.contract_address);
-    let eoa = EOATrait::at(test_utils::evm_address()).unwrap().unwrap();
-    let balance = eoa.balance().unwrap();
-
-    // Then
-    assert(balance == native_token.balanceOf(eoa.starknet_address), 'wrong balance');
-}

--- a/crates/evm/src/tests/test_state.cairo
+++ b/crates/evm/src/tests/test_state.cairo
@@ -217,7 +217,7 @@ mod test_state {
             evm_address,
             UninitializedAccount::TEST_CLASS_HASH.try_into().unwrap()
         );
-        let expected_type = AccountType::ContractAccount;
+        let expected_type = AccountType::Unknown;
         let expected_account = Account {
             account_type: expected_type,
             address: Address { evm: evm_address, starknet: starknet_address },

--- a/crates/evm/src/tests/test_state.cairo
+++ b/crates/evm/src/tests/test_state.cairo
@@ -195,7 +195,7 @@ mod test_state {
     use contracts::tests::test_utils as contract_utils;
     use contracts::uninitialized_account::UninitializedAccount;
     use evm::model::account::{Account, AccountType};
-    use evm::model::contract_account::{ContractAccount, ContractAccountTrait};
+    use evm::model::contract_account::{ContractAccountTrait};
     use evm::model::eoa::EOATrait;
     use evm::model::{Event, Transfer, Address};
     use evm::state::{State, StateTrait, StateInternalTrait};
@@ -217,11 +217,10 @@ mod test_state {
             evm_address,
             UninitializedAccount::TEST_CLASS_HASH.try_into().unwrap()
         );
-        let expected_type = AccountType::ContractAccount(
-            ContractAccount { evm_address, starknet_address }
-        );
+        let expected_type = AccountType::ContractAccount;
         let expected_account = Account {
             account_type: expected_type,
+            address: Address { evm: evm_address, starknet: starknet_address },
             code: Default::default().span(),
             nonce: 0,
             selfdestruct: false
@@ -245,11 +244,10 @@ mod test_state {
         let starknet_address = compute_starknet_address(
             deployer.into(), evm_address, UninitializedAccount::TEST_CLASS_HASH.try_into().unwrap()
         );
-        let expected_type = AccountType::ContractAccount(
-            ContractAccount { evm_address, starknet_address }
-        );
+        let expected_type = AccountType::ContractAccount;
         let expected_account = Account {
             account_type: expected_type,
+            address: Address { evm: evm_address, starknet: starknet_address },
             code: array![0xab, 0xcd, 0xef].span(),
             nonce: 1,
             selfdestruct: false
@@ -282,13 +280,13 @@ mod test_state {
         // Transfer native tokens to sender
         let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
         let evm_address: EthAddress = test_utils::evm_address();
-        let mut ca = ContractAccountTrait::deploy(evm_address, array![].span())
+        let mut ca_address = ContractAccountTrait::deploy(evm_address, array![].span())
             .expect('sender deploy failed');
 
         let mut state: State = Default::default();
         let key = 10;
         let value = 100;
-        ca.set_storage_at(key, value);
+        ca_address.store_storage(key, value);
 
         let read_value = state.read_state(evm_address, key).unwrap();
 

--- a/crates/evm/src/tests/test_state.cairo
+++ b/crates/evm/src/tests/test_state.cairo
@@ -286,7 +286,14 @@ mod test_state {
         let mut state: State = Default::default();
         let key = 10;
         let value = 100;
-        ca_address.store_storage(key, value);
+        let account = Account {
+            account_type: AccountType::ContractAccount,
+            address: ca_address,
+            code: array![0xab, 0xcd, 0xef].span(),
+            nonce: 1,
+            selfdestruct: false
+        };
+        account.store_storage(key, value);
 
         let read_value = state.read_state(evm_address, key).unwrap();
 

--- a/crates/evm/src/tests/test_state.cairo
+++ b/crates/evm/src/tests/test_state.cairo
@@ -375,7 +375,7 @@ mod test_state {
         // Transfer native tokens to sender - we need to set the contract address for this
         set_contract_address(contract_utils::constants::ETH_BANK());
         IERC20CamelDispatcher { contract_address: native_token.contract_address }
-            .transfer(eoa_account.starknet_address, 10000);
+            .transfer(eoa_account.starknet, 10000);
         // Revert back to contract_address = kakarot for the test
         set_contract_address(kakarot_core.contract_address);
         let mut state: State = Default::default();

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -4,7 +4,7 @@ use evm::context::{
 };
 use evm::errors::{EVMError};
 use evm::machine::{Machine, MachineCurrentContextTrait};
-use evm::model::{ContractAccountTrait, Address};
+use evm::model::{ContractAccountTrait, Address, Account, AccountType};
 use nullable::{match_nullable, FromNullableResult};
 use starknet::{
     StorageBaseAddress, storage_base_address_from_felt252, contract_address_try_from_felt252,
@@ -350,13 +350,20 @@ fn initialize_contract_account(
     let mut ca_address = ContractAccountTrait::deploy(eth_address, bytecode)
         .expect('failed deploying CA');
     // Set the storage of the contract account
+    let account = Account {
+        account_type: AccountType::ContractAccount,
+        address: ca_address,
+        code: array![0xab, 0xcd, 0xef].span(),
+        nonce: 1,
+        selfdestruct: false
+    };
     let mut i = 0;
     loop {
         if i == storage.len() {
             break;
         };
         let (key, value) = storage.get(i).unwrap().unbox();
-        ca_address.store_storage(*key, *value);
+        account.store_storage(*key, *value);
         i += 1;
     };
 

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -347,7 +347,8 @@ fn parent_ctx_return_data(ref self: Machine) -> Span<u8> {
 fn initialize_contract_account(
     eth_address: EthAddress, bytecode: Span<u8>, storage: Span<(u256, u256)>
 ) -> Result<Address, EVMError> {
-    let mut ca = ContractAccountTrait::deploy(eth_address, bytecode).expect('failed deploying CA');
+    let mut ca_address = ContractAccountTrait::deploy(eth_address, bytecode)
+        .expect('failed deploying CA');
     // Set the storage of the contract account
     let mut i = 0;
     loop {
@@ -355,9 +356,9 @@ fn initialize_contract_account(
             break;
         };
         let (key, value) = storage.get(i).unwrap().unbox();
-        ca.set_storage_at(*key, *value);
+        ca_address.store_storage(*key, *value);
         i += 1;
     };
 
-    Result::Ok(Address { evm: eth_address, starknet: ca.starknet_address() })
+    Result::Ok(ca_address)
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #480

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed `EOA` and `CA` types - methods kept now operate on the `Address` type.
- AccoutType variants don't take values. Introduced `Unknown` variant, for accounts that are touched but whose actual type is not known yet. They can be undeployed EOAs or undeployed CAs. If an `Unknown` account is deployed using create opcodes or in a deploy tx, its type is manually set to `ContractAccount`.
- Simplifies interactions with accounts overall. Less confusing methods.
- Account model is closer to the actual EVM model - the account type is used for optimisation.
- Fix selfdestruct by removing the entry from the kakarot address_registry upon commitment.
- Fix extcodehash selfdestruct test by expecting an empty hash instead of 0 (account still exists until TX ends!)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
