### PR TITLE
feat: include `gas_used` in `eth_call` return data

### DIFF
--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -65,7 +65,7 @@ trait IKakarotCore<TContractState> {
     /// It cannot modify the state of the chain
     fn eth_call(
         self: @TContractState, origin: EthAddress, tx: EthereumTransaction
-    ) -> (bool, Span<u8>);
+    ) -> (bool, Span<u8>, u128);
 
     /// Transaction entrypoint into the EVM
     /// Executes an EVM transaction and possibly modifies the state

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -252,17 +252,17 @@ mod KakarotCore {
 
         fn eth_call(
             self: @ContractState, origin: EthAddress, tx: EthereumTransaction
-        ) -> (bool, Span<u8>) {
+        ) -> (bool, Span<u8>, u128) {
             if !self.is_view() {
                 panic_with_felt252('fn must be called, not invoked');
             };
 
             let origin = Address { evm: origin, starknet: self.compute_starknet_address(origin) };
 
-            let TransactionResult{success, return_data, gas_used: _, state: _ } = self
+            let TransactionResult{success, return_data, gas_used, state: _ } = self
                 .process_transaction(origin, tx);
 
-            (success, return_data)
+            (success, return_data, gas_used)
         }
 
         fn eth_send_transaction(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Resolves: #696 

## What is the new behavior?

`gas_used` is added in the return data of `eth_call` function in KakarotCore contract.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/698)
<!-- Reviewable:end -->
