### PR TITLE
feat: pre_deployed_eoas in kakarot constructor

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -150,7 +150,7 @@ mod KakarotCore {
 
         loop {
             match eoas_to_deploy.pop_front() {
-                Option::Some(eoa) => self.deploy_eoa(*eoa),
+                Option::Some(eoa_address) => self.deploy_eoa(*eoa_address),
                 Option::None => { break; },
             };
         }

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -150,7 +150,7 @@ mod KakarotCore {
 
         loop {
             match eoas_to_deploy.pop_front() {
-                Option::Some(eoa_address) => self.deploy_eoa(*eoa_address),
+                Option::Some(eoa) => self.deploy_eoa(*eoa),
                 Option::None => { break; },
             };
         }

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -150,7 +150,7 @@ mod KakarotCore {
 
         loop {
             match eoas_to_deploy.pop_front() {
-                Option::Some(value) => self.deploy_eoa(*value),
+                Option::Some(eoa_address) => self.deploy_eoa(*eoa_address),
                 Option::None => { break; },
             };
         }

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -138,6 +138,7 @@ mod KakarotCore {
         ca_class_hash: ClassHash,
         owner: ContractAddress,
         chain_id: u128,
+        pre_deployed_eoas: Span<EthAddress>,
     ) {
         self.native_token.write(native_token);
         self.deploy_fee.write(deploy_fee);
@@ -146,6 +147,15 @@ mod KakarotCore {
         self.ca_class_hash.write(ca_class_hash);
         self.ownable.initializer(owner);
         self.chain_id.write(chain_id);
+
+        let mut i: usize = 0;
+        loop {
+            if (i == pre_deployed_eoas.len()) {
+                break;
+            }
+            self.deploy_eoa(*pre_deployed_eoas.at(i));
+            i += 1;
+        }
     }
 
     #[abi(embed_v0)]

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -138,7 +138,7 @@ mod KakarotCore {
         ca_class_hash: ClassHash,
         owner: ContractAddress,
         chain_id: u128,
-        pre_deployed_eoas: Span<EthAddress>,
+        mut eoas_to_deploy: Span<EthAddress>,
     ) {
         self.native_token.write(native_token);
         self.deploy_fee.write(deploy_fee);
@@ -148,13 +148,11 @@ mod KakarotCore {
         self.ownable.initializer(owner);
         self.chain_id.write(chain_id);
 
-        let mut i: usize = 0;
         loop {
-            if (i == pre_deployed_eoas.len()) {
-                break;
-            }
-            self.deploy_eoa(*pre_deployed_eoas.at(i));
-            i += 1;
+            match eoas_to_deploy.pop_front() {
+                Option::Some(value) => self.deploy_eoa(*value),
+                Option::None => { break; },
+            };
         }
     }
 

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -25,8 +25,8 @@ use core::option::OptionTrait;
 
 use core::traits::TryInto;
 use evm::model::{AccountType, Address};
-use evm::tests::test_utils;
 use evm::tests::test_utils::sequencer_evm_address;
+use evm::tests::test_utils;
 use starknet::{testing, contract_address_const, ContractAddress, EthAddress, ClassHash};
 use utils::eth_transaction::{EthereumTransaction, EthereumTransactionTrait, LegacyTransaction};
 //Required for assert_eq! macro

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -26,6 +26,7 @@ use core::option::OptionTrait;
 use core::traits::TryInto;
 use evm::model::{AccountType, Address};
 use evm::tests::test_utils;
+use evm::tests::test_utils::sequencer_evm_address;
 use starknet::{testing, contract_address_const, ContractAddress, EthAddress, ClassHash};
 use utils::eth_transaction::{EthereumTransaction, EthereumTransactionTrait, LegacyTransaction};
 //Required for assert_eq! macro
@@ -34,14 +35,15 @@ use utils::helpers::{EthAddressExTrait, u256_to_bytes_array};
 
 #[test]
 fn test_kakarot_core_owner() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
 
     assert(kakarot_core.owner() == test_utils::other_starknet_address(), 'wrong owner')
 }
 
 #[test]
 fn test_kakarot_core_transfer_ownership() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
     assert(kakarot_core.owner() == test_utils::other_starknet_address(), 'wrong owner');
     testing::set_contract_address(test_utils::other_starknet_address());
     kakarot_core.transfer_ownership(test_utils::starknet_address());
@@ -50,7 +52,8 @@ fn test_kakarot_core_transfer_ownership() {
 
 #[test]
 fn test_kakarot_core_renounce_ownership() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
     assert(kakarot_core.owner() == test_utils::other_starknet_address(), 'wrong owner');
     testing::set_contract_address(test_utils::other_starknet_address());
     kakarot_core.renounce_ownership();
@@ -59,19 +62,22 @@ fn test_kakarot_core_renounce_ownership() {
 
 #[test]
 fn test_kakarot_core_deploy_fee() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
     assert(kakarot_core.deploy_fee() == contract_utils::deploy_fee(), 'wrong deploy_fee');
 }
 
 #[test]
 fn test_kakarot_core_chain_id() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
     assert(kakarot_core.chain_id() == contract_utils::chain_id(), 'wrong chain id');
 }
 
 #[test]
 fn test_kakarot_core_set_deploy_fee() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
     assert(kakarot_core.deploy_fee() == contract_utils::deploy_fee(), 'wrong deploy_fee');
     testing::set_contract_address(test_utils::other_starknet_address());
     kakarot_core.set_deploy_fee(0x100);
@@ -80,8 +86,9 @@ fn test_kakarot_core_set_deploy_fee() {
 
 #[test]
 fn test_kakarot_core_set_native_token() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
-    assert(kakarot_core.native_token() == test_utils::native_token(), 'wrong native_token');
+    let (native_token, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
+    assert(kakarot_core.native_token() == native_token.contract_address, 'wrong native_token');
 
     testing::set_contract_address(test_utils::other_starknet_address());
     kakarot_core.set_native_token(contract_address_const::<0xdead>());
@@ -147,7 +154,8 @@ fn test_kakarot_core_compute_starknet_address() {
 
 #[test]
 fn test_kakarot_core_upgrade_contract() {
-    let kakarot_core = contract_utils::deploy_kakarot_core(test_utils::native_token());
+    let (_, kakarot_core) = contract_utils::setup_contracts_for_testing();
+
     let class_hash: ClassHash = MockContractUpgradeableV1::TEST_CLASS_HASH.try_into().unwrap();
 
     testing::set_contract_address(test_utils::other_starknet_address());

--- a/crates/contracts/src/tests/test_utils.cairo
+++ b/crates/contracts/src/tests/test_utils.cairo
@@ -109,7 +109,8 @@ fn deploy_kakarot_core(native_token: ContractAddress) -> IExtendedKakarotCoreDis
         ExternallyOwnedAccount::TEST_CLASS_HASH.try_into().unwrap(),
         ContractAccount::TEST_CLASS_HASH.try_into().unwrap(),
         other_starknet_address().into(),
-        chain_id().into()
+        chain_id().into(),
+        0,
     ];
     let maybe_address = deploy_syscall(
         KakarotCore::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

Feature added to kakarot contract constructor.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #588

## What is the new behavior?

KakarotCore contract is able to receive multiple EthAddress as arguments, and deploy them during constructor execution. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/685)
<!-- Reviewable:end -->
