### PR TITLE
fix: rip-7212 implementation incorrect return value

### DIFF
--- a/crates/evm/src/precompiles/p256verify.cairo
+++ b/crates/evm/src/precompiles/p256verify.cairo
@@ -19,7 +19,7 @@ impl P256Verify of Precompile {
         let gas: u128 = P256VERIFY_PRECOMPILE_GAS_COST;
 
         if input.len() != 160 {
-            return Result::Ok((gas, array![0].span()));
+            return Result::Ok((gas, array![].span()));
         }
 
         let message_hash = input.slice(0, 32);
@@ -59,7 +59,7 @@ impl P256Verify of Precompile {
         };
 
         if !is_valid_signature(message_hash, r, s, public_key) {
-            return Result::Ok((gas, array![0].span()));
+            return Result::Ok((gas, array![].span()));
         }
 
         return Result::Ok((gas, array![1].span()));

--- a/crates/evm/src/tests/test_precompiles/test_p256verify.cairo
+++ b/crates/evm/src/tests/test_precompiles/test_p256verify.cairo
@@ -87,7 +87,7 @@ fn test_p256verify_precompile_input_too_short() {
 
     let (gas, result) = P256Verify::exec(calldata.span()).unwrap();
 
-    assert_eq!(result, array![]);
+    assert_eq!(result, array![].span());
     assert_eq!(gas, 3450);
 }
 
@@ -116,5 +116,5 @@ fn test_p256verify_precompile_input_too_short_static_call() {
     let mut result = Default::default();
     vm.memory.load_n(0x1, ref result, 0x80);
 
-    assert_eq!(result, array![]);
+    assert_eq!(result, array![0]);
 }

--- a/crates/evm/src/tests/test_precompiles/test_p256verify.cairo
+++ b/crates/evm/src/tests/test_precompiles/test_p256verify.cairo
@@ -87,8 +87,7 @@ fn test_p256verify_precompile_input_too_short() {
 
     let (gas, result) = P256Verify::exec(calldata.span()).unwrap();
 
-    let result: u256 = result.from_be_bytes().unwrap();
-    assert_eq!(result, 0x00);
+    assert_eq!(result, array![]);
     assert_eq!(gas, 3450);
 }
 
@@ -117,5 +116,5 @@ fn test_p256verify_precompile_input_too_short_static_call() {
     let mut result = Default::default();
     vm.memory.load_n(0x1, ref result, 0x80);
 
-    assert_eq!(result, array![0x00]);
+    assert_eq!(result, array![]);
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

The current implementation doesn't meet with actual RIP-7212 behavior for the return values. It returns unwanted 0 value for some cases.

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The changes apply true behavior for the RIP-7212.

```
- **Output data:**
    - If the signature verification process succeeds, it returns 1 in 32 bytes format.
    - If the signature verification process fails, it does not return any output data.
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/790)
<!-- Reviewable:end -->
