### PR TITLE
feat: delegate call test

### DIFF
--- a/crates/evm/src/tests/test_instructions/test_system_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_system_operations.cairo
@@ -1,6 +1,8 @@
 use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::tests::test_data::{storage_evm_bytecode, storage_evm_initcode};
 use contracts::tests::test_utils::setup_contracts_for_testing;
+use core::result::ResultTrait;
+
 use evm::call_helpers::{MachineCallHelpers, MachineCallHelpersImpl};
 use evm::context::{ExecutionContext, ExecutionContextTrait, ExecutionContextType};
 use evm::instructions::MemoryOperationTrait;
@@ -369,7 +371,24 @@ fn test_exec_delegatecall() {
     // Deploy bytecode at 0x100
     // ret (+ 0x1 0x1)
     let deployed_bytecode = array![
-        0x60, 0x01, 0x60, 0x01, 0x01, 0x60, 0x00, 0x53, 0x60, 0x20, 0x60, 0x00, 0xf3
+        0x60,
+        0x01,
+        0x60,
+        0x01,
+        0x01,
+        0x60,
+        0x00,
+        0x53,
+        0x60,
+        0x42,
+        0x60,
+        0x42,
+        0x55,
+        0x60,
+        0x20,
+        0x60,
+        0x00,
+        0xf3
     ]
         .span();
     let eth_address: EthAddress = 0x100_u256.into();
@@ -383,6 +402,13 @@ fn test_exec_delegatecall() {
     assert(machine.error.is_none(), 'run should be success');
     assert(2 == load_word(1, machine.return_data()), 'Wrong return_data');
     assert(machine.stopped(), 'machine should be stopped');
+
+    let storage_val = machine
+        .state
+        .read_state(evm_address, 0x42)
+        .expect('failed reading storage slot');
+
+    assert(storage_val == 0x42, 'storage value is not 0x42');
 }
 
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The [current test](https://github.com/kkrt-labs/kakarot-ssj/blob/8597c6c8768c433778a819bf3ff20cf52b6b0e04/crates/evm/src/tests/test_instructions/test_system_operations.cairo#L335) doesn't test the behaviour delegate call properly.

Resolves: #550 

## What is the new behavior?

- The bytecode which is executed does SSTORE
- SSTORE of value 0x42 is done at key 0x42
- The existence of value is checked in the storage in the contract which made the delegate call
- This makes sure that opcode is properly being tested.

## Does this introduce a breaking change?

- [  ] Yes
- [x] No
