### PR TITLE
make memory_expansion_cost return a MemoryExpansion struct

### DIFF
--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -48,15 +48,15 @@ impl CreateHelpersImpl of CreateHelpers {
         let offset = self.stack.pop_usize()?;
         let size = self.stack.pop_usize()?;
 
-        let expand_memory_cost = gas::memory_expansion_cost(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
         let init_code_gas = gas::init_code_cost(size);
         let charged_gas = match create_type {
-            CreateType::Create => gas::CREATE + expand_memory_cost + init_code_gas,
+            CreateType::Create => gas::CREATE + memory_expansion.expansion_cost + init_code_gas,
             CreateType::Create2 => {
                 let calldata_words = ceil32(size) / 32;
                 gas::CREATE
                     + gas::KECCAK256WORD * calldata_words.into()
-                    + expand_memory_cost
+                    + memory_expansion.expansion_cost
                     + init_code_gas
             },
         };

--- a/crates/evm/src/instructions/logging_operations.cairo
+++ b/crates/evm/src/instructions/logging_operations.cairo
@@ -69,13 +69,13 @@ mod internal {
         let size = self.stack.pop_usize()?;
         let topics: Array<u256> = self.stack.pop_n(topics_len.into())?;
 
-        let expand_memory_cost = gas::memory_expansion_cost(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
         self
             .charge_gas(
                 gas::LOG
                     + topics_len.into() * gas::LOGTOPIC
                     + size.into() * gas::LOGDATA
-                    + expand_memory_cost
+                    + memory_expansion.expansion_cost
             )?;
 
         let mut data: Array<u8> = Default::default();

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -31,8 +31,8 @@ impl MemoryOperation of MemoryOperationTrait {
     fn exec_mload(ref self: VM) -> Result<(), EVMError> {
         let offset: usize = self.stack.pop_usize()?;
 
-        let expand_memory_cost = gas::memory_expansion_cost(self.memory.size(), offset + 32);
-        self.charge_gas(gas::VERYLOW + expand_memory_cost)?;
+        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + 32);
+        self.charge_gas(gas::VERYLOW + memory_expansion.expansion_cost)?;
 
         let result = self.memory.load(offset);
         self.stack.push(result)
@@ -44,8 +44,8 @@ impl MemoryOperation of MemoryOperationTrait {
     fn exec_mstore(ref self: VM) -> Result<(), EVMError> {
         let offset: usize = self.stack.pop_usize()?;
         let value: u256 = self.stack.pop()?;
-        let expand_memory_cost = gas::memory_expansion_cost(self.memory.size(), offset + 32);
-        self.charge_gas(gas::VERYLOW + expand_memory_cost)?;
+        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + 32);
+        self.charge_gas(gas::VERYLOW + memory_expansion.expansion_cost)?;
 
         self.memory.store(value, offset);
         Result::Ok(())
@@ -59,8 +59,8 @@ impl MemoryOperation of MemoryOperationTrait {
         let value = self.stack.pop()?;
         let value: u8 = (value.low & 0xFF).try_into().unwrap();
 
-        let expand_memory_cost = gas::memory_expansion_cost(self.memory.size(), offset + 1);
-        self.charge_gas(gas::VERYLOW + expand_memory_cost)?;
+        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + 1);
+        self.charge_gas(gas::VERYLOW + memory_expansion.expansion_cost)?;
 
         self.memory.store_byte(value, offset);
 

--- a/crates/evm/src/instructions/sha3.cairo
+++ b/crates/evm/src/instructions/sha3.cairo
@@ -25,8 +25,8 @@ impl Sha3Impl of Sha3Trait {
 
         let words_size: u128 = (ceil32(size) / 32).into();
         let word_gas_cost = gas::KECCAK256WORD * words_size;
-        let expand_memory_cost = gas::memory_expansion_cost(self.memory.size(), offset + size);
-        self.charge_gas(gas::KECCAK256 + word_gas_cost + expand_memory_cost)?;
+        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
+        self.charge_gas(gas::KECCAK256 + word_gas_cost + memory_expansion.expansion_cost)?;
 
         let mut to_hash: Array<u64> = Default::default();
 


### PR DESCRIPTION

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #748 

## What is the new behavior?

`memory_expansion_cost` is renamed `memory_expansion` and returns a `MemoryExpansion` struct containing the new size of memory and the cost of memory expansion.

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
