### PR TITLE
add_transfer update

### DIFF
--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -254,6 +254,9 @@ impl StateImpl of StateTrait {
 
     #[inline(always)]
     fn add_transfer(ref self: State, transfer: Transfer) -> Result<(), EVMError> {
+        if (transfer.amount == 0 || transfer.sender == transfer.recipient) {
+            return Result::Ok(());
+        }
         let sender_balance = self.read_balance(transfer.sender.evm)?;
         let recipient_balance = self.read_balance(transfer.recipient.evm)?;
 


### PR DESCRIPTION
add_transfer function returning earlier when sender and recipient is same and when amount is zero

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [*] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`add_transfer` would return early result when:
1. sender and recipient is ame
2. amount is  zero

Resolves: #572 

## What is the new behavior?

- behavior is same

## Does this introduce a breaking change?

- [ ] Yes
- [*] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
