### PR TITLE
implement DeRefMut for Box<T>

### DIFF
--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -127,6 +127,15 @@ pub impl U8IntoEthAddress of Into<u8, EthAddress> {
     }
 }
 
+// Note: DerefBox is already implemented in corelib::box
+
+impl DerefMutBox<T, +Copy<T>, +Drop<T>> of core::ops::DerefMut<Box<T>> {
+    type Target = T;
+    fn deref_mut(ref self: Box<T>) -> T {
+        self.unbox()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::starknet::{
@@ -148,5 +157,26 @@ mod tests {
         let val_2 = storage_base_address_from_felt252(0x02);
 
         assert_ne!(@val_1, @val_2)
+    }
+
+    #[derive(Copy, Drop)]
+    struct Type1 {
+        x: u8
+    }
+
+    fn f(ref b: Box<Type1>) -> u8 {
+        b.x
+    }
+
+    #[test]
+    fn test_deref_box() {
+        let boxed = BoxTrait::new(Type1 { x: 42 });
+        assert_eq!(boxed.x, 42)
+    }
+
+    #[test]
+    fn test_deref_mut_box() {
+        let mut boxed = BoxTrait::new(Type1 { x: 42 });
+        assert_eq!(f(ref boxed), 42)
     }
 }


### PR DESCRIPTION
See issue https://github.com/kkrt-labs/kakarot-ssj/issues/808.

Note that DerefBox is already implemented in corelib::box (https://github.com/starkware-libs/cairo/blob/dd86a0eb2707d0067939e5051e04b25d93f515f3/corelib/src/box.cairo#L56).

But I left the DerefBox unit test to be sure that it still works in the next Cairo versions.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/817)
<!-- Reviewable:end -->
