### PR TITLE
fix: bits_used when value is 0

### DIFF
--- a/crates/utils/src/crypto/modexp/mpnat.cairo
+++ b/crates/utils/src/crypto/modexp/mpnat.cairo
@@ -15,7 +15,7 @@ use super::arith::{
     in_place_add, in_place_mul_sub, big_wrapping_mul, monsq, monpro, borrowing_sub, carrying_add
 };
 use utils::checked_math::CheckedMath;
-use utils::helpers::{FromBytes, U64Trait, Felt252VecTrait, U128Trait, BitLengthTrait, ByteSize};
+use utils::helpers::{FromBytes, U64Trait, Felt252VecTrait, U128Trait, BitsUsed, ByteSize};
 use utils::math::{Bitshift, WrappingBitshift};
 
 type Word = u64;

--- a/crates/utils/src/tests/test_helpers.cairo
+++ b/crates/utils/src/tests/test_helpers.cairo
@@ -1,4 +1,4 @@
-use utils::helpers::{BitLengthTrait, BytesUsedTrait, ToBytes};
+use utils::helpers::{BitsUsed, BytesUsedTrait, ToBytes};
 use utils::helpers;
 
 #[test]
@@ -175,7 +175,7 @@ mod test_array_ext {
 }
 
 mod u8_test {
-    use utils::helpers::U8Trait;
+    use utils::helpers::BitsUsed;
     use utils::math::Bitshift;
 
     #[test]
@@ -197,7 +197,7 @@ mod u8_test {
 
 mod u32_test {
     use utils::helpers::Bitshift;
-    use utils::helpers::{BitLengthTrait, BytesUsedTrait, ToBytes, FromBytes};
+    use utils::helpers::{BitsUsed, BytesUsedTrait, ToBytes, FromBytes};
 
     #[test]
     fn test_u32_from_be_bytes() {
@@ -287,7 +287,7 @@ mod u32_test {
 mod u64_test {
     use utils::helpers::Bitshift;
     use utils::helpers::U64Trait;
-    use utils::helpers::{BitLengthTrait, BytesUsedTrait, ToBytes};
+    use utils::helpers::{BitsUsed, BytesUsedTrait, ToBytes};
 
 
     #[test]
@@ -336,9 +336,9 @@ mod u64_test {
     }
 
     #[test]
-    fn test_u64_bit_len() {
+    fn test_u64_bits_used() {
         let input: u64 = 7;
-        let result = input.bit_len();
+        let result = input.bits_used();
         let expected = 3;
 
         assert_eq!(result, expected);
@@ -349,7 +349,7 @@ mod u128_test {
     use integer::BoundedInt;
     use utils::helpers::Bitshift;
     use utils::helpers::U128Trait;
-    use utils::helpers::{BitLengthTrait, BytesUsedTrait, ToBytes};
+    use utils::helpers::{BitsUsed, BytesUsedTrait, ToBytes};
 
     #[test]
     fn test_u128_bytes_used() {
@@ -403,7 +403,7 @@ mod u128_test {
 mod u256_test {
     use utils::helpers::Bitshift;
     use utils::helpers::U256Trait;
-    use utils::helpers::{BitLengthTrait, BytesUsedTrait};
+    use utils::helpers::{BitsUsed, BytesUsedTrait};
 
     #[test]
     fn test_reverse_bytes_u256() {
@@ -451,9 +451,9 @@ mod u256_test {
     }
 
     #[test]
-    fn test_u64_bit_len() {
+    fn test_u64_bits_used() {
         let input: u256 = 7;
-        let result = input.bit_len();
+        let result = input.bits_used();
         let expected = 3;
 
         assert_eq!(result, expected);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix `bits_used`
- add Modexp to Precompiles library
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/734)
<!-- Reviewable:end -->
