### PR TITLE
feat: seperate target address and the code address

### DIFF
--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -22,6 +22,7 @@ use utils::traits::{BoolIntoNumeric, U256TryIntoResult};
 #[derive(Drop)]
 struct CallArgs {
     caller: Address,
+    code_address: Address,
     to: Address,
     gas: u128,
     value: u256,
@@ -45,10 +46,22 @@ impl MachineCallHelpersImpl of MachineCallHelpers {
     /// As part of the CALL family of opcodes.
     fn prepare_call(ref self: Machine, call_type: @CallType) -> Result<CallArgs, EVMError> {
         let gas = self.stack.pop_u128()?;
-        let to = self.stack.pop_eth_address()?;
+
+        let code_address = self.stack.pop_eth_address()?;
+        let to = match call_type {
+            CallType::Call => code_address,
+            CallType::DelegateCall => self.address().evm,
+            CallType::CallCode => self.address().evm,
+            CallType::StaticCall => code_address
+        };
 
         let kakarot_core = KakarotCore::unsafe_new_contract_state();
-        let to = Address { evm: to, starknet: kakarot_core.compute_starknet_address(to), };
+
+        let code_address = Address {
+            evm: code_address, starknet: kakarot_core.compute_starknet_address(code_address)
+        };
+
+        let to = Address { evm: to, starknet: kakarot_core.compute_starknet_address(to) };
 
         let (value, should_transfer) = match call_type {
             CallType::Call => (self.stack.pop()?, true),
@@ -60,7 +73,7 @@ impl MachineCallHelpersImpl of MachineCallHelpers {
         let caller = match call_type {
             CallType::Call => self.address(),
             CallType::DelegateCall => self.call_ctx().caller,
-            CallType::CallCode => self.address(),
+            CallType::CallCode => self.call_ctx().caller(),
             CallType::StaticCall => self.address(),
         };
 
@@ -76,6 +89,7 @@ impl MachineCallHelpersImpl of MachineCallHelpers {
         Result::Ok(
             CallArgs {
                 caller,
+                code_address,
                 to,
                 value,
                 gas,
@@ -113,7 +127,7 @@ impl MachineCallHelpersImpl of MachineCallHelpers {
 
         // Case 2: `to` address is not a precompile
         // We enter the standard flow
-        let bytecode = self.state.get_account(call_args.to.evm)?.code;
+        let bytecode = self.state.get_account(call_args.code_address.evm)?.code;
 
         let call_ctx = CallContextTrait::new(
             call_args.caller,

--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -73,7 +73,7 @@ impl MachineCallHelpersImpl of MachineCallHelpers {
         let caller = match call_type {
             CallType::Call => self.address(),
             CallType::DelegateCall => self.call_ctx().caller,
-            CallType::CallCode => self.call_ctx().caller(),
+            CallType::CallCode => self.address(),
             CallType::StaticCall => self.address(),
         };
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The separation of target address and the code address are not supported, this PR adds support for this and fixed the bug to resolve `to` address correctly.

Resolves: #551 #552 

## What is the new behavior?

- target and code address has been seperated
- the correct `to` address is now resolved.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
