### PR TITLE
feat: implement some remaining todos

### DIFF
--- a/crates/contracts/src/contract_account.cairo
+++ b/crates/contracts/src/contract_account.cairo
@@ -34,7 +34,6 @@ trait IContractAccount<TContractState> {
 
     fn nonce(self: @TContractState) -> u64;
     fn set_nonce(ref self: TContractState, new_nonce: u64);
-    fn increment_nonce(ref self: TContractState);
     // ***
     // JUMP
     // Records of valid jumps in the context of jump opcodes
@@ -144,6 +143,7 @@ mod ContractAccount {
         }
 
         fn set_bytecode(ref self: ContractState, bytecode: Span<u8>) {
+            self.assert_only_kakarot_core();
             let packed_bytecode: ByteArray = ByteArrayExTrait::from_bytes(bytecode);
             // data_address is h(h(sn_keccak("contract_account_bytecode")), evm_address)
             let data_address = storage_base_address_from_felt252(
@@ -192,6 +192,7 @@ mod ContractAccount {
         }
 
         fn set_storage_at(ref self: ContractState, key: u256, value: u256) {
+            self.assert_only_kakarot_core();
             let storage_address = compute_storage_base_address(
                 selector!("contract_account_storage_keys"),
                 array![key.low.into(), key.high.into()].span()
@@ -208,6 +209,7 @@ mod ContractAccount {
 
 
         fn set_nonce(ref self: ContractState, new_nonce: u64) {
+            self.assert_only_kakarot_core();
             let storage_address: StorageBaseAddress = storage_base_address_from_felt252(
                 selector!("contract_account_nonce")
             );
@@ -215,25 +217,18 @@ mod ContractAccount {
         }
 
 
-        fn increment_nonce(ref self: ContractState) {
-            let storage_address: StorageBaseAddress = storage_base_address_from_felt252(
-                selector!("contract_account_nonce")
-            );
-            let nonce = Store::<u64>::read(0, storage_address).expect(NONCE_READ_ERROR);
-            Store::<u64>::write(0, storage_address, nonce + 1).expect(NONCE_WRITE_ERROR)
-        }
-
         fn is_false_positive_jumpdest(self: @ContractState, offset: usize) -> bool {
             panic_with_felt252('unimplemented')
         }
 
 
         fn set_false_positive_jumpdest(ref self: ContractState, offset: usize) {
+            self.assert_only_kakarot_core();
             panic_with_felt252('unimplemented')
         }
 
         fn selfdestruct(ref self: ContractState) {
-            //TODO add access control
+            self.assert_only_kakarot_core();
             self.set_nonce(0);
             self.evm_address.write(0.try_into().unwrap());
             self.set_bytecode(array![].span());
@@ -243,11 +238,18 @@ mod ContractAccount {
 
 
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.assert_only_kakarot_core();
+            self.upgradeable.upgrade_contract(new_class_hash);
+        }
+    }
+
+    #[generate_trait]
+    impl PrivateImpl of PrivateTrait {
+        fn assert_only_kakarot_core(self: @ContractState) {
             assert(
                 get_caller_address() == self.kakarot_core_address.read(),
                 'Caller not Kakarot Core address'
             );
-            self.upgradeable.upgrade_contract(new_class_hash);
         }
     }
 }

--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -56,10 +56,9 @@ mod ExternallyOwnedAccount {
         fn chain_id(self: @ContractState) -> u128 {
             self.chain_id.read()
         }
-        // TODO: make this function reachable from an external invoke call
         // TODO: add some security methods to make sure that only some specific upgrades can be made ( low priority )
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
-            assert(get_caller_address() == get_contract_address(), 'Caller not contract address');
+            self.assert_only_self();
             self.upgradeable.upgrade_contract(new_class_hash);
         }
 
@@ -109,6 +108,13 @@ mod ExternallyOwnedAccount {
             // Call KakarotCore.send_eth_transaction with correct params
 
             array![]
+        }
+    }
+
+    #[generate_trait]
+    impl PrivateImpl of PrivateTrait {
+        fn assert_only_self(self: @ContractState) {
+            assert(get_caller_address() == get_contract_address(), 'Caller not self');
         }
     }
 }

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -92,7 +92,7 @@ mod test_external_owned_account {
 
     #[test]
     #[available_gas(2000000000)]
-    #[should_panic(expected: ('Caller not contract address', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Caller not self', 'ENTRYPOINT_FAILED'))]
     fn test_eoa_upgrade_from_noncontractaddress() {
         let (_, kakarot) = setup_contracts_for_testing();
         let kakarot_address = kakarot.contract_address;

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -1,5 +1,7 @@
 use contracts::contract_account::ContractAccount::TEST_CLASS_HASH as ContractAccountTestClassHash;
+use contracts::contract_account::{IContractAccountDispatcher, IContractAccountDispatcherTrait};
 use contracts::eoa::ExternallyOwnedAccount;
+use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::kakarot_core::kakarot::StoredAccountType;
 use contracts::kakarot_core::{
     interface::IExtendedKakarotCoreDispatcherImpl, KakarotCore, KakarotCore::{KakarotCoreInternal},
@@ -171,11 +173,84 @@ fn test_kakarot_core_upgrade_contract() {
     assert(version == 1, 'version is not 1');
 }
 
-// TODO add tests related to contract accounts once they can be deployed.
-#[ignore]
 #[test]
 #[available_gas(20000000)]
-fn test_kakarot_contract_account() {}
+fn test_kakarot_contract_account_nonce() {
+    // Given
+    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
+    let address = ContractAccountTrait::deploy(
+        test_utils::other_evm_address(), Default::default().span()
+    )
+        .unwrap();
+
+    // When
+    let nonce = kakarot_core.contract_account_nonce(address.evm);
+
+    // Then
+    assert(nonce == 1, 'wrong nonce');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+fn test_kakarot_contract_account_storage_at() {
+    // Given
+    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
+    let address = ContractAccountTrait::deploy(
+        test_utils::other_evm_address(), Default::default().span()
+    )
+        .unwrap();
+    let ca = IContractAccountDispatcher { contract_address: address.starknet };
+    let expected_value = 420;
+    let key = 69;
+    ca.set_storage_at(69, expected_value);
+
+    // When
+    let value = kakarot_core.contract_account_storage_at(address.evm, key);
+
+    // Then
+    assert(value == expected_value, 'wrong storage value');
+}
+
+#[test]
+#[available_gas(2000000000)]
+fn test_kakarot_contract_account_bytecode() {
+    // Given
+    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
+    let address = ContractAccountTrait::deploy(
+        test_utils::other_evm_address(), counter_evm_bytecode()
+    )
+        .unwrap();
+
+    // When
+    let bytecode = kakarot_core.contract_account_bytecode(address.evm);
+
+    // Then
+    assert(bytecode == counter_evm_bytecode(), 'wrong bytecode');
+}
+
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('unimplemented', 'ENTRYPOINT_FAILED'))]
+fn test_kakarot_contract_account_false_positive_jumpdest() {
+    // Given
+    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
+    let address = ContractAccountTrait::deploy(
+        test_utils::other_evm_address(), Default::default().span()
+    )
+        .unwrap();
+    let ca = IContractAccountDispatcher { contract_address: address.starknet };
+    let offset = 1337;
+    ca.set_false_positive_jumpdest(offset);
+
+    // When
+    let is_false_jumpdest = kakarot_core
+        .contract_account_false_positive_jumpdest(address.evm, offset);
+
+    // Then
+    assert(is_false_jumpdest, 'should be false jumpdest');
+}
 
 #[test]
 #[available_gas(2000000000000)]

--- a/crates/evm/src/execution.cairo
+++ b/crates/evm/src/execution.cairo
@@ -65,35 +65,14 @@ fn execute(
     let transfer = Transfer { sender: origin, recipient: target, amount: value };
     match machine.state.add_transfer(transfer) {
         Result::Ok(x) => {},
-        Result::Err(err) => {
-            return ExecutionResult {
-                status: Status::Reverted,
-                return_data: Default::default().span(),
-                destroyed_contracts: Default::default().span(),
-                create_addresses: Default::default().span(),
-                events: Default::default().span(),
-                state: machine.state,
-                error: Option::Some(err)
-            };
-        }
+        Result::Err(err) => { return reverted_with_err(machine, err); }
     }
 
     // cache the EOA of origin inside the state, and set its nonce to get_tx_info().unbox().nonce.
     // This allows us to call create with the correct nonce as the salt.
     let mut origin_account = match machine.state.get_account(origin.evm) {
         Result::Ok(account) => { account },
-        //TODO create helper method to avoid this boilerplace
-        Result::Err(err) => {
-            return ExecutionResult {
-                status: Status::Reverted,
-                return_data: Default::default().span(),
-                destroyed_contracts: Default::default().span(),
-                create_addresses: Default::default().span(),
-                events: Default::default().span(),
-                state: machine.state,
-                error: Option::Some(err)
-            };
-        }
+        Result::Err(err) => { return reverted_with_err(machine, err); }
     };
     origin_account.nonce = starknet::get_tx_info().unbox().nonce.try_into().unwrap();
     machine.state.set_account(origin_account);
@@ -118,3 +97,14 @@ fn execute(
     }
 }
 
+fn reverted_with_err(self: Machine, error: EVMError) -> ExecutionResult {
+    ExecutionResult {
+        status: Status::Reverted,
+        return_data: Default::default().span(),
+        destroyed_contracts: Default::default().span(),
+        create_addresses: Default::default().span(),
+        events: Default::default().span(),
+        state: self.state,
+        error: Option::Some(error)
+    }
+}

--- a/crates/evm/src/tests/test_execution_context.cairo
+++ b/crates/evm/src/tests/test_execution_context.cairo
@@ -18,11 +18,6 @@ use starknet::{EthAddress, ContractAddress};
 use test_utils::{callvalue, test_address};
 use traits::PartialEq;
 
-// TODO remove once no longer required (see https://github.com/starkware-libs/cairo/issues/3863)
-#[inline(never)]
-fn no_op() {}
-
-
 #[test]
 #[available_gas(1000000)]
 fn test_call_context_new() {

--- a/crates/evm/src/tests/test_instructions/test_block_information.cairo
+++ b/crates/evm/src/tests/test_instructions/test_block_information.cairo
@@ -45,7 +45,6 @@ fn test_exec_blockhash_above_bounds() {
 
 // TODO: implement exec_blockhash testing for block number within bounds
 // https://github.com/starkware-libs/cairo/blob/77a7e7bc36aa1c317bb8dd5f6f7a7e6eef0ab4f3/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo#L173
-#[ignore]
 #[test]
 #[available_gas(20000000)]
 fn test_exec_blockhash_within_bounds() {
@@ -56,9 +55,13 @@ fn test_exec_blockhash_within_bounds() {
 
     // When
     machine.stack.push(244).unwrap();
-    machine.exec_blockhash();
-    // Then
-    assert(machine.stack.peek().unwrap() == 0xF, 'stack top should be 0xF');
+
+    //TODO the CASM runner used in tests doesn't implement
+    //`get_block_hash_syscall` yet. As such, this test should fail no if the
+    //queried block is within bounds
+    assert(machine.exec_blockhash().is_err(), 'CASM Runner cant blockhash');
+// Then
+// assert(machine.stack.peek().unwrap() == 0xF, 'stack top should be 0xF');
 }
 
 

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -355,7 +355,7 @@ fn test_exec_jump_out_of_bounds() {
 // Remove ignore once its handled
 #[test]
 #[available_gas(20000000)]
-#[ignore]
+#[should_panic(expected: ('exec_jump should throw error',))]
 fn test_exec_jump_inside_pushn() {
     // Given
     let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();
@@ -367,8 +367,11 @@ fn test_exec_jump_inside_pushn() {
     let result = machine.exec_jump();
 
     // Then
-    assert(result.is_err(), 'invalid jump dest');
-    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+    assert(result.is_err(), 'exec_jump should throw error');
+    assert(
+        result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION),
+        'jump dest should be invalid'
+    );
 }
 
 #[test]
@@ -481,7 +484,7 @@ fn test_exec_jumpi_invalid_zero() {
 // Remove ignore once its handled
 #[test]
 #[available_gas(20000000)]
-#[ignore]
+#[should_panic(expected: ('exec_jump should throw error',))]
 fn test_exec_jumpi_inside_pushn() {
     // Given
     let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();
@@ -495,8 +498,11 @@ fn test_exec_jumpi_inside_pushn() {
     let result = machine.exec_jumpi();
 
     // Then
-    assert(result.is_err(), 'invalid jump dest');
-    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+    assert(result.is_err(), 'exec_jump should throw error');
+    assert(
+        result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION),
+        'jump dest should be invalid'
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Guard functions in Contract Account
- Moved `ignored` tests to `should_panic` instead - after thinking about it it makes more sense to expect a panic for a feature not working/not implemented than just ignoring the test, as we will directly notice that the test result changed if we changed a function
- Tests for KakarotCore contract-account related functions
- `reverted_with_err` function in `execute` to avoid code dup


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
