### PR TITLE
Add a Precompiles contract

### DIFF
--- a/crates/contracts/Scarb.toml
+++ b/crates/contracts/Scarb.toml
@@ -16,6 +16,7 @@ fmt.workspace = true
 
 [[target.starknet-contract]]
 casm = true
+casm-add-pythonic-hints = true
 
 [lib]
 name = "contracts"

--- a/crates/contracts/src/lib.cairo
+++ b/crates/contracts/src/lib.cairo
@@ -12,3 +12,5 @@ mod tests;
 
 // Account transparent proxy
 mod uninitialized_account;
+
+mod precompiles;

--- a/crates/contracts/src/lib.cairo
+++ b/crates/contracts/src/lib.cairo
@@ -7,10 +7,10 @@ mod errors;
 // Kakarot smart contract
 mod kakarot_core;
 
+mod precompiles;
+
 #[cfg(test)]
 mod tests;
 
 // Account transparent proxy
 mod uninitialized_account;
-
-mod precompiles;

--- a/crates/contracts/src/precompiles.cairo
+++ b/crates/contracts/src/precompiles.cairo
@@ -1,0 +1,31 @@
+#[starknet::interface]
+trait IPrecompiles<T> {
+    fn exec_precompile(self: @T, address: felt252, data: Span<u8>) -> Span<u8>;
+}
+
+#[starknet::contract]
+mod Precompiles {
+    use alexandria_math::sha256::sha256;
+
+    use super::IPrecompiles;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl Precompiles of IPrecompiles<ContractState> {
+        fn exec_precompile(self: @ContractState, address: felt252, data: Span<u8>) -> Span<u8> {
+            let result = match address {
+                0 => panic!("Precompile address can't be 0"),
+                1 => panic!("Precompile ecRecover not available"),
+                2 => {
+                    let mut input = array![];
+                    input.append_span(data);
+                    sha256(input).span()
+                    },
+                _ => panic!("Precompile {} not available", address)
+            };
+            return result;
+        }
+    }
+}

--- a/crates/contracts/src/precompiles.cairo
+++ b/crates/contracts/src/precompiles.cairo
@@ -1,6 +1,6 @@
 #[starknet::interface]
 trait IPrecompiles<T> {
-    fn exec_precompile(self: @T, address: felt252, data: Span<u8>) -> Span<u8>;
+    fn exec_precompile(self: @T, address: felt252, data: Array<u8>) -> Span<u8>;
 }
 
 #[starknet::contract]
@@ -14,15 +14,11 @@ mod Precompiles {
 
     #[abi(embed_v0)]
     impl Precompiles of IPrecompiles<ContractState> {
-        fn exec_precompile(self: @ContractState, address: felt252, data: Span<u8>) -> Span<u8> {
+        fn exec_precompile(self: @ContractState, address: felt252, data: Array<u8>) -> Span<u8> {
             let result = match address {
                 0 => panic!("Precompile address can't be 0"),
                 1 => panic!("Precompile ecRecover not available"),
-                2 => {
-                    let mut input = array![];
-                    input.append_span(data);
-                    sha256(input).span()
-                },
+                2 => sha256(data).span(),
                 _ => panic!("Precompile {} not available", address)
             };
             return result;

--- a/crates/contracts/src/precompiles.cairo
+++ b/crates/contracts/src/precompiles.cairo
@@ -22,7 +22,7 @@ mod Precompiles {
                     let mut input = array![];
                     input.append_span(data);
                     sha256(input).span()
-                    },
+                },
                 _ => panic!("Precompile {} not available", address)
             };
             return result;


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Precompiles are available within an EVM run only.

Resolves: https://github.com/kkrt-labs/kakarot/issues/909

## What is the new behavior?

Added a Precompiles contract with one `exec_precompile` entrypoint to run a precompile.

Note: I've just put the SHA256 has it's the only one missing currently for Kakarot0. I don't know if it's worth adding them all.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/710)
<!-- Reviewable:end -->
