### PR TITLE
feat: add event emission to `__execute__`

### DIFF
--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -19,6 +19,7 @@ mod ExternallyOwnedAccount {
     use contracts::components::upgradeable::upgradeable_component;
     use contracts::kakarot_core::interface::{IKakarotCoreDispatcher, IKakarotCoreDispatcherTrait};
     use core::option::OptionTrait;
+    use core::starknet::event::EventEmitter;
 
     use starknet::account::{Call, AccountContract};
 

--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -53,9 +53,12 @@ mod ExternallyOwnedAccount {
         TransactionExecuted: TransactionExecuted
     }
 
-    /// @notice Emitted when the account executes a transaction
-    /// @param hash The transaction hash
-    /// @param response The data returned by the methods called
+    /// event representing execution of transaction, should be emmitted inside `__execute__` of an EOA
+    ///
+    /// # Arguments
+    /// * `hash`: the transaction hash { can be obtained from `get_tx_info` }
+    /// * `response`: represents the return data obtained by applying the transaction
+    /// * `success`: represents whether the transaction succeeded or not
     #[derive(Drop, starknet::Event)]
     struct TransactionExecuted {
         #[key]

--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -19,7 +19,6 @@ mod ExternallyOwnedAccount {
     use contracts::components::upgradeable::upgradeable_component;
     use contracts::kakarot_core::interface::{IKakarotCoreDispatcher, IKakarotCoreDispatcherTrait};
     use core::option::OptionTrait;
-    use core::starknet::event::EventEmitter;
 
     use starknet::account::{Call, AccountContract};
 

--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -19,6 +19,7 @@ mod ExternallyOwnedAccount {
     use contracts::components::upgradeable::upgradeable_component;
     use contracts::kakarot_core::interface::{IKakarotCoreDispatcher, IKakarotCoreDispatcherTrait};
     use core::option::OptionTrait;
+    use core::starknet::event::EventEmitter;
 
     use starknet::account::{Call, AccountContract};
 
@@ -49,6 +50,18 @@ mod ExternallyOwnedAccount {
     #[derive(Drop, starknet::Event)]
     enum Event {
         UpgradeableEvent: upgradeable_component::Event,
+        TransactionExecuted: TransactionExecuted
+    }
+
+    /// @notice Emitted when the account executes a transaction
+    /// @param hash The transaction hash
+    /// @param response The data returned by the methods called
+    #[derive(Drop, starknet::Event)]
+    struct TransactionExecuted {
+        #[key]
+        hash: felt252,
+        response: Span<Span<felt252>>,
+        success: bool
     }
 
 
@@ -147,10 +160,22 @@ mod ExternallyOwnedAccount {
                 contract_address: self.kakarot_core_address()
             };
 
-            let (_, return_data) = kakarot_core_dispatcher
+            let (success, return_data) = kakarot_core_dispatcher
                 .eth_send_transaction(destination, gas_limit, gas_price, amount, calldata);
+            let return_data = return_data.to_felt252_array().span();
 
-            array![return_data.to_felt252_array().span()]
+            let tx_info = get_tx_info().unbox();
+            // see argent -> https://github.com/argentlabs/argent-contracts-starknet/blob/4070f39a039c85df4d7a32003030db598c17d27d/contracts/account/src/argent_account.cairo#L231C10-L231C10
+            self
+                .emit(
+                    TransactionExecuted {
+                        hash: tx_info.transaction_hash,
+                        response: array![return_data].span(),
+                        success
+                    }
+                );
+
+            array![return_data]
         }
     }
 

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod test_external_owned_account {
+    use contracts::eoa::ExternallyOwnedAccount::TransactionExecuted;
     use contracts::eoa::{
         IExternallyOwnedAccount, ExternallyOwnedAccount, IExternallyOwnedAccountDispatcher,
         IExternallyOwnedAccountDispatcherTrait
@@ -15,13 +16,14 @@ mod test_external_owned_account {
         MockContractUpgradeableV1
     };
     use contracts::tests::test_utils::{
-        setup_contracts_for_testing, deploy_eoa, deploy_contract_account
+        setup_contracts_for_testing, deploy_eoa, deploy_contract_account, pop_log
     };
     use contracts::uninitialized_account::{
         IUninitializedAccountDispatcher, IUninitializedAccountDispatcherTrait, UninitializedAccount,
         IUninitializedAccount
     };
     use core::array::SpanTrait;
+    use core::box::BoxTrait;
     use core::starknet::account::{Call, AccountContractDispatcher, AccountContractDispatcherTrait};
 
     use evm::model::{Address, AddressTrait, ContractAccountTrait};
@@ -34,7 +36,7 @@ mod test_external_owned_account {
     use starknet::testing::{set_caller_address, set_contract_address, set_signature};
     use starknet::{
         deploy_syscall, ContractAddress, ClassHash, VALIDATED, get_contract_address,
-        contract_address_const, EthAddress, eth_signature::{Signature}
+        contract_address_const, EthAddress, eth_signature::{Signature}, get_tx_info
     };
     use utils::helpers::EthAddressSignatureTrait;
     use utils::helpers::{U8SpanExTrait, u256_to_bytes_array};
@@ -134,7 +136,26 @@ mod test_external_owned_account {
             calldata: encoded_tx.to_felt252_array()
         };
 
-        eoa_contract.__execute__(array![call]);
+        let result = eoa_contract.__execute__(array![call]);
+        assert!(result.len() == 1, "expected result to be of length 1");
+
+        let tx_info = get_tx_info().unbox();
+
+        let event = pop_log::<TransactionExecuted>(kakarot_core.contract_address).unwrap();
+
+        assert!(
+            event.hash == tx_info.transaction_hash,
+            "expected {}, got {}",
+            tx_info.transaction_hash,
+            event.hash
+        );
+        assert!(
+            event.response == result.span(),
+            "expected {}, got {}",
+            tx_info.transaction_hash,
+            event.hash
+        );
+        assert!(event.success == true, "expected `success` to be `true`");
 
         // check counter value has increased
         let (_, return_data) = kakarot_core

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -41,6 +41,7 @@ mod test_external_owned_account {
     use utils::helpers::EthAddressSignatureTrait;
     use utils::helpers::{U8SpanExTrait, u256_to_bytes_array};
     use utils::tests::test_data::{legacy_rlp_encoded_tx, eip_2930_encoded_tx, eip_1559_encoded_tx};
+    use utils::traits::{SpanTDisplay, debug_display_based::TDisplay};
 
 
     #[test]
@@ -137,25 +138,25 @@ mod test_external_owned_account {
         };
 
         let result = eoa_contract.__execute__(array![call]);
-        assert!(result.len() == 1, "expected result to be of length 1");
+        assert_eq!(result.len(), 1);
+
+        let return_data = result[0];
 
         let tx_info = get_tx_info().unbox();
 
         let event = pop_log::<TransactionExecuted>(kakarot_core.contract_address).unwrap();
 
-        assert!(
-            event.hash == tx_info.transaction_hash,
-            "expected {}, got {}",
-            tx_info.transaction_hash,
-            event.hash
+        assert_eq!(
+            event.hash, tx_info.transaction_hash
         );
-        assert!(
-            event.response == result.span(),
-            "expected {}, got {}",
-            tx_info.transaction_hash,
-            event.hash
-        );
-        assert!(event.success == true, "expected `success` to be `true`");
+
+        assert_eq!(return_data, return_data);
+
+        // assert_eq!(
+        //     event.response[0], return_data
+        // );
+
+        assert_eq!(event.success, true);
 
         // check counter value has increased
         let (_, return_data) = kakarot_core

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -41,7 +41,7 @@ mod test_external_owned_account {
     use utils::helpers::EthAddressSignatureTrait;
     use utils::helpers::{U8SpanExTrait, u256_to_bytes_array};
     use utils::tests::test_data::{legacy_rlp_encoded_tx, eip_2930_encoded_tx, eip_1559_encoded_tx};
-    use utils::traits::{SpanTDisplay, debug_display_based::TDisplay};
+    use utils::traits::SpanDebug;
 
 
     #[test]
@@ -140,21 +140,13 @@ mod test_external_owned_account {
         let result = eoa_contract.__execute__(array![call]);
         assert_eq!(result.len(), 1);
 
-        let return_data = result[0];
-
         let tx_info = get_tx_info().unbox();
 
         let event = pop_log::<TransactionExecuted>(kakarot_core.contract_address).unwrap();
 
-        assert_eq!(
-            event.hash, tx_info.transaction_hash
-        );
+        assert_eq!(event.hash, tx_info.transaction_hash);
 
-        assert_eq!(return_data, return_data);
-
-        // assert_eq!(
-        //     event.response[0], return_data
-        // );
+        assert_eq!(event.response, result.span());
 
         assert_eq!(event.success, true);
 

--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -52,6 +52,7 @@ impl EthAddressDisplay = display_felt252_based::TDisplay<EthAddress>;
 impl ContractAddressDisplay = display_felt252_based::TDisplay<ContractAddress>;
 impl EthAddressDebug = debug_display_based::TDisplay<EthAddress>;
 impl ContractAddressDebug = debug_display_based::TDisplay<ContractAddress>;
+impl SpanDebug<T, +Display<T>, +Copy<T>> = debug_display_based::TDisplay<Span<T>>;
 
 impl SpanTDisplay<T, +Display<T>, +Copy<T>> of Display<Span<T>> {
     fn fmt(self: @Span<T>, ref f: Formatter) -> Result<(), Error> {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We don't emit an event for a transaction's execution inside `__execute__`, which is done in case of [KKRT-0](https://github.com/kkrt-labs/kakarot/blob/92ab8dffd63ecfa967ac834c88c554026b7e05ad/src/kakarot/accounts/eoa/library.cairo#L28).

Resolves: #619 

## What is the new behavior?

- We emit event inside `__execute__`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/636)
<!-- Reviewable:end -->
