### PR TITLE
feat: put extraction of y_parity in kakarot codebase

### DIFF
--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -29,7 +29,7 @@ mod ExternallyOwnedAccount {
     };
     use utils::eth_transaction::{EthTransactionTrait, EthereumTransaction, TransactionMetadata};
     use utils::helpers::{
-        Felt252SpanExTrait, U8SpanExTrait, EthAddressSignatureTrait, TryIntoEthSignature
+        Felt252SpanExTrait, U8SpanExTrait, EthAddressSignatureTrait, TryIntoEthSignatureTrait
     };
 
     component!(path: upgradeable_component, storage: upgradeable, event: UpgradeableEvent);
@@ -113,12 +113,15 @@ mod ExternallyOwnedAccount {
             );
 
             let signature = tx_info.signature;
+            let chain_id = self.chain_id();
 
             let tx_metadata = TransactionMetadata {
                 address: self.evm_address(),
-                chain_id: self.chain_id(),
+                chain_id,
                 account_nonce: tx_info.nonce.try_into().unwrap(),
-                signature: signature.try_into().expect('signature extraction failed')
+                signature: signature
+                    .try_into_eth_signature(chain_id)
+                    .expect('signature extraction failed')
             };
 
             let encoded_tx = (call.calldata)

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -262,10 +262,7 @@ mod test_external_owned_account {
             y_parity: true
         };
         set_signature(
-            signature
-                .to_felt252_array(TransactionType::Legacy, chain_id)
-                .unwrap()
-                .span()
+            signature.to_felt252_array(TransactionType::Legacy, chain_id).unwrap().span()
         );
 
         set_contract_address(contract_address_const::<0>());

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -262,7 +262,7 @@ mod test_external_owned_account {
             y_parity: true
         };
         set_signature(
-            signature.to_felt252_array(TransactionType::Legacy, chain_id).unwrap().span()
+            signature.try_into_felt252_array(TransactionType::Legacy, chain_id).unwrap().span()
         );
 
         set_contract_address(contract_address_const::<0>());
@@ -295,7 +295,7 @@ mod test_external_owned_account {
         };
 
         set_signature(
-            signature.to_felt252_array(TransactionType::EIP2930, chain_id).unwrap().span()
+            signature.try_into_felt252_array(TransactionType::EIP2930, chain_id).unwrap().span()
         );
 
         set_contract_address(contract_address_const::<0>());
@@ -328,7 +328,7 @@ mod test_external_owned_account {
         };
 
         set_signature(
-            signature.to_felt252_array(TransactionType::EIP1559, chain_id).unwrap().span()
+            signature.try_into_felt252_array(TransactionType::EIP1559, chain_id).unwrap().span()
         );
 
         set_contract_address(contract_address_const::<0>());

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -38,6 +38,7 @@ mod test_external_owned_account {
         deploy_syscall, ContractAddress, ClassHash, VALIDATED, get_contract_address,
         contract_address_const, EthAddress, eth_signature::{Signature}, get_tx_info
     };
+    use utils::eth_transaction::TransactionType;
     use utils::helpers::EthAddressSignatureTrait;
     use utils::helpers::{U8SpanExTrait, u256_to_bytes_array};
     use utils::tests::test_data::{legacy_rlp_encoded_tx, eip_2930_encoded_tx, eip_1559_encoded_tx};
@@ -254,12 +255,18 @@ mod test_external_owned_account {
         // to reproduce locally:
         // run: cp .env.example .env
         // bun install & bun run scripts/compute_rlp_encoding.ts
+        // v -> 0x869082929cbe92ac
         let signature = Signature {
             r: 0xaae7c4f6e4caa03257e37a6879ed5b51a6f7db491d559d10a0594f804aa8d797,
             s: 0x2f3d9634f8cb9b9a43b048ee3310be91c2d3dc3b51a3313b473ef2260bbf6bc7,
             y_parity: true
         };
-        set_signature(signature.to_felt252_array().span());
+        set_signature(
+            signature
+                .to_felt252_array(TransactionType::Legacy, Option::Some(0x869082929cbe92ac))
+                .unwrap()
+                .span()
+        );
 
         set_contract_address(contract_address_const::<0>());
 
@@ -289,7 +296,9 @@ mod test_external_owned_account {
             y_parity: true
         };
 
-        set_signature(signature.to_felt252_array().span());
+        set_signature(
+            signature.to_felt252_array(TransactionType::EIP2930, Option::None).unwrap().span()
+        );
 
         set_contract_address(contract_address_const::<0>());
 
@@ -319,7 +328,9 @@ mod test_external_owned_account {
             y_parity: true
         };
 
-        set_signature(signature.to_felt252_array().span());
+        set_signature(
+            signature.to_felt252_array(TransactionType::EIP1559, Option::None).unwrap().span()
+        );
 
         set_contract_address(contract_address_const::<0>());
 

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -251,11 +251,11 @@ mod test_external_owned_account {
         let evm_address: EthAddress = 0x6Bd85F39321B00c6d603474C5B2fddEB9c92A466_u256.into();
         let eoa = kakarot_core.deploy_eoa(evm_address);
         let eoa_contract = AccountContractDispatcher { contract_address: eoa };
+        let chain_id = kakarot_core.chain_id();
 
         // to reproduce locally:
         // run: cp .env.example .env
         // bun install & bun run scripts/compute_rlp_encoding.ts
-        // v -> 0x869082929cbe92ac
         let signature = Signature {
             r: 0xaae7c4f6e4caa03257e37a6879ed5b51a6f7db491d559d10a0594f804aa8d797,
             s: 0x2f3d9634f8cb9b9a43b048ee3310be91c2d3dc3b51a3313b473ef2260bbf6bc7,
@@ -263,7 +263,7 @@ mod test_external_owned_account {
         };
         set_signature(
             signature
-                .to_felt252_array(TransactionType::Legacy, Option::Some(0x869082929cbe92ac))
+                .to_felt252_array(TransactionType::Legacy, chain_id)
                 .unwrap()
                 .span()
         );
@@ -286,6 +286,7 @@ mod test_external_owned_account {
         let evm_address: EthAddress = 0x6Bd85F39321B00c6d603474C5B2fddEB9c92A466_u256.into();
         let eoa = kakarot_core.deploy_eoa(evm_address);
         let eoa_contract = AccountContractDispatcher { contract_address: eoa };
+        let chain_id = kakarot_core.chain_id();
 
         // to reproduce locally:
         // run: cp .env.example .env
@@ -297,7 +298,7 @@ mod test_external_owned_account {
         };
 
         set_signature(
-            signature.to_felt252_array(TransactionType::EIP2930, Option::None).unwrap().span()
+            signature.to_felt252_array(TransactionType::EIP2930, chain_id).unwrap().span()
         );
 
         set_contract_address(contract_address_const::<0>());
@@ -318,6 +319,7 @@ mod test_external_owned_account {
         let evm_address: EthAddress = 0x6Bd85F39321B00c6d603474C5B2fddEB9c92A466_u256.into();
         let eoa = kakarot_core.deploy_eoa(evm_address);
         let eoa_contract = AccountContractDispatcher { contract_address: eoa };
+        let chain_id = kakarot_core.chain_id();
 
         // to reproduce locally:
         // run: cp .env.example .env
@@ -329,7 +331,7 @@ mod test_external_owned_account {
         };
 
         set_signature(
-            signature.to_felt252_array(TransactionType::EIP1559, Option::None).unwrap().span()
+            signature.to_felt252_array(TransactionType::EIP1559, chain_id).unwrap().span()
         );
 
         set_contract_address(contract_address_const::<0>());

--- a/crates/utils/src/constants.cairo
+++ b/crates/utils/src/constants.cairo
@@ -14,7 +14,7 @@ const CONTRACT_ADDRESS_PREFIX: felt252 = 'STARKNET_CONTRACT_ADDRESS';
 //TODO(gas): determine correct block gas limit
 const BLOCK_GAS_LIMIT: u128 = 30_000_000;
 // CHAIN_ID = KKRT (0x4b4b5254) in ASCII
-const CHAIN_ID: u256 = 1263227476;
+const CHAIN_ID: u128 = 1263227476;
 
 // STACK
 const STACK_MAX_DEPTH: usize = 1024;

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -219,6 +219,39 @@ impl EncodedTransactionImpl of EncodedTransactionTrait {
     }
 }
 
+#[derive(Drop, PartialEq)]
+enum TransactionType {
+    Legacy,
+    EIP2930,
+    EIP1559
+}
+
+impl TranscationTypeIntoU8Impl of Into<TransactionType, u8> {
+    fn into(self: TransactionType) -> u8 {
+        match self {
+            TransactionType::Legacy => { 0 },
+            TransactionType::EIP2930 => { 1 },
+            TransactionType::EIP1559 => { 2 }
+        }
+    }
+}
+
+impl TryIntoTransactionTypeImpl of TryInto<u128, TransactionType> {
+    fn try_into(self: u128) -> Option<TransactionType> {
+        if (self == 0) {
+            return Option::Some(TransactionType::Legacy);
+        }
+        if (self == 1) {
+            return Option::Some(TransactionType::EIP2930);
+        }
+        if (self == 2) {
+            return Option::Some(TransactionType::EIP1559);
+        }
+
+        Option::None
+    }
+}
+
 #[generate_trait]
 impl EthTransactionImpl of EthTransactionTrait {
     /// Decode a raw Ethereum transaction

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -236,8 +236,8 @@ impl TranscationTypeIntoU8Impl of Into<TransactionType, u8> {
     }
 }
 
-impl TryIntoTransactionTypeImpl of TryInto<u128, TransactionType> {
-    fn try_into(self: u128) -> Option<TransactionType> {
+impl TryIntoTransactionTypeImpl of TryInto<u8, TransactionType> {
+    fn try_into(self: u8) -> Option<TransactionType> {
         if (self == 0) {
             return Option::Some(TransactionType::Legacy);
         }

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -1199,20 +1199,17 @@ impl EthAddressSignatureTraitImpl of EthAddressSignatureTrait {
     fn to_felt252_array(
         self: EthSignature, tx_type: TransactionType, chain_id: u128
     ) -> Option<Array<felt252>> {
-        let tx_type: u8 = tx_type.into();
-
         let mut res: Array<felt252> = array![
             self.r.low.into(), self.r.high.into(), self.s.low.into(), self.s.high.into()
         ];
 
-        if (tx_type == 0) {
-            let v = self.y_parity.into() + 2 * chain_id + 35;
-            res.append(v.into());
-        } else {
-            let y_parity: u128 = self.y_parity.into();
-            res.append(y_parity.into())
+        let value = match tx_type {
+            TransactionType::Legacy => { self.y_parity.into() + 2 * chain_id + 35 },
+            TransactionType::EIP2930 => { self.y_parity.into() },
+            TransactionType::EIP1559 => { self.y_parity.into() }
         };
 
+        res.append(value.into());
         Option::Some(res)
     }
 }

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -1196,7 +1196,7 @@ impl TryIntoEthSignatureImpl of TryIntoEthSignatureTrait {
 
 #[generate_trait]
 impl EthAddressSignatureTraitImpl of EthAddressSignatureTrait {
-    fn to_felt252_array(
+    fn try_into_felt252_array(
         self: EthSignature, tx_type: TransactionType, chain_id: u128
     ) -> Option<Array<felt252>> {
         let mut res: Array<felt252> = array![

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -591,19 +591,19 @@ mod eth_signature_test {
             .span();
 
         let result = signature_0
-            .to_felt252_array(TransactionType::Legacy, CHAIN_ID)
+            .try_into_felt252_array(TransactionType::Legacy, CHAIN_ID)
             .unwrap()
             .span();
         assert_eq!(result, expected_signature_0);
 
         let result = signature_1
-            .to_felt252_array(TransactionType::EIP2930, CHAIN_ID)
+            .try_into_felt252_array(TransactionType::EIP2930, CHAIN_ID)
             .unwrap()
             .span();
         assert_eq!(result, expected_signature_1);
 
         let result = signature_2
-            .to_felt252_array(TransactionType::EIP1559, CHAIN_ID)
+            .try_into_felt252_array(TransactionType::EIP1559, CHAIN_ID)
             .unwrap()
             .span();
         assert_eq!(result, expected_signature_2);

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -564,7 +564,6 @@ mod eth_signature_test {
         };
 
         let expected_signature_0: Span<felt252> = array![
-            0x0,
             signature_0.r.low.into(),
             signature_0.r.high.into(),
             signature_0.s.low.into(),
@@ -574,7 +573,6 @@ mod eth_signature_test {
             .span();
 
         let expected_signature_1: Span<felt252> = array![
-            0x1,
             signature_1.r.low.into(),
             signature_1.r.high.into(),
             signature_1.s.low.into(),
@@ -584,7 +582,6 @@ mod eth_signature_test {
             .span();
 
         let expected_signature_2: Span<felt252> = array![
-            0x2,
             signature_2.r.low.into(),
             signature_2.r.high.into(),
             signature_2.s.low.into(),
@@ -594,19 +591,19 @@ mod eth_signature_test {
             .span();
 
         let result = signature_0
-            .to_felt252_array(TransactionType::Legacy, Option::Some(0x9696a4cb))
+            .to_felt252_array(TransactionType::Legacy, CHAIN_ID)
             .unwrap()
             .span();
         assert_eq!(result, expected_signature_0);
 
         let result = signature_1
-            .to_felt252_array(TransactionType::EIP2930, Option::None)
+            .to_felt252_array(TransactionType::EIP2930, CHAIN_ID)
             .unwrap()
             .span();
         assert_eq!(result, expected_signature_1);
 
         let result = signature_2
-            .to_felt252_array(TransactionType::EIP1559, Option::None)
+            .to_felt252_array(TransactionType::EIP1559, CHAIN_ID)
             .unwrap()
             .span();
         assert_eq!(result, expected_signature_2);
@@ -647,7 +644,6 @@ mod eth_signature_test {
         };
 
         let signature_0_felt252_arr: Array<felt252> = array![
-            0x0,
             signature_0.r.low.into(),
             signature_0.r.high.into(),
             signature_0.s.low.into(),
@@ -656,7 +652,6 @@ mod eth_signature_test {
         ];
 
         let signature_1_felt252_arr: Array<felt252> = array![
-            0x1,
             signature_1.r.low.into(),
             signature_1.r.high.into(),
             signature_1.s.low.into(),
@@ -665,7 +660,6 @@ mod eth_signature_test {
         ];
 
         let signature_2_felt252_arr: Array<felt252> = array![
-            0x2,
             signature_2.r.low.into(),
             signature_2.r.high.into(),
             signature_2.s.low.into(),

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -524,79 +524,171 @@ mod span_u8_test {
 
 mod eth_signature_test {
     use starknet::eth_signature::Signature;
-    use utils::helpers::{EthAddressSignatureTrait, TryIntoEthSignature};
+    use utils::constants::CHAIN_ID;
+    use utils::eth_transaction::TransactionType;
+    use utils::helpers::{EthAddressSignatureTrait, TryIntoEthSignatureTrait};
+    use utils::traits::{EthSignatureDisplay, debug_display_based::TDisplay, SpanTDisplay};
 
     #[test]
     fn test_eth_signature_to_felt252_array() {
-        let signature_1 = Signature {
-            r: 0x3e1d21af857363cb69f565cf5a791b6e326186250815570c80bd2b7f465802f8,
-            s: 0x37a9cec24f7d5c8916ded76f702fcf2b93a20b28a7db8f27d7f4e6e11288bda4,
-            y_parity: true
-        };
+        // generated via ./scripts/compute_rlp_encoding.ts
+        // inputs:
+        //          to: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+        //          value: 1
+        //          gasLimit: 1
+        //          gasPrice: 1
+        //          nonce: 1
+        //          chainId: 1263227476
+        //          data: 0xabcdef
+        //          tx_type: 0 for signature_0, 1 for signature_1, 2 for signature_2
 
-        let signature_2 = Signature {
-            r: 0x3e1d21af857363cb69f565cf5a791b6e326186250815570c80bd2b7f465802f8,
-            s: 0x37a9cec24f7d5c8916ded76f702fcf2b93a20b28a7db8f27d7f4e6e11288bda4,
+        // tx_type = 0, v: 0x9696a4cb
+        let signature_0 = Signature {
+            r: 0x306c3f638450a95f1f669481bf8ede9b056ef8d94259a3104f3a28673e02823d,
+            s: 0x41ea07e6d3d02773e380e752e5b3f9d28aca3882ee165e56b402cca0189967c9,
             y_parity: false
         };
 
-        let expected_signature_1: Array<felt252> = array![
-            signature_1.r.low.into(),
-            signature_1.r.high.into(),
-            signature_1.s.low.into(),
-            signature_1.s.high.into(),
-            0x01_felt252,
-        ];
+        // tx_type = 1
+        let signature_1 = Signature {
+            r: 0x615c33039b7b09e3d5aa3cf1851c35abe7032f92111cc95ef45f83d032ccff5d,
+            s: 0x30b5f1a58abce1c7d45309b7a3b0befeddd1aee203021172779dd693a1e59505,
+            y_parity: false
+        };
 
-        let expected_signature_2: Array<felt252> = array![
+        // tx_type = 2
+        let signature_2 = Signature {
+            r: 0xbc485ed0b43483ebe5fbff90962791c015755cc03060a33360b1b3e823bb71a4,
+            s: 0x4c47017509e1609db6c2e8e2b02327caeb709c986d8b63099695105432afa533,
+            y_parity: false
+        };
+
+        let expected_signature_0: Span<felt252> = array![
+            0x0,
+            signature_0.r.low.into(),
+            signature_0.r.high.into(),
+            signature_0.s.low.into(),
+            signature_0.s.high.into(),
+            0x9696a4cb
+        ]
+            .span();
+
+        let expected_signature_1: Span<felt252> = array![
+            0x1,
             signature_1.r.low.into(),
             signature_1.r.high.into(),
             signature_1.s.low.into(),
             signature_1.s.high.into(),
             0x0_felt252,
-        ];
+        ]
+            .span();
 
-        let result = signature_1.to_felt252_array();
-        assert(result == expected_signature_1, 'wrong signature conversion');
+        let expected_signature_2: Span<felt252> = array![
+            0x2,
+            signature_2.r.low.into(),
+            signature_2.r.high.into(),
+            signature_2.s.low.into(),
+            signature_2.s.high.into(),
+            0x0_felt252,
+        ]
+            .span();
 
-        let result = signature_2.to_felt252_array();
-        assert(result == expected_signature_2, 'wrong signature conversion');
+        let result = signature_0
+            .to_felt252_array(TransactionType::Legacy, Option::Some(0x9696a4cb))
+            .unwrap()
+            .span();
+        assert_eq!(result, expected_signature_0);
+
+        let result = signature_1
+            .to_felt252_array(TransactionType::EIP2930, Option::None)
+            .unwrap()
+            .span();
+        assert_eq!(result, expected_signature_1);
+
+        let result = signature_2
+            .to_felt252_array(TransactionType::EIP1559, Option::None)
+            .unwrap()
+            .span();
+        assert_eq!(result, expected_signature_2);
     }
 
     #[test]
     fn test_felt252_array_to_eth_signature() {
-        let signature_1 = Signature {
-            r: 0x3e1d21af857363cb69f565cf5a791b6e326186250815570c80bd2b7f465802f8,
-            s: 0x37a9cec24f7d5c8916ded76f702fcf2b93a20b28a7db8f27d7f4e6e11288bda4,
-            y_parity: true
-        };
+        // generated via ./scripts/compute_rlp_encoding.ts
+        // inputs:
+        //          to: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+        //          value: 1
+        //          gasLimit: 1
+        //          gasPrice: 1
+        //          nonce: 1
+        //          chainId: 1263227476
+        //          data: 0xabcdef
+        //          tx_type: 0 for signature_0, 1 for signature_1, 2 for signature_2
 
-        let signature_2 = Signature {
-            r: 0x3e1d21af857363cb69f565cf5a791b6e326186250815570c80bd2b7f465802f8,
-            s: 0x37a9cec24f7d5c8916ded76f702fcf2b93a20b28a7db8f27d7f4e6e11288bda4,
+        // tx_type = 0, v: 0x9696a4cb
+        let signature_0 = Signature {
+            r: 0x306c3f638450a95f1f669481bf8ede9b056ef8d94259a3104f3a28673e02823d,
+            s: 0x41ea07e6d3d02773e380e752e5b3f9d28aca3882ee165e56b402cca0189967c9,
             y_parity: false
         };
 
+        // tx_type = 1
+        let signature_1 = Signature {
+            r: 0x615c33039b7b09e3d5aa3cf1851c35abe7032f92111cc95ef45f83d032ccff5d,
+            s: 0x30b5f1a58abce1c7d45309b7a3b0befeddd1aee203021172779dd693a1e59505,
+            y_parity: false
+        };
+
+        // tx_type = 2
+        let signature_2 = Signature {
+            r: 0xbc485ed0b43483ebe5fbff90962791c015755cc03060a33360b1b3e823bb71a4,
+            s: 0x4c47017509e1609db6c2e8e2b02327caeb709c986d8b63099695105432afa533,
+            y_parity: false
+        };
+
+        let signature_0_felt252_arr: Array<felt252> = array![
+            0x0,
+            signature_0.r.low.into(),
+            signature_0.r.high.into(),
+            signature_0.s.low.into(),
+            signature_0.s.high.into(),
+            0x9696a4cb
+        ];
+
         let signature_1_felt252_arr: Array<felt252> = array![
+            0x1,
             signature_1.r.low.into(),
             signature_1.r.high.into(),
             signature_1.s.low.into(),
             signature_1.s.high.into(),
-            0x01_felt252,
+            0x0
         ];
 
         let signature_2_felt252_arr: Array<felt252> = array![
-            signature_1.r.low.into(),
-            signature_1.r.high.into(),
-            signature_1.s.low.into(),
-            signature_1.s.high.into(),
-            0x0_felt252,
+            0x2,
+            signature_2.r.low.into(),
+            signature_2.r.high.into(),
+            signature_2.s.low.into(),
+            signature_2.s.high.into(),
+            0x0
         ];
 
-        let result = signature_1_felt252_arr.span().try_into().unwrap();
-        assert(result == signature_1, 'wrong signature extracted');
+        let result: Signature = signature_0_felt252_arr
+            .span()
+            .try_into_eth_signature(CHAIN_ID)
+            .unwrap();
+        assert_eq!(result, signature_0);
 
-        let result = signature_2_felt252_arr.span().try_into().unwrap();
-        assert(result == signature_2, 'wrong signature extracted');
+        let result: Signature = signature_1_felt252_arr
+            .span()
+            .try_into_eth_signature(CHAIN_ID)
+            .unwrap();
+        assert_eq!(result, signature_1);
+
+        let result: Signature = signature_2_felt252_arr
+            .span()
+            .try_into_eth_signature(CHAIN_ID)
+            .unwrap();
+        assert_eq!(result, signature_2);
     }
 }

--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -3,7 +3,7 @@ use core::fmt::{Display, Debug, Formatter, Error};
 use evm::errors::{EVMError, ensure, TYPE_CONVERSION_ERROR};
 use starknet::{
     StorageBaseAddress, storage_address_from_base, storage_base_address_from_felt252, EthAddress,
-    ContractAddress, Store, SyscallResult
+    ContractAddress, Store, SyscallResult, eth_signature::Signature as EthSignature
 };
 use utils::math::{Zero, One, Bitshift};
 
@@ -53,6 +53,16 @@ impl ContractAddressDisplay = display_felt252_based::TDisplay<ContractAddress>;
 impl EthAddressDebug = debug_display_based::TDisplay<EthAddress>;
 impl ContractAddressDebug = debug_display_based::TDisplay<ContractAddress>;
 impl SpanDebug<T, +Display<T>, +Copy<T>> = debug_display_based::TDisplay<Span<T>>;
+
+impl EthSignatureDisplay of Display<EthSignature> {
+    fn fmt(self: @EthSignature, ref f: Formatter) -> Result<(), Error> {
+        write!(f, "r: {}", *self.r);
+        write!(f, "s: {}", *self.s);
+        write!(f, "y_parity: {}", *self.y_parity);
+
+        Result::Ok(())
+    }
+}
 
 impl SpanTDisplay<T, +Display<T>, +Copy<T>> of Display<Span<T>> {
     fn fmt(self: @Span<T>, ref f: Formatter) -> Result<(), Error> {

--- a/scripts/compute_rlp_encoding.ts
+++ b/scripts/compute_rlp_encoding.ts
@@ -129,6 +129,9 @@ const main = async () => {
       : parseInt(v, 16) == 1;
   console.log("r: ", r);
   console.log("s: ", s);
+  if (tx_type == 0) {
+    console.log("v: ", v);
+  }
   console.log("y parity: ", y_parity);
 
   process.exit(0);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The extraction of `y_parity` for legacy transactions is left to the RPC.

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The extraction of `y_parity` for legacy transactions is done on kakarot EOA itself.
- The new eth signature format is: `[tx_type, r.low, r.high, s.low, s.high, v || y_parity]`
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/643)
<!-- Reviewable:end -->
