### PR TITLE
feat(gas): charge tx gas fee

### DIFF
--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -80,15 +80,18 @@ impl ExecutionResultImpl of ExecutionResultTrait {
 
 #[derive(Destruct)]
 struct ExecutionSummary {
-    state: State,
+    success: bool,
     return_data: Span<u8>,
-    success: bool
+    gas_left: u128,
+    state: State,
 }
 
 #[generate_trait]
 impl ExecutionSummaryImpl of ExecutionSummaryTrait {
     fn exceptional_failure(error: Span<u8>) -> ExecutionSummary {
-        ExecutionSummary { state: Default::default(), return_data: error, success: false }
+        ExecutionSummary {
+            success: false, return_data: error, gas_left: 0, state: Default::default(),
+        }
     }
 }
 

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -260,10 +260,6 @@ impl AccountImpl of AccountTrait {
         }
     }
 
-    #[inline(always)]
-    fn set_balance(ref self: Account, value: u256) {
-        self.balance = value;
-    }
 
     #[inline(always)]
     fn balance(self: @Account) -> u256 {
@@ -369,5 +365,13 @@ impl AccountImpl of AccountTrait {
     #[inline(always)]
     fn is_selfdestruct(self: @Account) -> bool {
         *self.selfdestruct
+    }
+}
+
+#[generate_trait]
+impl AccountInternals of AccountInternalTrait {
+    #[inline(always)]
+    fn set_balance(ref self: Account, value: u256) {
+        self.balance = value;
     }
 }

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -2,7 +2,7 @@ use contracts::kakarot_core::{IKakarotCore, KakarotCore};
 use core::starknet::SyscallResultTrait;
 
 use evm::errors::{ensure, EVMError, WRITE_SYSCALL_FAILED, READ_SYSCALL_FAILED, BALANCE_OVERFLOW};
-use evm::model::account::{AccountTrait};
+use evm::model::account::{AccountTrait, AccountInternalTrait};
 use evm::model::{Event, Transfer, Account, AccountType, Address, AddressTrait};
 use hash::{HashStateTrait, HashStateExTrait};
 use integer::{u256_overflow_sub, u256_overflowing_add};

--- a/crates/evm/src/tests/test_state.cairo
+++ b/crates/evm/src/tests/test_state.cairo
@@ -70,7 +70,7 @@ mod test_state {
     use contracts::kakarot_core::interface::{IExtendedKakarotCoreDispatcherTrait};
     use contracts::tests::test_utils as contract_utils;
     use contracts::uninitialized_account::UninitializedAccount;
-    use evm::model::account::{Account, AccountType, AccountTrait};
+    use evm::model::account::{Account, AccountType, AccountTrait, AccountInternalTrait};
     use evm::model::contract_account::{ContractAccountTrait};
     use evm::model::eoa::EOATrait;
     use evm::model::{Event, Transfer, Address};


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

- When submitting a TX, we charge the total gas fee to the sender before executing the transaction, ensuring that if the entire gas is consumed the user is charged accordingly
- The unused gas is refunded after the execution
- When clearing storage slots, gas can be refunded. The maximum amount refunded is `gas_used // 5`, and the actual gas refunded is min(gas_used //5, refunded_gas)
- Created a new issue for gas refunds

Resolves: #671

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Charges tx gas fee
- Refund unused gas after the execution of a transcation

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/682)
<!-- Reviewable:end -->
