### PR TITLE
refactor: gas_left VM field

### DIFF
--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -150,7 +150,6 @@ impl CallHelpersImpl of CallHelpers {
         self.merge_child(@result);
 
         self.return_data = result.return_data;
-        self.gas_used += result.gas_used;
         if result.success {
             self.stack.push(1)?;
         } else {

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -210,7 +210,7 @@ impl MemoryOperation of MemoryOperationTrait {
     /// # Specification: https://www.evm.codes/#5a?fork=shanghai
     fn exec_gas(ref self: VM) -> Result<(), EVMError> {
         self.charge_gas(gas::BASE)?;
-        self.stack.push(self.gas_used().into())
+        self.stack.push(self.gas_left().into())
     }
 
 

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -106,7 +106,7 @@ impl EVMImpl of EVMTrait {
                         success: false,
                         //TODO(optimization) avoid converstion to u256 to get bytes
                         return_data: Into::<felt252, u256>::into(err.to_string()).to_bytes(),
-                        gas_used: 0,
+                        gas_left: 0,
                         accessed_addresses: Default::default(),
                         accessed_storage_keys: Default::default(),
                     };
@@ -154,7 +154,7 @@ impl EVMImpl of EVMTrait {
             return ExecutionResult {
                 success: true,
                 return_data: vm.return_data(),
-                gas_used: vm.gas_used(),
+                gas_left: vm.gas_left(),
                 accessed_addresses: vm.accessed_addresses(),
                 accessed_storage_keys: vm.accessed_storage_keys(),
             };
@@ -172,7 +172,7 @@ impl EVMImpl of EVMTrait {
                 return ExecutionResult {
                     success: true,
                     return_data: vm.return_data(),
-                    gas_used: vm.gas_used(),
+                    gas_left: vm.gas_left(),
                     accessed_addresses: vm.accessed_addresses(),
                     accessed_storage_keys: vm.accessed_storage_keys(),
                 };
@@ -183,7 +183,7 @@ impl EVMImpl of EVMTrait {
                 return ExecutionResult {
                     success: false,
                     return_data: Into::<felt252, u256>::into(error.to_string()).to_bytes(),
-                    gas_used: vm.gas_used(),
+                    gas_left: 0,
                     accessed_addresses: vm.accessed_addresses(),
                     accessed_storage_keys: vm.accessed_storage_keys(),
                 };

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -46,7 +46,7 @@ struct Message {
 struct ExecutionResult {
     success: bool,
     return_data: Span<u8>,
-    gas_used: u128,
+    gas_left: u128,
     accessed_addresses: SpanSet<EthAddress>,
     accessed_storage_keys: SpanSet<(EthAddress, u256)>,
 }

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -614,7 +614,7 @@ fn test_exec_sstore_finalized() {
 }
 
 #[test]
-fn test_gas_should_push_gas_used_to_stack() {
+fn test_gas_should_push_gas_left_to_stack() {
     // Given
     let mut vm = VMBuilderTrait::new_with_presets().build();
 
@@ -623,5 +623,5 @@ fn test_gas_should_push_gas_used_to_stack() {
 
     // Then
     let result = vm.stack.peek().unwrap();
-    assert(result == vm.gas_used().into(), 'stack top should be gas_limit');
+    assert(result == vm.gas_left().into(), 'stack top should be gas_limit');
 }

--- a/crates/evm/src/tests/test_machine.cairo
+++ b/crates/evm/src/tests/test_machine.cairo
@@ -12,7 +12,7 @@ fn test_vm_default() {
     assert!(vm.pc() == 0);
     assert!(vm.is_running());
     assert!(!vm.error);
-    assert_eq!(vm.gas_used(), 0);
+    assert_eq!(vm.gas_left(), vm.message().gas_limit);
 }
 
 
@@ -36,21 +36,10 @@ fn test_error() {
 }
 
 #[test]
-fn test_increment_gas_unchecked() {
-    let mut vm = VMTrait::new(Default::default(), Default::default());
-
-    assert(vm.gas_used() == 0, 'wrong gas_used');
-
-    vm.increment_gas_used_unchecked(tx_gas_limit());
-
-    assert(vm.gas_used() == tx_gas_limit(), 'wrong gas_used');
-}
-
-#[test]
 fn test_increment_gas_checked() {
     let mut vm = VMTrait::new(Default::default(), Default::default());
 
-    assert(vm.gas_used() == 0, 'wrong gas_used');
+    assert_eq!(vm.gas_left(), vm.message().gas_limit);
 
     let result = vm.charge_gas(tx_gas_limit());
 

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -223,7 +223,7 @@ fn preset_vm() -> VM {
         return_data,
         env: environment,
         message,
-        gas_used: 0,
+        gas_left: message.gas_limit,
         running: true,
         error: false,
         accessed_addresses: Default::default(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #630 #622

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Refactors the `gas_used` field to use `gas_left` instead - as all accountability and querying of gas inside the EVM is performed against the gas left
- Overrides #623 
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
