### PR TITLE
feat: return validation error on validation of value and gas

### DIFF
--- a/.github/workflows/ef_tests.yml
+++ b/.github/workflows/ef_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout ef-tests
         uses: actions/checkout@v3
         with:
-          repository: kkrt-labs/ef-tests
+          repository: enitrat/ef-tests
       - name: Checkout local skip file
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/checkout@v3

--- a/crates/contracts/src/eoa.cairo
+++ b/crates/contracts/src/eoa.cairo
@@ -144,7 +144,7 @@ mod ExternallyOwnedAccount {
                 contract_address: self.kakarot_core_address()
             };
 
-            let (success, return_data) = kakarot_core_dispatcher.eth_send_transaction(tx);
+            let (return_data, success) = kakarot_core_dispatcher.eth_send_transaction(tx);
             let return_data = return_data.to_felt252_array().span();
 
             let tx_info = get_tx_info().unbox();

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -55,11 +55,11 @@ trait IKakarotCore<TContractState> {
     /// It cannot modify the state of the chain
     fn eth_call(
         self: @TContractState, origin: EthAddress, tx: EthereumTransaction
-    ) -> (bool, Span<u8>, u128);
+    ) -> (Span<u8>, bool, u128);
 
     /// Transaction entrypoint into the EVM
     /// Executes an EVM transaction and possibly modifies the state
-    fn eth_send_transaction(ref self: TContractState, tx: EthereumTransaction) -> (bool, Span<u8>);
+    fn eth_send_transaction(ref self: TContractState, tx: EthereumTransaction) -> (Span<u8>, bool);
 
     /// Upgrade the KakarotCore smart contract
     /// Using replace_class_syscall
@@ -133,11 +133,11 @@ trait IExtendedKakarotCore<TContractState> {
     /// It cannot modify the state of the chain
     fn eth_call(
         self: @TContractState, origin: EthAddress, tx: EthereumTransaction
-    ) -> (bool, Span<u8>);
+    ) -> (Span<u8>, bool);
 
     /// Transaction entrypoint into the EVM
     /// Executes an EVM transaction and possibly modifies the state
-    fn eth_send_transaction(ref self: TContractState, tx: EthereumTransaction) -> (bool, Span<u8>);
+    fn eth_send_transaction(ref self: TContractState, tx: EthereumTransaction) -> (Span<u8>, bool);
 
     /// Upgrade the KakarotCore smart contract
     /// Using replace_class_syscall

--- a/crates/contracts/src/tests/test_eoa.cairo
+++ b/crates/contracts/src/tests/test_eoa.cairo
@@ -127,7 +127,7 @@ mod test_external_owned_account {
             kakarot_core.chain_id(), Option::Some(other_evm_address()), data_get_tx
         );
 
-        let (_, return_data) = kakarot_core
+        let (return_data, _) = kakarot_core
             .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx),);
 
         assert_eq!(return_data, u256_to_bytes_array(0).span());
@@ -159,7 +159,7 @@ mod test_external_owned_account {
         let tx = call_transaction(
             kakarot_core.chain_id(), Option::Some(other_evm_address()), data_get_tx
         );
-        let (_, return_data) = kakarot_core
+        let (return_data, _) = kakarot_core
             .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx),);
         assert_eq!(return_data, u256_to_bytes_array(1).span());
     }

--- a/crates/contracts/src/tests/test_kakarot_core.cairo
+++ b/crates/contracts/src/tests/test_kakarot_core.cairo
@@ -245,7 +245,7 @@ fn test_eth_send_transaction_non_deploy_tx() {
     let tx = contract_utils::call_transaction(
         kakarot_core.chain_id(), Option::Some(counter_address), data_get_tx
     );
-    let (_, return_data) = kakarot_core
+    let (return_data, _) = kakarot_core
         .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx));
 
     assert_eq!(return_data, u256_to_bytes_array(0).span());
@@ -266,7 +266,7 @@ fn test_eth_send_transaction_non_deploy_tx() {
         calldata: data_increment_counter
     };
 
-    let (success, _) = kakarot_core
+    let (_, success) = kakarot_core
         .eth_send_transaction(EthereumTransaction::LegacyTransaction(tx));
     assert!(success);
 
@@ -280,7 +280,7 @@ fn test_eth_send_transaction_non_deploy_tx() {
     );
     let (_, _) = kakarot_core
         .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx));
-    let (_, return_data) = kakarot_core
+    let (return_data, _) = kakarot_core
         .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx));
 
     // Then
@@ -307,7 +307,7 @@ fn test_eth_call() {
 
     // When
     let tx = contract_utils::call_transaction(kakarot_core.chain_id(), to, calldata);
-    let (success, return_data) = kakarot_core
+    let (return_data, success) = kakarot_core
         .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx));
 
     // Then
@@ -383,14 +383,14 @@ fn test_eth_send_transaction_deploy_tx() {
         calldata: deploy_counter_calldata()
     };
     testing::set_contract_address(eoa);
-    let (_, deploy_result) = kakarot_core
+    let (return_data, _success) = kakarot_core
         .eth_send_transaction(EthereumTransaction::LegacyTransaction(tx));
 
     // Then
     let expected_address: EthAddress = 0x19587b345dcadfe3120272bd0dbec24741891759
         .try_into()
         .unwrap();
-    assert(deploy_result == expected_address.to_bytes().span(), 'returndata not counter bytecode');
+    assert(return_data == expected_address.to_bytes().span(), 'returndata not counter bytecode');
 
     // Set back the contract address to Kakarot for the calculation of the deployed SN contract address, where we use a kakarot
     // internal functions and thus must "mock" its address.
@@ -415,10 +415,10 @@ fn test_eth_send_transaction_deploy_tx() {
         gas_limit,
         calldata
     };
-    let (_, result) = kakarot_core
+    let (return_data, _success) = kakarot_core
         .eth_call(origin: evm_address, tx: EthereumTransaction::LegacyTransaction(tx));
     // Then
-    assert(result == u256_to_bytes_array(0).span(), 'wrong result');
+    assert(return_data == u256_to_bytes_array(0).span(), 'wrong result');
 }
 
 #[test]

--- a/crates/evm/src/errors.cairo
+++ b/crates/evm/src/errors.cairo
@@ -58,6 +58,7 @@ enum EVMError {
     OutOfGas,
     Assertion,
     DepthLimit,
+    ValidateError,
 }
 
 #[generate_trait]
@@ -81,6 +82,7 @@ impl EVMErrorImpl of EVMErrorTrait {
             EVMError::OutOfGas => 'out of gas'.into(),
             EVMError::Assertion => 'assertion failed'.into(),
             EVMError::DepthLimit => 'max call depth exceeded'.into(),
+            EVMError::ValidateError => 'Kakarot: eth validation failed',
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Similar to what was done in SSJ, if the value is not enough to pay for topmost value transfer and the gas of the tx, the same error is returned
- Switched (success, return_data) to (return_data, success) for compatibility with C0
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/736)
<!-- Reviewable:end -->
