### PR TITLE
feat: support only valid jumps

### DIFF
--- a/crates/evm/src/context.cairo
+++ b/crates/evm/src/context.cairo
@@ -141,6 +141,8 @@ struct ExecutionContext {
     return_data: Span<u8>,
     parent_ctx: Nullable<ExecutionContext>,
     gas_used: u128,
+    is_valid_jump_destinations_set: bool,
+    valid_jump_destinations: Array<u32>
 }
 
 
@@ -187,6 +189,8 @@ impl ExecutionContextImpl of ExecutionContextTrait {
             return_data,
             parent_ctx,
             gas_used: Default::default(),
+            is_valid_jump_destinations_set: false,
+            valid_jump_destinations: Default::default()
         }
     }
 

--- a/crates/evm/src/errors.cairo
+++ b/crates/evm/src/errors.cairo
@@ -62,6 +62,7 @@ enum EVMError {
     InvalidMachineState: felt252,
     DeployError: felt252,
     OriginError: felt252,
+    ValidJumpDestinationsNotSet,
     OutOfGas,
 }
 
@@ -83,6 +84,7 @@ impl EVMErrorImpl of EVMErrorTrait {
             EVMError::InvalidMachineState(error_message) => error_message.into(),
             EVMError::DeployError(error_message) => error_message,
             EVMError::OriginError(error_message) => error_message,
+            EVMError::ValidJumpDestinationsNotSet => 'ValidJumpDestinationsNotSet'.into(),
             EVMError::OutOfGas => 'OutOfGas'.into(),
         }
     }

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -114,22 +114,18 @@ impl MemoryOperation of MemoryOperationTrait {
 
         let index = self.stack.pop_usize()?;
 
-        // TODO: Currently this doesn't check that byte is actually `JUMPDEST`
-        // and not `0x5B` that is a part of PUSHN instruction
-        //
-        // That can be done by storing all valid jump locations during contract deployment
-        // which would also simplify the logic because we would be just checking if idx is
-        // present in that list
-        //
         // Check if idx in bytecode points to `JUMPDEST` opcode
         match self.bytecode().get(index) {
-            Option::Some(opcode) => {
-                if *opcode.unbox() != 0x5B {
+            Option::Some(_) => {
+                self.init_valid_jump_destinations()?;
+
+                if (!self.is_valid_jump(index)?) {
                     return Result::Err(EVMError::JumpError(INVALID_DESTINATION));
                 }
             },
             Option::None => { return Result::Err(EVMError::JumpError(INVALID_DESTINATION)); }
         }
+
         self.set_pc(index);
         Result::Ok(())
     }

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -317,24 +317,6 @@ fn test_exec_jump_invalid() {
 }
 
 #[test]
-fn test_exec_jump_invalid_0x5B_is_push_argument() {
-    // Given
-    let bytecode: Span<u8> = array![0x01, 0x02, 0x60, 0x5B, 0x04, 0x05].span();
-
-    let mut machine = MachineBuilderTestTrait::new_with_presets().with_bytecode(bytecode).build();
-
-    let counter = 0x03;
-    machine.stack.push(counter).expect('push failed');
-
-    // When
-    let result = machine.exec_jump();
-
-    // Then
-    assert(result.is_err(), 'invalid jump dest');
-    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
-}
-
-#[test]
 fn test_exec_jump_out_of_bounds() {
     // Given
     let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
@@ -352,12 +334,7 @@ fn test_exec_jump_out_of_bounds() {
     assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
 }
 
-// TODO: This is third edge case in which `0x5B` is part of PUSHN instruction and hence
-// not a valid opcode to jump to
-//
-// Remove ignore once its handled
 #[test]
-#[should_panic(expected: ('exec_jump should throw error',))]
 fn test_exec_jump_inside_pushn() {
     // Given
     let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -317,6 +317,24 @@ fn test_exec_jump_invalid() {
 }
 
 #[test]
+fn test_exec_jump_invalid_0x5B_is_push_argument() {
+    // Given
+    let bytecode: Span<u8> = array![0x01, 0x02, 0x60, 0x5B, 0x04, 0x05].span();
+
+    let mut machine = MachineBuilderTestTrait::new_with_presets().with_bytecode(bytecode).build();
+
+    let counter = 0x03;
+    machine.stack.push(counter).expect('push failed');
+
+    // When
+    let result = machine.exec_jump();
+
+    // Then
+    assert(result.is_err(), 'invalid jump dest');
+    assert(result.unwrap_err() == EVMError::JumpError(INVALID_DESTINATION), 'invalid jump dest');
+}
+
+#[test]
 fn test_exec_jump_out_of_bounds() {
     // Given
     let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

This PR adds a new `valid_jump_destinations` to the execution context, which when initialised should contain indexes which are valid jump destinations.

Resolves: #544 

## What is the new behavior?

- Jumps to only valid jump destinations will be permitted, i.e if 0x5b is an argument to PUSH, then it cannot be confused for a valid jump.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No