### PR TITLE
dev: optimize to_u64_words to use span<u8> as input

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -32,7 +32,7 @@ lint:
     - actionlint@1.6.26
     - bandit@1.7.5
     - black@23.9.1
-    - checkov@3.0.29
+    - checkov@3.0.32
     - git-diff-check
     - isort@5.12.0
     - markdownlint@0.37.0
@@ -44,7 +44,7 @@ lint:
     - taplo@0.8.1
     - trivy@0.47.0
     - trufflehog@3.62.1
-    - yamllint@1.32.0
+    - yamllint@1.33.0
 actions:
   disabled:
     - trunk-announce

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -196,12 +196,7 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
         preimage.concat(salt);
         preimage.concat(hash);
 
-        let (mut keccak_input, last_input_word, last_input_num_bytes) = preimage
-            .span()
-            .to_u64_words();
-        let address_hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
-            .reverse_endianness()
-            .to_bytes();
+        let address_hash = preimage.span().compute_keccak256_hash().to_bytes();
 
         let address: EthAddress = address_hash.slice(12, 20).try_into_result()?;
 

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -183,10 +183,7 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
     fn get_create2_address(
         self: @Machine, sender_address: EthAddress, salt: u256, bytecode: Span<u8>
     ) -> Result<EthAddress, EVMError> {
-        let (mut keccak_input, last_input_word, last_input_num_bytes) = bytecode.to_u64_words();
-        let hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
-            .reverse_endianness()
-            .to_bytes();
+        let hash = bytecode.compute_keccak256_hash().to_bytes();
 
         let sender_address = sender_address.to_bytes();
 

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -15,7 +15,7 @@ use evm::state::StateTrait;
 use keccak::cairo_keccak;
 use starknet::{EthAddress, get_tx_info};
 use utils::helpers::ArrayExtTrait;
-use utils::helpers::{ByteArrayExTrait, ResultExTrait, EthAddressExt, U256Trait};
+use utils::helpers::{ResultExTrait, EthAddressExt, U256Trait, U8SpanExTrait};
 use utils::traits::{
     BoolIntoNumeric, EthAddressIntoU256, U256TryIntoResult, SpanU8TryIntoResultEthAddress
 };
@@ -183,7 +183,6 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
     fn get_create2_address(
         self: @Machine, sender_address: EthAddress, salt: u256, bytecode: Span<u8>
     ) -> Result<EthAddress, EVMError> {
-        let mut bytecode = ByteArrayExTrait::from_bytes(bytecode);
         let (mut keccak_input, last_input_word, last_input_num_bytes) = bytecode.to_u64_words();
         let hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
             .reverse_endianness()
@@ -200,8 +199,9 @@ impl MachineCreateHelpersImpl of MachineCreateHelpers {
         preimage.concat(salt);
         preimage.concat(hash);
 
-        let mut preimage = ByteArrayExTrait::from_bytes(preimage.span());
-        let (mut keccak_input, last_input_word, last_input_num_bytes) = preimage.to_u64_words();
+        let (mut keccak_input, last_input_word, last_input_num_bytes) = preimage
+            .span()
+            .to_u64_words();
         let address_hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
             .reverse_endianness()
             .to_bytes();

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -16,7 +16,7 @@ use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDi
 use pedersen::{PedersenTrait, HashState};
 use starknet::{Store, storage_base_address_from_felt252, ContractAddress, get_contract_address};
 use utils::constants::EMPTY_KECCAK;
-use utils::helpers::{load_word, U256Trait, ByteArrayExTrait};
+use utils::helpers::{load_word, U256Trait, U8SpanExTrait};
 use utils::math::BitshiftImpl;
 use utils::traits::{EthAddressIntoU256};
 
@@ -252,8 +252,6 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         if bytecode.is_empty() {
             return self.stack.push(EMPTY_KECCAK);
         }
-        //TODO optimize this by avoiding a ByteArray -> Span<u64> conversion
-        let mut bytecode: ByteArray = ByteArrayExTrait::from_bytes(bytecode);
 
         // `cairo_keccak` takes in an array of little-endian u64s
         let (mut keccak_input, last_input_word, last_input_num_bytes) = bytecode.to_u64_words();

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -254,8 +254,7 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         }
 
         // `cairo_keccak` takes in an array of little-endian u64s
-        let (mut keccak_input, last_input_word, last_input_num_bytes) = bytecode.to_u64_words();
-        let hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes);
-        self.stack.push(hash.reverse_endianness())
+        let hash = bytecode.compute_keccak256_hash();
+        self.stack.push(hash)
     }
 }

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -13,7 +13,7 @@ use openzeppelin::token::erc20::interface::{
     IERC20CamelSafeDispatcher, IERC20CamelSafeDispatcherTrait
 };
 use starknet::{EthAddress, get_contract_address, ContractAddress};
-use utils::helpers::{ResultExTrait, ByteArrayExTrait};
+use utils::helpers::{ResultExTrait};
 use utils::traits::{EthAddressDefault, ContractAddressDefault};
 
 /// The struct representing an EVM event.

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -115,12 +115,7 @@ impl EncodedTransactionImpl of EncodedTransactionTrait {
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
                 let chain_id = (*val.at(chain_id_idx)).parse_u128_from_string().map_err()?;
 
-                let (mut keccak_input, last_input_word, last_input_num_bytes) = tx_data
-                    .to_u64_words();
-                let msg_hash = cairo_keccak(
-                    ref keccak_input, :last_input_word, :last_input_num_bytes
-                )
-                    .reverse_endianness();
+                let msg_hash = tx_data.compute_keccak256_hash();
 
                 let destination: EthAddress = to.into();
 

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -7,10 +7,7 @@ use starknet::{EthAddress};
 use utils::errors::RLPErrorTrait;
 
 use utils::errors::{EthTransactionError, RLPErrorImpl, RLPHelpersErrorImpl, RLPHelpersErrorTrait};
-use utils::helpers::ByteArrayExTrait;
-use utils::helpers::U256Trait;
-
-use utils::helpers::{U256Impl, ByteArrayExt};
+use utils::helpers::{U256Trait, U256Impl, ByteArrayExt, U8SpanExTrait};
 
 use utils::rlp::RLPItem;
 use utils::rlp::{RLPTrait, RLPHelpersTrait};
@@ -117,6 +114,13 @@ impl EncodedTransactionImpl of EncodedTransactionTrait {
                 let amount = (*val.at(value_idx)).parse_u256_from_string().map_err()?;
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
                 let chain_id = (*val.at(chain_id_idx)).parse_u128_from_string().map_err()?;
+
+                let (mut keccak_input, last_input_word, last_input_num_bytes) = tx_data
+                    .to_u64_words();
+                let msg_hash = cairo_keccak(
+                    ref keccak_input, :last_input_word, :last_input_num_bytes
+                )
+                    .reverse_endianness();
 
                 let destination: EthAddress = to.into();
 

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -115,8 +115,6 @@ impl EncodedTransactionImpl of EncodedTransactionTrait {
                 let calldata = (*val.at(calldata_idx)).parse_bytes_from_string().map_err()?;
                 let chain_id = (*val.at(chain_id_idx)).parse_u128_from_string().map_err()?;
 
-                let msg_hash = tx_data.compute_keccak256_hash();
-
                 let destination: EthAddress = to.into();
 
                 Result::Ok(

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -522,6 +522,14 @@ impl SpanExtension<T, +Copy<T>, +Drop<T>> of SpanExtTrait<T> {
 
 #[generate_trait]
 impl U8SpanExImpl of U8SpanExTrait {
+    // keccack256 on a bytes message
+    fn compute_keccak256_hash(self: Span<u8>) -> u256 {
+        let (mut keccak_input, last_input_word, last_input_num_bytes) = self.to_u64_words();
+        let hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
+            .reverse_endianness();
+
+        hash
+    }
     /// Transforms a Span<u8> into an Array of u64 full words, a pending u64 word and its length in bytes
     fn to_u64_words(self: Span<u8>) -> (Array<u64>, u64, usize) {
         let (full_u64_word_count, last_input_num_bytes) = DivRem::div_rem(
@@ -577,19 +585,6 @@ impl U8SpanExImpl of U8SpanExTrait {
         };
 
         (u64_words, last_input_word, last_input_num_bytes)
-    }
-}
-
-
-#[generate_trait]
-impl BytesImpl of BytesTrait {
-    // keccack256 on a bytes message
-    fn compute_keccak256_hash(self: Span<u8>) -> u256 {
-        let (mut keccak_input, last_input_word, last_input_num_bytes) = self.to_u64_words();
-        let msg_hash = cairo_keccak(ref keccak_input, :last_input_word, :last_input_num_bytes)
-            .reverse_endianness();
-
-        msg_hash
     }
 }
 

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -1,5 +1,6 @@
 use utils::helpers::{
-    SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, U32Trait, BytesTrait
+    SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, U32Trait, U8SpanExTrait,
+    BytesTrait
 };
 use utils::helpers::{ByteArrayExTrait};
 use utils::helpers;
@@ -446,4 +447,72 @@ fn test_compute_msg_hash() {
     let hash = msg.compute_keccak256_hash();
 
     assert(hash == expected_hash, 'msg_hash is incorrect');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytearray_to_64_words_partial() {
+    let input = ByteArrayExTrait::from_bytes(array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06].span());
+    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
+    assert(pending_word == 6618611909121, 'wrong pending word');
+    assert(pending_word_len == 6, 'wrong pending word length');
+    assert(u64_words.len() == 0, 'wrong u64 words length');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytearray_to_64_words_full() {
+    let input = ByteArrayExTrait::from_bytes(
+        array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08].span()
+    );
+    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
+
+    assert(pending_word == 0, 'wrong pending word');
+    assert(pending_word_len == 0, 'wrong pending word length');
+    assert(u64_words.len() == 1, 'wrong u64 words length');
+    assert(*u64_words[0] == 578437695752307201, 'wrong u64 words length');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_span_u8_to_64_words_partial() {
+    let mut input: Span<u8> = array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06].span();
+    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
+    assert(pending_word == 6618611909121, 'wrong pending word');
+    assert(pending_word_len == 6, 'wrong pending word length');
+    assert(u64_words.len() == 0, 'wrong u64 words length');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_span_u8_to_64_words_full() {
+    let mut input: Span<u8> = array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08].span();
+    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
+
+    assert(pending_word == 0, 'wrong pending word');
+    assert(pending_word_len == 0, 'wrong pending word length');
+    assert(u64_words.len() == 1, 'wrong u64 words length');
+    assert(*u64_words[0] == 578437695752307201, 'wrong u64 words length');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_span_u8_to_64_words_partial() {
+    let mut input: Span<u8> = array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06].span();
+    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
+    assert(pending_word == 6618611909121, 'wrong pending word');
+    assert(pending_word_len == 6, 'wrong pending word length');
+    assert(u64_words.len() == 0, 'wrong u64 words length');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_span_u8_to_64_words_full() {
+    let mut input: Span<u8> = array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08].span();
+    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
+
+    assert(pending_word == 0, 'wrong pending word');
+    assert(pending_word_len == 0, 'wrong pending word length');
+    assert(u64_words.len() == 1, 'wrong u64 words length');
+    assert(*u64_words[0] == 578437695752307201, 'wrong u64 words length');
 }

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -1,6 +1,5 @@
 use utils::helpers::{
     SpanExtension, SpanExtTrait, ArrayExtension, ArrayExtTrait, U256Trait, U32Trait, U8SpanExTrait,
-    BytesTrait
 };
 use utils::helpers::{ByteArrayExTrait};
 use utils::helpers;

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -494,25 +494,3 @@ fn test_span_u8_to_64_words_full() {
     assert(u64_words.len() == 1, 'wrong u64 words length');
     assert(*u64_words[0] == 578437695752307201, 'wrong u64 words length');
 }
-
-#[test]
-#[available_gas(20000000)]
-fn test_span_u8_to_64_words_partial() {
-    let mut input: Span<u8> = array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06].span();
-    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
-    assert(pending_word == 6618611909121, 'wrong pending word');
-    assert(pending_word_len == 6, 'wrong pending word length');
-    assert(u64_words.len() == 0, 'wrong u64 words length');
-}
-
-#[test]
-#[available_gas(20000000)]
-fn test_span_u8_to_64_words_full() {
-    let mut input: Span<u8> = array![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08].span();
-    let (u64_words, pending_word, pending_word_len) = input.to_u64_words();
-
-    assert(pending_word == 0, 'wrong pending word');
-    assert(pending_word_len == 0, 'wrong pending word length');
-    assert(u64_words.len() == 1, 'wrong u64 words length');
-    assert(*u64_words[0] == 578437695752307201, 'wrong u64 words length');
-}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): opti

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #516

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Span<u8> are not converted to ByteArray before packing them in u64 words
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
