### PR TITLE
feat: valid jumps

### DIFF
--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -116,17 +116,9 @@ impl MemoryOperation of MemoryOperationTrait {
 
         let index = self.stack.pop_usize()?;
 
-        // TODO: Currently this doesn't check that byte is actually `JUMPDEST`
-        // and not `0x5B` that is a part of PUSHN instruction
-        //
-        // That can be done by storing all valid jump locations during contract deployment
-        // which would also simplify the logic because we would be just checking if idx is
-        // present in that list
-        //
-        // Check if idx in bytecode points to `JUMPDEST` opcode
         match self.message().code.get(index) {
             Option::Some(opcode) => {
-                if *opcode.unbox() != 0x5B {
+                if !self.is_valid_jump(index) {
                     return Result::Err(EVMError::JumpError(INVALID_DESTINATION));
                 }
             },

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -140,6 +140,9 @@ impl EVMImpl of EVMTrait {
     }
 
     fn execute_code(ref vm: VM) -> ExecutionResult {
+        // initalize valid jumpdests
+        vm.init_valid_jump_destinations();
+
         // Retrieve the current program counter.
         let pc = vm.pc();
         let bytecode = vm.message().code;

--- a/crates/evm/src/model/vm.cairo
+++ b/crates/evm/src/model/vm.cairo
@@ -3,7 +3,7 @@ use evm::memory::{Memory, MemoryTrait};
 use evm::model::{Message, Environment};
 use evm::stack::{Stack, StackTrait};
 use starknet::EthAddress;
-use utils::helpers::ArrayExtTrait;
+use utils::helpers::{SpanExtension, ArrayExtTrait};
 use utils::set::{Set, SetTrait};
 use utils::traits::{SpanDefault};
 

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -285,6 +285,7 @@ fn test_exec_jump_valid() {
     let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
 
     let mut vm = VMBuilderTrait::new_with_presets().with_bytecode(bytecode).build();
+    vm.init_valid_jump_destinations();
 
     let counter = 0x03;
     vm.stack.push(counter).expect('push failed');
@@ -336,10 +337,7 @@ fn test_exec_jump_out_of_bounds() {
 
 // TODO: This is third edge case in which `0x5B` is part of PUSHN instruction and hence
 // not a valid opcode to jump to
-//
-// Remove ignore once its handled
 #[test]
-#[should_panic(expected: ('exec_jump should throw error',))]
 fn test_exec_jump_inside_pushn() {
     // Given
     let bytecode: Span<u8> = array![0x60, 0x5B, 0x60, 0x00].span();
@@ -366,6 +364,7 @@ fn test_exec_jumpi_valid_non_zero_1() {
     let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
 
     let mut vm = VMBuilderTrait::new_with_presets().with_bytecode(bytecode).build();
+    vm.init_valid_jump_destinations();
 
     let b = 0x1;
     vm.stack.push(b).expect('push failed');
@@ -386,6 +385,7 @@ fn test_exec_jumpi_valid_non_zero_2() {
     let bytecode: Span<u8> = array![0x01, 0x02, 0x03, 0x5B, 0x04, 0x05].span();
 
     let mut vm = VMBuilderTrait::new_with_presets().with_bytecode(bytecode).build();
+    vm.init_valid_jump_destinations();
 
     let b = 0x69;
     vm.stack.push(b).expect('push failed');

--- a/crates/evm/src/tests/test_model.cairo
+++ b/crates/evm/src/tests/test_model.cairo
@@ -1,5 +1,6 @@
 mod test_contract_account;
 mod test_eoa;
+mod test_vm;
 use contracts::contract_account::{IContractAccountDispatcherTrait, IContractAccountDispatcher};
 use contracts::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
 use contracts::tests::test_utils::{

--- a/crates/evm/src/tests/test_model/test_vm.cairo
+++ b/crates/evm/src/tests/test_model/test_vm.cairo
@@ -14,10 +14,10 @@ fn test_is_valid_jump_destinations() {
 
     vm.init_valid_jump_destinations();
 
-    let expected_valid_jump_destinations = array![0x3, 0x9].span();
+    let expected_valid_jump_destinations = array![3, 9].span();
     assert!(
         vm.valid_jumpdests == expected_valid_jump_destinations,
-        "expected valid_jump_destinations to be [0x3, 0x9]"
+        "expected valid_jump_destinations to be [3, 9]"
     );
 
     assert!(vm.is_valid_jump(0x3) == true, "expected jump to be valid");
@@ -28,8 +28,7 @@ fn test_is_valid_jump_destinations() {
 }
 
 #[test]
-fn test_valid_jump_destination_failing() {
-    // PUSH1, 0x03, JUMP, JUMPDEST, PUSH1, 0x09, JUMP, PUSH1 0x2, JUMPDDEST, PUSH1 0x2
+fn test_valid_jump_destination_inside_jumpn() {
     let bytecode: Array<u8> = array![0x60, 0x5B, 0x60, 0x00];
     let mut message: Message = Default::default();
     message.code = bytecode.span();

--- a/crates/evm/src/tests/test_model/test_vm.cairo
+++ b/crates/evm/src/tests/test_model/test_vm.cairo
@@ -1,0 +1,41 @@
+use evm::model::vm::{VM, VMTrait};
+use evm::model::{Message, Environment};
+
+#[test]
+fn test_is_valid_jump_destinations() {
+    // PUSH1, 0x03, JUMP, JUMPDEST, PUSH1, 0x09, JUMP, PUSH1 0x2, JUMPDDEST, PUSH1 0x2
+    let bytecode: Array<u8> = array![
+        0x60, 0x3, 0x56, 0x5b, 0x60, 0x9, 0x56, 0x60, 0x2, 0x5b, 0x60, 0x2
+    ];
+    let mut message: Message = Default::default();
+    message.code = bytecode.span();
+
+    let mut vm = VMTrait::new(message, Default::default());
+
+    vm.init_valid_jump_destinations();
+
+    let expected_valid_jump_destinations = array![0x3, 0x9].span();
+    assert!(
+        vm.valid_jumpdests == expected_valid_jump_destinations,
+        "expected valid_jump_destinations to be [0x3, 0x9]"
+    );
+
+    assert!(vm.is_valid_jump(0x3) == true, "expected jump to be valid");
+    assert!(vm.is_valid_jump(0x9) == true, "expected jump to be valid");
+
+    assert!(vm.is_valid_jump(0x4) == false, "expected jump to be invalid");
+    assert!(vm.is_valid_jump(0x5) == false, "expected jump to be invalid");
+}
+
+#[test]
+fn test_valid_jump_destination_failing() {
+    // PUSH1, 0x03, JUMP, JUMPDEST, PUSH1, 0x09, JUMP, PUSH1 0x2, JUMPDDEST, PUSH1 0x2
+    let bytecode: Array<u8> = array![0x60, 0x5B, 0x60, 0x00];
+    let mut message: Message = Default::default();
+    message.code = bytecode.span();
+
+    let mut vm = VMTrait::new(message, Default::default());
+    vm.init_valid_jump_destinations();
+
+    assert!(vm.is_valid_jump(0x1) == false, "expected false");
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

This PR adds a new `valid_jump_destinations` to the execution context, which when initialised should contain indexes which are valid jump destinations.

Resolves: #544 

## What is the new behavior?

- Jumps to only valid jump destinations will be permitted, i.e if 0x5b is an argument to PUSH, then it cannot be confused for a valid jump.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No