### PR TITLE
ci: add workflow dispatch event

### DIFF
--- a/.github/workflows/gas_snapshot.yml
+++ b/.github/workflows/gas_snapshot.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
Adds a `workflow_dispatch` to enable triggering the workflow from GH UI