### PR TITLE
fix: read state on undeployed alive account

### DIFF
--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -4,6 +4,7 @@ use evm::gas;
 use evm::memory::MemoryTrait;
 use evm::model::account::AccountTrait;
 use evm::model::vm::{VM, VMTrait};
+use evm::model::{AddressTrait};
 use evm::stack::StackTrait;
 use evm::state::{StateTrait, compute_state_key};
 use hash::{HashStateTrait, HashStateExTrait};
@@ -101,7 +102,9 @@ impl MemoryOperation of MemoryOperationTrait {
         let new_value = self.stack.pop()?;
         let evm_address = self.message().target.evm;
         let account = self.env.state.get_account(evm_address);
-        let original_value = account.fetch_original_storage(key)?;
+        //TODO(bug) restore check for `is_deployed` inside `read_storage`
+        let is_deployed = evm_address.is_deployed();
+        let original_value = account.read_storage(key, is_deployed)?;
         let current_value = self.env.state.read_state(evm_address, key)?;
 
         // GAS

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -140,11 +140,14 @@ impl StateImpl of StateTrait {
     fn read_state(ref self: State, evm_address: EthAddress, key: u256) -> Result<u256, EVMError> {
         let internal_key = compute_state_key(evm_address, key);
         let maybe_entry = self.accounts_storage.read(internal_key);
+        // TODO(bug): Due to a compiler bug, we pass is_deployed to the read_storage
+        // function instead of calling it inside `read_storage` directly.
+        let is_deployed = evm_address.is_deployed();
         match maybe_entry {
             Option::Some((_, _, value)) => { return Result::Ok(value); },
             Option::None => {
                 let account = self.get_account(evm_address);
-                return account.read_storage(key);
+                return account.read_storage(key, is_deployed);
             }
         }
     }

--- a/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
+++ b/crates/evm/src/tests/test_instructions/test_memory_operations.cairo
@@ -554,8 +554,9 @@ fn test_exec_sstore_from_state() {
     assert(vm.env.state.read_state(evm_address(), key).unwrap() == value, 'wrong value in state')
 }
 
+
 #[test]
-fn test_exec_sstore_on_undeployed_account() {
+fn test_exec_sstore_on_account_undeployed() {
     // Given
     setup_contracts_for_testing();
     let mut vm = VMBuilderTrait::new_with_presets().build();
@@ -570,6 +571,34 @@ fn test_exec_sstore_on_undeployed_account() {
     // Then
     assert(vm.env.state.read_state(evm_address(), key).unwrap() == value, 'wrong value in state')
 }
+
+#[test]
+fn test_exec_sstore_on_contract_account_alive() {
+    // Given
+    setup_contracts_for_testing();
+    let mut vm = VMBuilderTrait::new_with_presets().build();
+    let key: u256 = 0x100000000000000000000000000000001;
+    let value: u256 = 0xABDE1E11A5;
+    vm.stack.push(value).expect('push failed');
+    vm.stack.push(key).expect('push failed');
+
+    // When
+    let account = Account {
+        account_type: AccountType::ContractAccount,
+        address: vm.message().target,
+        code: array![].span(),
+        nonce: 1,
+        balance: 0,
+        selfdestruct: false
+    };
+    vm.env.state.set_account(account);
+    assert!(vm.env.state.is_account_alive(account.address.evm));
+    vm.exec_sstore().expect('exec sstore failed');
+
+    // Then
+    assert(vm.env.state.read_state(evm_address(), key).unwrap() == value, 'wrong value in state')
+}
+
 
 #[test]
 fn test_exec_sstore_static_call() {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #656 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Accounts can be either
- unalive && undeployed (and thus, "Unkown")
- alive && undeployed (and thus, their type is set - alive means that it's in the state but not commited yet)

In this PR
- Added a check to ensure that when reading from state, the account is __deployed__
- Added a related test

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/658)
<!-- Reviewable:end -->
