### PR TITLE
feat: gas refunds

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -513,7 +513,7 @@ mod KakarotCore {
             TransactionResult {
                 success: summary.success,
                 return_data: summary.return_data,
-                gas_used: gas_used,
+                gas_used: total_gas_used,
                 state: summary.state,
             }
         }

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -50,6 +50,7 @@ struct ExecutionResult {
     gas_left: u128,
     accessed_addresses: SpanSet<EthAddress>,
     accessed_storage_keys: SpanSet<(EthAddress, u256)>,
+    gas_refund: u128,
 }
 
 #[generate_trait]
@@ -64,7 +65,8 @@ impl ExecutionResultImpl of ExecutionResultTrait {
             return_data: error,
             gas_left: 0,
             accessed_addresses,
-            accessed_storage_keys
+            accessed_storage_keys,
+            gas_refund: 0,
         }
     }
 
@@ -84,13 +86,34 @@ struct ExecutionSummary {
     return_data: Span<u8>,
     gas_left: u128,
     state: State,
+    gas_refund: u128
 }
 
 #[generate_trait]
 impl ExecutionSummaryImpl of ExecutionSummaryTrait {
     fn exceptional_failure(error: Span<u8>) -> ExecutionSummary {
         ExecutionSummary {
-            success: false, return_data: error, gas_left: 0, state: Default::default(),
+            success: false,
+            return_data: error,
+            gas_left: 0,
+            state: Default::default(),
+            gas_refund: 0
+        }
+    }
+}
+
+struct TransactionResult {
+    success: bool,
+    return_data: Span<u8>,
+    gas_used: u128,
+    state: State
+}
+
+#[generate_trait]
+impl TransactionResultImpl of TransactionResultTrait {
+    fn exceptional_failure(error: Span<u8>, gas_used: u128) -> TransactionResult {
+        TransactionResult {
+            success: false, return_data: error, gas_used, state: Default::default()
         }
     }
 }

--- a/crates/evm/src/model/vm.cairo
+++ b/crates/evm/src/model/vm.cairo
@@ -22,6 +22,7 @@ struct VM {
     error: bool,
     accessed_addresses: Set<EthAddress>,
     accessed_storage_keys: Set<(EthAddress, u256)>,
+    gas_refund: u128
 }
 
 
@@ -42,6 +43,7 @@ impl VMImpl of VMTrait {
             error: false,
             accessed_addresses: message.accessed_addresses.inner.clone(),
             accessed_storage_keys: message.accessed_storage_keys.inner.clone(),
+            gas_refund: 0
         }
     }
 
@@ -152,6 +154,11 @@ impl VMImpl of VMTrait {
     }
 
     #[inline(always)]
+    fn gas_refund(self: @VM) -> u128 {
+        *self.gas_refund
+    }
+
+    #[inline(always)]
     fn accessed_addresses(self: @VM) -> SpanSet<EthAddress> {
         self.accessed_addresses.spanset()
     }
@@ -181,6 +188,7 @@ impl VMImpl of VMTrait {
             //TODO: merge accessed storage
             self.accessed_addresses.extend(*child.accessed_addresses);
             self.accessed_storage_keys.extend(*child.accessed_storage_keys);
+            self.gas_refund += *child.gas_refund;
         }
         //TODO(gas) handle error case
 

--- a/crates/evm/src/tests/test_utils.cairo
+++ b/crates/evm/src/tests/test_utils.cairo
@@ -238,6 +238,7 @@ fn preset_vm() -> VM {
         error: false,
         accessed_addresses: Default::default(),
         accessed_storage_keys: Default::default(),
+        gas_refund: 0,
     }
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #683 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Implements the gas refund mechanism
- Simplifies the gas fee payment mechanism by paying only AFTER the execution - rationale is that since env.gas_price == tx.gas_price and we don't have support for EIP-1559 transactions, we can simply charge (gas_used - gas_refund) gas to the user in a single step
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/686)
<!-- Reviewable:end -->
