### PR TITLE
feat: storage bytecode stored in 31-bytes chunks from address 0

### DIFF
--- a/crates/contracts/src/account_contract.cairo
+++ b/crates/contracts/src/account_contract.cairo
@@ -37,6 +37,7 @@ pub mod AccountContract {
     use contracts::components::ownable::IOwnable;
     use contracts::components::ownable::ownable_component::InternalTrait;
     use contracts::components::ownable::ownable_component;
+    use contracts::storage::StorageBytecode;
     use contracts::errors::{
         BYTECODE_READ_ERROR, BYTECODE_WRITE_ERROR, STORAGE_READ_ERROR, STORAGE_WRITE_ERROR,
         NONCE_READ_ERROR, NONCE_WRITE_ERROR, KAKAROT_VALIDATION_FAILED
@@ -82,8 +83,9 @@ pub mod AccountContract {
 
 
     #[storage]
-    struct Storage {
-        Account_bytecode: ByteArray,
+    pub(crate) struct Storage {
+        Account_bytecode: StorageBytecode,
+        pub(crate) Account_bytecode_len: u32,
         Account_storage: Map<u256, u256>,
         Account_is_initialized: bool,
         Account_nonce: u64,
@@ -157,7 +159,7 @@ pub mod AccountContract {
             assert(calls.len() == 1, 'EOA: multicall not supported');
             // todo: activate check once using snfoundry
             // assert(tx_info.version.try_into().unwrap() >= 1_u128, 'EOA: deprecated tx version');
-            assert(self.Account_bytecode.read().len().is_zero(), 'EOAs: Cannot have code');
+            assert(self.Account_bytecode_len.read().is_zero(), 'EOAs: Cannot have code');
             assert(tx_info.signature.len() == 5, 'EOA: invalid signature length');
 
             let call = calls.at(0);
@@ -242,13 +244,11 @@ pub mod AccountContract {
 
         fn write_bytecode(ref self: ContractState, bytecode: Span<u8>) {
             self.ownable.assert_only_owner();
-            let packed_bytecode: ByteArray = ByteArrayExTrait::from_bytes(bytecode);
-            self.Account_bytecode.write(packed_bytecode);
+            self.Account_bytecode.write(StorageBytecode { bytecode });
         }
 
         fn bytecode(self: @ContractState) -> Span<u8> {
-            let packed_bytecode = self.Account_bytecode.read();
-            packed_bytecode.into_bytes()
+            self.Account_bytecode.read().bytecode
         }
 
         fn write_storage(ref self: ContractState, key: u256, value: u256) {

--- a/crates/contracts/src/account_contract.cairo
+++ b/crates/contracts/src/account_contract.cairo
@@ -37,12 +37,12 @@ pub mod AccountContract {
     use contracts::components::ownable::IOwnable;
     use contracts::components::ownable::ownable_component::InternalTrait;
     use contracts::components::ownable::ownable_component;
-    use contracts::storage::StorageBytecode;
     use contracts::errors::{
         BYTECODE_READ_ERROR, BYTECODE_WRITE_ERROR, STORAGE_READ_ERROR, STORAGE_WRITE_ERROR,
         NONCE_READ_ERROR, NONCE_WRITE_ERROR, KAKAROT_VALIDATION_FAILED
     };
     use contracts::kakarot_core::interface::{IKakarotCoreDispatcher, IKakarotCoreDispatcherTrait};
+    use contracts::storage::StorageBytecode;
     use core::integer;
     use core::num::traits::Bounded;
     use core::num::traits::zero::Zero;

--- a/crates/contracts/src/cairo1_helpers.cairo
+++ b/crates/contracts/src/cairo1_helpers.cairo
@@ -109,6 +109,13 @@ pub trait IHelpers<T> {
 mod embeddable_impls {
     use core::keccak::{cairo_keccak, keccak_u256s_be_inputs};
     use core::num::traits::Zero;
+    use core::starknet::EthAddress;
+    use core::starknet::eth_signature::{
+        Signature, verify_eth_signature, public_key_point_to_eth_address
+    };
+    use core::starknet::secp256_trait::{recover_public_key, Secp256PointTrait, is_valid_signature};
+    use core::starknet::secp256k1::Secp256k1Point;
+    use core::starknet::secp256r1::{secp256r1_new_syscall, Secp256r1Point};
     use core::traits::Into;
     use core::{starknet, starknet::SyscallResultTrait};
     use evm::errors::EVMError;
@@ -117,13 +124,6 @@ mod embeddable_impls {
     use evm::precompiles::identity::Identity;
     use evm::precompiles::modexp::ModExp;
     use evm::precompiles::sha256::Sha256;
-    use core::starknet::EthAddress;
-    use core::starknet::eth_signature::{
-        Signature, verify_eth_signature, public_key_point_to_eth_address
-    };
-    use core::starknet::secp256_trait::{recover_public_key, Secp256PointTrait, is_valid_signature};
-    use core::starknet::secp256k1::Secp256k1Point;
-    use core::starknet::secp256r1::{secp256r1_new_syscall, Secp256r1Point};
     use utils::helpers::U256Trait;
 
 

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -16,6 +16,11 @@ pub mod KakarotCore {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess
     };
+    use core::starknet::syscalls::deploy_syscall;
+    use core::starknet::{
+        EthAddress, ContractAddress, ClassHash, get_tx_info, get_contract_address,
+        get_caller_address
+    };
     use evm::backend::starknet_backend;
     use evm::errors::{EVMError, ensure, EVMErrorTrait,};
     use evm::gas;
@@ -26,11 +31,6 @@ pub mod KakarotCore {
         ExecutionSummaryTrait, Address, AddressTrait
     };
     use evm::state::{State, StateTrait};
-    use core::starknet::syscalls::deploy_syscall;
-    use core::starknet::{
-        EthAddress, ContractAddress, ClassHash, get_tx_info, get_contract_address,
-        get_caller_address
-    };
     use super::{INVOKE_ETH_CALL_FORBIDDEN};
     use utils::address::compute_contract_address;
     use utils::constants;

--- a/crates/contracts/src/lib.cairo
+++ b/crates/contracts/src/lib.cairo
@@ -19,3 +19,5 @@ mod uninitialized_account;
 mod mocks {
     mod cairo1_helpers_fixture;
 }
+
+mod storage;

--- a/crates/contracts/src/lib.cairo
+++ b/crates/contracts/src/lib.cairo
@@ -7,6 +7,8 @@ mod errors;
 // Kakarot smart contract
 mod kakarot_core;
 
+mod storage;
+
 #[cfg(target: 'test')]
 mod test_data;
 
@@ -19,5 +21,3 @@ mod uninitialized_account;
 mod mocks {
     mod cairo1_helpers_fixture;
 }
-
-mod storage;

--- a/crates/contracts/src/storage.cairo
+++ b/crates/contracts/src/storage.cairo
@@ -1,0 +1,205 @@
+use starknet::storage::StorageTraitMut;
+use core::ops::DerefMut;
+use starknet::storage::StorageTrait;
+use core::ops::SnapshotDeref;
+use super::account_contract::IAccount;
+use core::starknet::{
+    SyscallResult, storage_read_syscall, Store, StorageBaseAddress, StorageAddress,
+    storage_write_syscall
+};
+use utils::utils::{pack_bytes, load_packed_bytes};
+use contracts::account_contract::AccountContract::unsafe_new_contract_state as account_contract_state;
+
+/// A wrapper type for the bytecode storage. Packing / unpacking is done transparently inside the
+/// `read` and `write` methods of `Store`.
+#[derive(Copy, Drop)]
+struct StorageBytecode {
+    bytecode: Span<u8>
+}
+
+const BYTES_PER_FELT: NonZero<u32> = 31;
+
+/// An implamentation of the `Store` trait for our specific `StorageBytecode` type.
+/// The packing-unpacking is done inside the `read` and `write` methods, thus transparent to the
+/// user.
+/// The bytecode is stored sequentially, starting from storage address 0, for compatibility purposes
+/// with KakarotZero.
+/// The bytecode length is stored in the `Account_bytecode_len` storage variable, which is accessed
+/// by the `read` and `write` methods.
+impl StoreBytecode of Store<StorageBytecode> {
+    /// Side effect: reads the bytecode len from the Account_bytecode_len storage variable
+    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<StorageBytecode> {
+        // Read the bytecode len from the storage of the current contract
+        let state = account_contract_state();
+        let bytecode_len: u32 = state.snapshot_deref().storage().Account_bytecode_len.read();
+        let (chunks_count, _remainder) = DivRem::div_rem(bytecode_len, BYTES_PER_FELT);
+
+        // Read the bytecode from the storage of the current contract, starting from address 0.
+        //TODO(opti): unpack chunks directly instead of reading them one by one and unpacking them
+        // afterwards.
+        let base: felt252 = 0;
+        let mut packed_bytecode = array![];
+        let mut i = 0;
+        while i != (chunks_count + 1) {
+            let storage_address: StorageAddress = (base + i.into()).try_into().unwrap();
+            let chunk = storage_read_syscall(address_domain, storage_address).unwrap();
+            packed_bytecode.append(chunk);
+            i += 1;
+        };
+        let bytecode = load_packed_bytes(packed_bytecode.span(), bytecode_len);
+        SyscallResult::Ok(StorageBytecode { bytecode: bytecode.span() })
+    }
+
+    /// Side effect: Writes the bytecode len to the Account_bytecode_len storage variable
+    fn write(
+        address_domain: u32, base: StorageBaseAddress, value: StorageBytecode
+    ) -> SyscallResult<()> {
+        let base: felt252 = 0;
+        let mut state = account_contract_state();
+        let bytecode_len: u32 = value.bytecode.len();
+        state.deref_mut().storage_mut().Account_bytecode_len.write(bytecode_len);
+
+        let mut packed_bytecode = pack_bytes(value.bytecode);
+        let mut i = 0;
+        for chunk in packed_bytecode {
+            let storage_address: StorageAddress = (base + i.into()).try_into().unwrap();
+            storage_write_syscall(address_domain, storage_address, chunk).unwrap();
+            i += 1;
+        };
+        SyscallResult::Ok(())
+    }
+
+    fn read_at_offset(
+        address_domain: u32, base: StorageBaseAddress, offset: u8
+    ) -> SyscallResult<StorageBytecode> {
+        panic!("'read_at_offset' is not implemented for StoreBytecode")
+    }
+
+    fn write_at_offset(
+        address_domain: u32, base: StorageBaseAddress, offset: u8, value: StorageBytecode
+    ) -> SyscallResult<()> {
+        panic!("'write_at_offset' is not implemented for StoreBytecode")
+    }
+
+    fn size() -> u8 {
+        panic!("'size' is not implemented for StoreBytecode")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StorageTrait;
+    use super::SnapshotDeref;
+    use super::StorageTraitMut;
+    use super::DerefMut;
+    use starknet::testing::set_contract_address;
+    use starknet::contract_address::ContractAddress;
+    use starknet::storage_access::{
+        StorageBaseAddress, StorageAddress, storage_base_address_from_felt252
+    };
+    use starknet::syscalls::storage_read_syscall;
+    use starknet::storage_access::Store;
+    use utils::utils::{pack_bytes, load_packed_bytes};
+    use contracts::account_contract::AccountContract::{
+        unsafe_new_contract_state as account_contract_state, ContractState as AccountContractState
+    };
+    use super::StorageBytecode;
+
+    #[test]
+    fn test_store_bytecode_empty() {
+        let mut state = account_contract_state();
+        let bytecode = [].span();
+        // Write the bytecode to the storage
+        state.deref_mut().storage_mut().Account_bytecode.write(StorageBytecode { bytecode });
+        // Verify that the bytecode was written correctly and the len as well
+        let bytecode_len = state.snapshot_deref().storage().Account_bytecode_len.read();
+        let stored_bytecode = state.snapshot_deref().storage().Account_bytecode.read();
+        assert_eq!(bytecode_len, bytecode.len());
+        assert_eq!(stored_bytecode.bytecode, bytecode);
+    }
+
+    #[test]
+    fn test_store_bytecode_single_chunk() {
+        let mut state = account_contract_state();
+        let bytecode = [0, 1, 2, 3, 4, 5].span();
+        // Write the bytecode to the storage
+        state.deref_mut().storage_mut().Account_bytecode.write(StorageBytecode { bytecode });
+        // Verify that the bytecode was written correctly and the len as well
+        let bytecode_len = state.snapshot_deref().storage().Account_bytecode_len.read();
+        let stored_bytecode = state.snapshot_deref().storage().Account_bytecode.read();
+        assert_eq!(bytecode_len, bytecode.len());
+        assert_eq!(stored_bytecode.bytecode, bytecode);
+    }
+
+    #[test]
+    fn test_store_bytecode_multiple_chunks() {
+        let mut state = account_contract_state();
+        let mut bytecode_array = array![];
+        let mut i = 0;
+        while i != 100 {
+            bytecode_array.append(i);
+            i += 1;
+        };
+        let bytecode = bytecode_array.span();
+        // Write the bytecode to the storage
+        state.deref_mut().storage_mut().Account_bytecode.write(StorageBytecode { bytecode });
+        // Verify that the bytecode was written correctly and the len as well
+        let bytecode_len = state.snapshot_deref().storage().Account_bytecode_len.read();
+        let stored_bytecode = state.snapshot_deref().storage().Account_bytecode.read();
+        assert_eq!(bytecode_len, bytecode.len());
+        assert_eq!(stored_bytecode.bytecode, bytecode);
+    }
+
+    #[test]
+    fn test_store_bytecode_partial_chunk() {
+        let mut state = account_contract_state();
+        let bytecode = [
+            1
+        ; 33].span(); // 33 bytes will require 2 chunks, with the second chunk partially filled
+        // Write the bytecode to the storage
+        state.deref_mut().storage_mut().Account_bytecode.write(StorageBytecode { bytecode });
+        // Verify that the bytecode was written correctly and the len as well
+        let bytecode_len = state.snapshot_deref().storage().Account_bytecode_len.read();
+        let stored_bytecode = state.snapshot_deref().storage().Account_bytecode.read();
+        assert_eq!(bytecode_len, bytecode.len());
+        assert_eq!(stored_bytecode.bytecode, bytecode);
+    }
+
+    #[test]
+    fn test_storage_layout_sequential_from_zero() {
+        let base_address: StorageAddress = 0.try_into().unwrap();
+        let bytecode = [0x12; 33].span();
+        let stored_bytecode = StorageBytecode { bytecode };
+        let mut state = account_contract_state();
+        state.deref_mut().storage_mut().Account_bytecode.write(stored_bytecode);
+
+        // Verify that the bytecode was packed in chunks sequential from zero
+        let chunk0 = storage_read_syscall(0, base_address).unwrap();
+        let chunk1 = storage_read_syscall(0, 1.try_into().unwrap()).unwrap();
+
+        assert_eq!(chunk0, (*pack_bytes([0x12; 31].span())[0]));
+        assert_eq!(chunk1, 0x1212);
+    }
+
+    #[test]
+    #[should_panic(expected: "'read_at_offset' is not implemented for StoreBytecode")]
+    fn test_read_at_offset_panics() {
+        let base_address: StorageBaseAddress = storage_base_address_from_felt252(0);
+        let _ = Store::<StorageBytecode>::read_at_offset(0, base_address, 0);
+    }
+
+    #[test]
+    #[should_panic(expected: "'write_at_offset' is not implemented for StoreBytecode")]
+    fn test_write_at_offset_panics() {
+        let base_address: StorageBaseAddress = storage_base_address_from_felt252(0);
+        let bytecode = array![].span();
+        let stored_bytecode = StorageBytecode { bytecode };
+        let _ = Store::<StorageBytecode>::write_at_offset(0, base_address, 0, stored_bytecode);
+    }
+
+    #[test]
+    #[should_panic(expected: "'size' is not implemented for StoreBytecode")]
+    fn test_size_panics() {
+        let _ = Store::<StorageBytecode>::size();
+    }
+}

--- a/crates/contracts/src/storage.cairo
+++ b/crates/contracts/src/storage.cairo
@@ -1,14 +1,14 @@
-use starknet::storage::StorageTraitMut;
+use contracts::account_contract::AccountContract::unsafe_new_contract_state as account_contract_state;
 use core::ops::DerefMut;
-use starknet::storage::StorageTrait;
 use core::ops::SnapshotDeref;
-use super::account_contract::IAccount;
 use core::starknet::{
     SyscallResult, storage_read_syscall, Store, StorageBaseAddress, StorageAddress,
     storage_write_syscall
 };
+use starknet::storage::StorageTrait;
+use starknet::storage::StorageTraitMut;
+use super::account_contract::IAccount;
 use utils::utils::{pack_bytes, load_packed_bytes};
-use contracts::account_contract::AccountContract::unsafe_new_contract_state as account_contract_state;
 
 /// A wrapper type for the bytecode storage. Packing / unpacking is done transparently inside the
 /// `read` and `write` methods of `Store`.
@@ -88,22 +88,22 @@ impl StoreBytecode of Store<StorageBytecode> {
 
 #[cfg(test)]
 mod tests {
-    use super::StorageTrait;
-    use super::SnapshotDeref;
-    use super::StorageTraitMut;
-    use super::DerefMut;
-    use starknet::testing::set_contract_address;
+    use contracts::account_contract::AccountContract::{
+        unsafe_new_contract_state as account_contract_state, ContractState as AccountContractState
+    };
     use starknet::contract_address::ContractAddress;
+    use starknet::storage_access::Store;
     use starknet::storage_access::{
         StorageBaseAddress, StorageAddress, storage_base_address_from_felt252
     };
     use starknet::syscalls::storage_read_syscall;
-    use starknet::storage_access::Store;
-    use utils::utils::{pack_bytes, load_packed_bytes};
-    use contracts::account_contract::AccountContract::{
-        unsafe_new_contract_state as account_contract_state, ContractState as AccountContractState
-    };
+    use starknet::testing::set_contract_address;
+    use super::DerefMut;
+    use super::SnapshotDeref;
     use super::StorageBytecode;
+    use super::StorageTrait;
+    use super::StorageTraitMut;
+    use utils::utils::{pack_bytes, load_packed_bytes};
 
     #[test]
     fn test_store_bytecode_empty() {

--- a/crates/contracts/src/test_utils.cairo
+++ b/crates/contracts/src/test_utils.cairo
@@ -7,16 +7,16 @@ use contracts::kakarot_core::{
 use contracts::uninitialized_account::{UninitializedAccount};
 use core::fmt::Debug;
 use core::result::ResultTrait;
+use core::starknet::{
+    testing, contract_address_const, EthAddress, ContractAddress, deploy_syscall,
+    get_contract_address
+};
 use evm::backend::starknet_backend;
 use evm::model::{Address};
 
 use evm::test_utils::{ca_address, other_starknet_address, chain_id, sequencer_evm_address};
 use openzeppelin::token::erc20::ERC20;
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-use core::starknet::{
-    testing, contract_address_const, EthAddress, ContractAddress, deploy_syscall,
-    get_contract_address
-};
 use utils::constants::BLOCK_GAS_LIMIT;
 use utils::eth_transaction::LegacyTransaction;
 

--- a/crates/contracts/tests/test_eoa.cairo
+++ b/crates/contracts/tests/test_eoa.cairo
@@ -16,13 +16,6 @@ use contracts_tests::test_upgradeable::{
 use core::array::SpanTrait;
 use core::box::BoxTrait;
 use core::starknet::account::{Call};
-
-use evm::model::{Address, AddressTrait};
-use evm::test_utils::{
-    kakarot_address, evm_address, other_evm_address, other_starknet_address, eoa_address, chain_id,
-    tx_gas_limit, gas_price, VMBuilderTrait
-};
-use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use core::starknet::class_hash::Felt252TryIntoClassHash;
 use core::starknet::testing::{
     set_caller_address, set_contract_address, set_signature, set_chain_id
@@ -31,6 +24,13 @@ use core::starknet::{
     deploy_syscall, ContractAddress, ClassHash, VALIDATED, get_contract_address,
     contract_address_const, EthAddress, eth_signature::{Signature}, get_tx_info
 };
+
+use evm::model::{Address, AddressTrait};
+use evm::test_utils::{
+    kakarot_address, evm_address, other_evm_address, other_starknet_address, eoa_address, chain_id,
+    tx_gas_limit, gas_price, VMBuilderTrait
+};
+use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
 use utils::eth_transaction::{
     TransactionType, EthereumTransaction, EthereumTransactionTrait, LegacyTransaction
 };

--- a/crates/contracts/tests/test_kakarot_core.cairo
+++ b/crates/contracts/tests/test_kakarot_core.cairo
@@ -16,13 +16,13 @@ use contracts_tests::test_upgradeable::{
 };
 use core::num::traits::Zero;
 use core::option::OptionTrait;
+use core::starknet::{testing, contract_address_const, ContractAddress, EthAddress, ClassHash};
 
 
 use core::traits::TryInto;
 use evm::model::{Address};
 use evm::test_utils::{sequencer_evm_address, chain_id};
 use evm::test_utils;
-use core::starknet::{testing, contract_address_const, ContractAddress, EthAddress, ClassHash};
 use utils::eth_transaction::{EthereumTransaction, EthereumTransactionTrait, LegacyTransaction};
 use utils::helpers::{EthAddressExTrait, u256_to_bytes_array};
 

--- a/crates/contracts/tests/test_ownable.cairo
+++ b/crates/contracts/tests/test_ownable.cairo
@@ -2,11 +2,11 @@ use contracts::components::ownable::{ownable_component};
 use contracts::test_utils::constants::{ZERO, OWNER, OTHER};
 use contracts::test_utils;
 use core::num::traits::Zero;
+use core::starknet::ContractAddress;
+use core::starknet::testing;
 
 
 use ownable_component::{InternalImpl, OwnableImpl};
-use core::starknet::ContractAddress;
-use core::starknet::testing;
 
 
 #[starknet::contract]

--- a/crates/evm/src/backend/starknet_backend.cairo
+++ b/crates/evm/src/backend/starknet_backend.cairo
@@ -4,14 +4,14 @@ use core::num::traits::zero::Zero;
 use core::ops::deref::SnapshotDeref;
 use core::starknet::storage::StoragePointerReadAccess;
 use core::starknet::storage::StoragePointerWriteAccess;
-use evm::errors::{ensure, EVMError, EOA_EXISTS};
-use evm::model::{Address, AddressTrait, Environment, Account, AccountTrait};
-use evm::state::{State, StateTrait};
-use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 use core::starknet::{
     EthAddress, get_contract_address, deploy_syscall, get_tx_info, get_block_info,
     SyscallResultTrait
 };
+use evm::errors::{ensure, EVMError, EOA_EXISTS};
+use evm::model::{Address, AddressTrait, Environment, Account, AccountTrait};
+use evm::state::{State, StateTrait};
+use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 use utils::constants;
 
 
@@ -125,12 +125,12 @@ fn fetch_balance(self: @Address) -> u256 {
 mod internals {
     use contracts::account_contract::{IAccountDispatcher, IAccountDispatcherTrait};
     use contracts::kakarot_core::{KakarotCore, KakarotCore::KakarotCoreImpl};
+    use core::starknet::SyscallResultTrait;
+    use core::starknet::syscalls::{emit_event_syscall};
     use evm::errors::EVMError;
     use evm::model::account::{Account, AccountTrait};
     use evm::model::{Address, AddressTrait, Transfer};
     use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-    use core::starknet::SyscallResultTrait;
-    use core::starknet::syscalls::{emit_event_syscall};
     use super::{State, StateTrait, deploy};
     use utils::constants::BURN_ADDRESS;
     use utils::set::{Set, SetTrait};
@@ -278,11 +278,11 @@ mod tests {
     use contracts::kakarot_core::KakarotCore;
     use contracts::test_utils as contract_utils;
     use contracts::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
+    use core::starknet::testing::{set_contract_address, set_chain_id};
     use evm::backend::starknet_backend;
     use evm::errors::EVMErrorTrait;
     use evm::test_utils::{chain_id, evm_address, VMBuilderTrait};
     use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
-    use core::starknet::testing::{set_contract_address, set_chain_id};
 
 
     #[test]

--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -2,6 +2,7 @@ use contracts::kakarot_core::KakarotCore;
 use contracts::kakarot_core::interface::IKakarotCore;
 //! CALL, CALLCODE, DELEGATECALL, STATICCALL opcode helpers
 use core::cmp::min;
+use core::starknet::{EthAddress, get_contract_address};
 
 use evm::errors::{EVMError, CALL_GAS_GT_GAS_LIMIT, ACTIVE_MACHINE_STATE_IN_CALL_FINALIZATION};
 use evm::gas;
@@ -12,7 +13,6 @@ use evm::model::vm::{VM, VMTrait};
 use evm::model::{Transfer, Address, Message};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
-use core::starknet::{EthAddress, get_contract_address};
 use utils::constants;
 use utils::helpers::compute_starknet_address;
 use utils::set::SetTrait;

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -2,7 +2,9 @@ use contracts::kakarot_core::KakarotCore;
 use contracts::kakarot_core::interface::IKakarotCore;
 //! CREATE, CREATE2 opcode helpers
 use core::cmp::min;
+use core::keccak::cairo_keccak;
 use core::num::traits::Bounded;
+use core::starknet::{EthAddress, get_tx_info};
 use evm::errors::{
     ensure, EVMError, CALL_GAS_GT_GAS_LIMIT, ACTIVE_MACHINE_STATE_IN_CALL_FINALIZATION
 };
@@ -15,8 +17,6 @@ use evm::model::{ExecutionResult, ExecutionResultTrait, ExecutionSummary, Enviro
 use evm::model::{Message, Address, Transfer};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
-use core::keccak::cairo_keccak;
-use core::starknet::{EthAddress, get_tx_info};
 use utils::address::{compute_contract_address, compute_create2_contract_address};
 use utils::constants;
 use utils::helpers::ArrayExtTrait;
@@ -177,9 +177,9 @@ impl CreateHelpersImpl of CreateHelpers {
 #[cfg(test)]
 mod tests {
     use contracts::test_data::counter_evm_bytecode;
+    use core::starknet::EthAddress;
     use evm::create_helpers::CreateHelpers;
     use evm::test_utils::{VMBuilderTrait};
-    use core::starknet::EthAddress;
     use utils::address::{compute_contract_address, compute_create2_contract_address};
     //TODO: test create helpers
 

--- a/crates/evm/src/gas.cairo
+++ b/crates/evm/src/gas.cairo
@@ -236,13 +236,13 @@ fn calculate_intrinsic_gas_cost(tx: @EthereumTransaction) -> u128 {
 #[cfg(test)]
 mod tests {
     use core::option::OptionTrait;
+    use core::starknet::EthAddress;
 
     use evm::gas::{
         calculate_intrinsic_gas_cost, calculate_memory_gas_cost, ACCESS_LIST_ADDRESS,
         ACCESS_LIST_STORAGE_KEY
     };
     use evm::test_utils::evm_address;
-    use core::starknet::EthAddress;
     use utils::eth_transaction::{
         EthereumTransaction, LegacyTransaction, AccessListTransaction, EthereumTransactionTrait,
         AccessListItem

--- a/crates/evm/src/instructions/block_information.cairo
+++ b/crates/evm/src/instructions/block_information.cairo
@@ -3,6 +3,10 @@
 use contracts::kakarot_core::{KakarotCore, IKakarotCore};
 use core::starknet::SyscallResultTrait;
 
+// Corelib imports
+use core::starknet::info::get_block_number;
+use core::starknet::{get_block_hash_syscall, EthAddress};
+
 use evm::errors::{
     EVMError, BLOCK_HASH_SYSCALL_FAILED, EXECUTION_INFO_SYSCALL_FAILED, TYPE_CONVERSION_ERROR
 };
@@ -13,10 +17,6 @@ use evm::model::vm::{VM, VMTrait};
 use evm::model::{Account};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
-
-// Corelib imports
-use core::starknet::info::get_block_number;
-use core::starknet::{get_block_hash_syscall, EthAddress};
 
 use utils::helpers::ResultExTrait;
 use utils::traits::{EthAddressTryIntoResultContractAddress, EthAddressIntoU256};
@@ -138,14 +138,14 @@ mod tests {
         setup_contracts_for_testing, fund_account_with_native_token, deploy_contract_account,
     };
     use core::result::ResultTrait;
-    use evm::instructions::BlockInformationTrait;
-    use evm::stack::StackTrait;
-    use evm::test_utils::{evm_address, VMBuilderTrait, tx_gas_limit, gas_price};
-    use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
     use core::starknet::testing::{
         set_block_timestamp, set_block_number, set_block_hash, set_contract_address,
         set_sequencer_address, ContractAddress
     };
+    use evm::instructions::BlockInformationTrait;
+    use evm::stack::StackTrait;
+    use evm::test_utils::{evm_address, VMBuilderTrait, tx_gas_limit, gas_price};
+    use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
     use utils::constants;
     use utils::traits::{EthAddressIntoU256};
 

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -1,9 +1,13 @@
 use contracts::kakarot_core::interface::{IKakarotCore};
 use contracts::kakarot_core::{KakarotCore};
 use core::hash::{HashStateExTrait, HashStateTrait};
+use core::keccak::cairo_keccak;
 use core::num::traits::OverflowingAdd;
 use core::num::traits::Zero;
 use core::pedersen::{PedersenTrait, HashState};
+use core::starknet::{
+    Store, storage_base_address_from_felt252, ContractAddress, get_contract_address
+};
 use evm::errors::{ensure, EVMError, READ_SYSCALL_FAILED};
 use evm::gas;
 use evm::memory::MemoryTrait;
@@ -12,11 +16,7 @@ use evm::model::vm::{VM, VMTrait};
 use evm::model::{AddressTrait};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
-use core::keccak::cairo_keccak;
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-use core::starknet::{
-    Store, storage_base_address_from_felt252, ContractAddress, get_contract_address
-};
 use utils::constants::EMPTY_KECCAK;
 use utils::helpers::ResultExTrait;
 use utils::helpers::{ceil32, load_word, U256Trait, U8SpanExTrait};
@@ -328,6 +328,8 @@ mod tests {
         setup_contracts_for_testing, fund_account_with_native_token, deploy_contract_account
     };
     use core::num::traits::CheckedAdd;
+
+    use core::starknet::testing::set_contract_address;
     use evm::errors::{EVMError, TYPE_CONVERSION_ERROR};
     use evm::instructions::EnvironmentInformationTrait;
     use evm::memory::{InternalMemoryTrait, MemoryTrait};
@@ -341,8 +343,6 @@ mod tests {
         tx_gas_limit
     };
     use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
-
-    use core::starknet::testing::set_contract_address;
     use utils::helpers::{u256_to_bytes_array, ArrayExtTrait};
     use utils::traits::{EthAddressIntoU256};
 

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -1,5 +1,6 @@
 use core::hash::{HashStateTrait, HashStateExTrait};
 use core::poseidon::PoseidonTrait;
+use core::starknet::{storage_base_address_from_felt252, Store};
 use evm::backend::starknet_backend::fetch_original_storage;
 //! Stack Memory Storage and Flow Operations.
 use evm::errors::{EVMError, ensure, INVALID_DESTINATION, READ_SYSCALL_FAILED};
@@ -10,7 +11,6 @@ use evm::model::vm::{VM, VMTrait};
 use evm::model::{AddressTrait};
 use evm::stack::StackTrait;
 use evm::state::{StateTrait, compute_state_key};
-use core::starknet::{storage_base_address_from_felt252, Store};
 use utils::helpers::U256Trait;
 use utils::set::SetTrait;
 
@@ -252,6 +252,7 @@ mod tests {
     use contracts::test_utils::{setup_contracts_for_testing, deploy_contract_account};
     use core::num::traits::Bounded;
     use core::result::ResultTrait;
+    use core::starknet::get_contract_address;
     use evm::backend::starknet_backend::fetch_original_storage;
     use evm::backend::starknet_backend;
     use evm::errors::{EVMError, INVALID_DESTINATION};
@@ -262,7 +263,6 @@ mod tests {
     use evm::stack::StackTrait;
     use evm::state::{StateTrait, compute_storage_address};
     use evm::test_utils::{evm_address, VMBuilderTrait};
-    use core::starknet::get_contract_address;
 
     #[test]
     fn test_pc_basic() {

--- a/crates/evm/src/instructions/sha3.cairo
+++ b/crates/evm/src/instructions/sha3.cairo
@@ -1,3 +1,4 @@
+use core::keccak::{cairo_keccak, u128_split};
 //! SHA3.
 
 use evm::errors::EVMError;
@@ -6,7 +7,6 @@ use evm::gas;
 use evm::memory::MemoryTrait;
 use evm::model::vm::{VM, VMTrait};
 use evm::stack::StackTrait;
-use core::keccak::{cairo_keccak, u128_split};
 use utils::helpers::{ArrayExtTrait, U256Trait, ceil32};
 
 #[generate_trait]

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -413,6 +413,8 @@ mod tests {
         deploy_eoa
     };
     use core::result::ResultTrait;
+    use core::starknet::EthAddress;
+    use core::starknet::testing::set_contract_address;
     use core::traits::TryInto;
     use evm::backend::starknet_backend;
     use evm::call_helpers::{CallHelpers, CallHelpersImpl};
@@ -431,8 +433,6 @@ mod tests {
         other_evm_address,
     };
     use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-    use core::starknet::EthAddress;
-    use core::starknet::testing::set_contract_address;
     use utils::helpers::load_word;
     use utils::traits::{EthAddressIntoU256};
 

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -1,3 +1,4 @@
+use core::starknet::{EthAddress, ContractAddress};
 use evm::create_helpers::CreateHelpers;
 use evm::errors::{EVMError, ensure, PC_OUT_OF_BOUNDS, EVMErrorTrait, CONTRACT_ACCOUNT_EXISTS};
 
@@ -18,7 +19,6 @@ use evm::model::{
 use evm::precompiles::Precompiles;
 use evm::stack::{Stack, StackTrait};
 use evm::state::{State, StateTrait};
-use core::starknet::{EthAddress, ContractAddress};
 use utils::constants;
 use utils::helpers::{U256Trait, compute_starknet_address, EthAddressExTrait};
 

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -4,10 +4,10 @@ use contracts::kakarot_core::{KakarotCore, IKakarotCore};
 
 use core::num::traits::Zero;
 use core::num::traits::{CheckedAdd, CheckedSub, CheckedMul};
+use core::starknet::{EthAddress, get_contract_address, ContractAddress};
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::model::account::{Account, AccountTrait};
 use evm::state::State;
-use core::starknet::{EthAddress, get_contract_address, ContractAddress};
 use utils::fmt::{TSpanSetDebug};
 use utils::helpers::{ResultExTrait};
 use utils::set::{Set, SpanSet};
@@ -160,6 +160,7 @@ mod tests {
         setup_contracts_for_testing, fund_account_with_native_token, deploy_contract_account
     };
     use core::starknet::EthAddress;
+    use core::starknet::testing::set_contract_address;
     use evm::backend::starknet_backend;
     use evm::model::account::AccountTrait;
 
@@ -168,7 +169,6 @@ mod tests {
     use evm::state::{State, StateChangeLog, StateChangeLogTrait};
     use evm::test_utils::{evm_address};
     use openzeppelin::token::erc20::interface::IERC20CamelDispatcherTrait;
-    use core::starknet::testing::set_contract_address;
 
     #[test]
     fn test_is_deployed_eoa_exists() {

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -2,6 +2,10 @@ use contracts::account_contract::{IAccountDispatcher, IAccountDispatcherTrait, I
 use contracts::kakarot_core::kakarot::KakarotCore::KakarotCoreInternal;
 use contracts::kakarot_core::{KakarotCore, IKakarotCore};
 use core::num::traits::Zero;
+use core::starknet::{
+    ContractAddress, EthAddress, get_contract_address, deploy_syscall, get_tx_info,
+    SyscallResultTrait
+};
 use core::traits::TryInto;
 use evm::backend::starknet_backend::fetch_balance;
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
@@ -9,10 +13,6 @@ use evm::model::{Address, AddressTrait, Transfer};
 use evm::state::State;
 use evm::state::StateTrait;
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-use core::starknet::{
-    ContractAddress, EthAddress, get_contract_address, deploy_syscall, get_tx_info,
-    SyscallResultTrait
-};
 use utils::helpers::{ResultExTrait, ByteArrayExTrait, compute_starknet_address};
 
 #[derive(Drop)]

--- a/crates/evm/src/model/vm.cairo
+++ b/crates/evm/src/model/vm.cairo
@@ -1,9 +1,9 @@
 use core::num::traits::CheckedSub;
+use core::starknet::EthAddress;
 use evm::errors::{EVMError, ensure};
 use evm::memory::{Memory, MemoryTrait};
 use evm::model::{Message, Environment, ExecutionResult, AccountTrait};
 use evm::stack::{Stack, StackTrait};
-use core::starknet::EthAddress;
 use utils::helpers::{SpanExtTrait, ArrayExtTrait};
 use utils::set::{Set, SetTrait, SpanSet};
 use utils::traits::{SpanDefault};

--- a/crates/evm/src/precompiles.cairo
+++ b/crates/evm/src/precompiles.cairo
@@ -4,6 +4,7 @@ mod identity;
 mod modexp;
 mod p256verify;
 mod sha256;
+use core::starknet::EthAddress;
 
 use core::traits::Into;
 use evm::errors::EVMError;
@@ -15,7 +16,6 @@ use evm::precompiles::identity::Identity;
 use evm::precompiles::modexp::ModExp;
 use evm::precompiles::p256verify::P256Verify;
 use evm::precompiles::sha256::Sha256;
-use core::starknet::EthAddress;
 
 
 trait Precompile {

--- a/crates/evm/src/precompiles/blake2f.cairo
+++ b/crates/evm/src/precompiles/blake2f.cairo
@@ -1,10 +1,10 @@
 use core::array::ArrayTrait;
 use core::option::OptionTrait;
+use core::starknet::EthAddress;
 
 use evm::errors::{EVMError, ensure};
 use evm::model::vm::{VM, VMTrait};
 use evm::precompiles::Precompile;
-use core::starknet::EthAddress;
 use utils::crypto::blake2_compress::compress;
 use utils::helpers::{FromBytes, ToBytes};
 
@@ -85,6 +85,7 @@ impl Blake2f of Precompile {
 mod tests {
     use contracts::test_utils::{setup_contracts_for_testing};
     use core::array::SpanTrait;
+    use core::starknet::testing::set_contract_address;
     use evm::errors::EVMError;
     use evm::instructions::memory_operations::MemoryOperationTrait;
     use evm::instructions::system_operations::SystemOperationsTrait;
@@ -100,7 +101,6 @@ mod tests {
         blake2_precompile_pass_0_test_case, blake2_precompile_pass_2_test_case
     };
     use evm::test_utils::{VMBuilderTrait, native_token, other_starknet_address};
-    use core::starknet::testing::set_contract_address;
     use utils::helpers::FromBytes;
 
     #[test]

--- a/crates/evm/src/precompiles/ec_recover.cairo
+++ b/crates/evm/src/precompiles/ec_recover.cairo
@@ -1,13 +1,13 @@
+use core::starknet::{
+    EthAddress, eth_signature::{recover_public_key, public_key_point_to_eth_address, Signature},
+    secp256k1::{Secp256k1Point}
+};
 use core::traits::Into;
 use evm::errors::{EVMError, TYPE_CONVERSION_ERROR};
 use evm::model::vm::VM;
 use evm::model::vm::VMTrait;
 use evm::precompiles::Precompile;
 use evm::stack::StackTrait;
-use core::starknet::{
-    EthAddress, eth_signature::{recover_public_key, public_key_point_to_eth_address, Signature},
-    secp256k1::{Secp256k1Point}
-};
 use utils::helpers::EthAddressExTrait;
 use utils::helpers::U8SpanExTrait;
 use utils::helpers::{U256Trait, BoolIntoNumeric, ToBytes, FromBytes};

--- a/crates/evm/src/precompiles/identity.cairo
+++ b/crates/evm/src/precompiles/identity.cairo
@@ -1,8 +1,8 @@
+use core::starknet::EthAddress;
 use evm::errors::EVMError;
 use evm::model::vm::VM;
 use evm::model::vm::VMTrait;
 use evm::precompiles::Precompile;
-use core::starknet::EthAddress;
 
 const BASE_COST: u128 = 15;
 const COST_PER_WORD: u128 = 3;
@@ -26,13 +26,13 @@ mod tests {
     use contracts::test_utils::{setup_contracts_for_testing};
     use core::clone::Clone;
     use core::result::ResultTrait;
+    use core::starknet::testing::set_contract_address;
     use evm::instructions::system_operations::SystemOperationsTrait;
 
     use evm::memory::MemoryTrait;
     use evm::precompiles::identity::Identity;
     use evm::stack::StackTrait;
     use evm::test_utils::{VMBuilderTrait, native_token, other_starknet_address};
-    use core::starknet::testing::set_contract_address;
 
     // source:
     // <https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code='wFirsWplaceqparameters%20in%20memorybFFjdata~0vMSTOREvvwDoqcall~1QX3FQ_1YX1FY_4jaddressZ4%200xFFFFFFFFjgasvSTATICCALLvvwPutqresulWalonVonqstackvPOPb20vMLOAD'~Z1j//%20v%5Cnq%20thVj%20wb~0x_Offset~ZvPUSHYjargsXSizebWt%20Ve%20Qjret%01QVWXYZ_bjqvw~_>

--- a/crates/evm/src/precompiles/modexp.cairo
+++ b/crates/evm/src/precompiles/modexp.cairo
@@ -6,6 +6,7 @@ use core::num::traits::OverflowingAdd;
 // [revm](https://github.com/bluealloy/revm/blob/main/crates/precompile/src/modexp.rs)
 
 use core::option::OptionTrait;
+use core::starknet::EthAddress;
 use core::traits::TryInto;
 
 use evm::errors::EVMError;
@@ -13,7 +14,6 @@ use evm::model::vm::VM;
 use evm::model::vm::VMTrait;
 
 use evm::precompiles::Precompile;
-use core::starknet::EthAddress;
 use utils::crypto::modexp::lib::modexp;
 use utils::helpers::{U256Trait, U8SpanExTrait, U64Trait, FromBytes, BitsUsed};
 
@@ -156,6 +156,8 @@ fn calculate_iteration_count(exp_length: u64, exp_highp: u256) -> u64 {
 mod tests {
     use contracts::test_utils::{setup_contracts_for_testing};
     use core::result::ResultTrait;
+    use core::starknet::EthAddress;
+    use core::starknet::testing::set_contract_address;
 
     use evm::instructions::system_operations::SystemOperationsTrait;
 
@@ -170,8 +172,6 @@ mod tests {
         test_modexp_eip198_example_2_data, test_modexp_nagydani_1_square_data,
         test_modexp_nagydani_1_qube_data
     };
-    use core::starknet::EthAddress;
-    use core::starknet::testing::set_contract_address;
     use utils::helpers::U256Trait;
 
     // the tests are taken from

--- a/crates/evm/src/precompiles/p256verify.cairo
+++ b/crates/evm/src/precompiles/p256verify.cairo
@@ -1,10 +1,10 @@
 use core::starknet::SyscallResultTrait;
-use evm::errors::{EVMError};
-use evm::precompiles::Precompile;
 use core::starknet::{
     EthAddress, eth_signature::{recover_public_key, public_key_point_to_eth_address, Signature},
     secp256r1::{Secp256r1Point, secp256r1_new_syscall}, secp256_trait::is_valid_signature
 };
+use evm::errors::{EVMError};
+use evm::precompiles::Precompile;
 use utils::helpers::{U256Trait, ToBytes, FromBytes};
 
 const P256VERIFY_PRECOMPILE_GAS_COST: u128 = 3450;

--- a/crates/evm/src/precompiles/sha256.cairo
+++ b/crates/evm/src/precompiles/sha256.cairo
@@ -1,11 +1,11 @@
 use core::circuit::CircuitInputs;
 use core::iter::IntoIterator;
 use core::sha256::compute_sha256_u32_array;
+use core::starknet::EthAddress;
 use evm::errors::EVMError;
 use evm::model::vm::VM;
 use evm::model::vm::VMTrait;
 use evm::precompiles::Precompile;
-use core::starknet::EthAddress;
 use utils::helpers::Bitshift;
 use utils::helpers::{FromBytes, ToBytes};
 
@@ -56,13 +56,13 @@ impl Sha256 of Precompile {
 mod tests {
     use contracts::test_utils::{setup_contracts_for_testing};
     use core::result::ResultTrait;
+    use core::starknet::testing::set_contract_address;
     use evm::instructions::system_operations::SystemOperationsTrait;
 
     use evm::memory::MemoryTrait;
     use evm::precompiles::sha256::Sha256;
     use evm::stack::StackTrait;
     use evm::test_utils::{VMBuilderTrait, native_token, other_starknet_address};
-    use core::starknet::testing::set_contract_address;
     use utils::helpers::ToBytes;
     use utils::helpers::{FromBytes};
 

--- a/crates/evm/src/stack.cairo
+++ b/crates/evm/src/stack.cairo
@@ -1,5 +1,6 @@
 use core::fmt::{Debug, Formatter, Error, Display};
 use core::nullable::{NullableTrait};
+use core::starknet::{StorageBaseAddress, EthAddress};
 //! Stack implementation.
 //! # Example
 //! ```
@@ -16,7 +17,6 @@ use core::nullable::{NullableTrait};
 //! let value = stack.pop()?;
 //! ```
 use evm::errors::{ensure, EVMError, TYPE_CONVERSION_ERROR};
-use core::starknet::{StorageBaseAddress, EthAddress};
 
 use utils::constants;
 use utils::i256::i256;
@@ -326,8 +326,8 @@ mod tests {
     }
 
     mod pop {
-        use evm::errors::{EVMError, TYPE_CONVERSION_ERROR};
         use core::starknet::storage_base_address_const;
+        use evm::errors::{EVMError, TYPE_CONVERSION_ERROR};
         use super::StackTrait;
         use utils::traits::StorageBaseAddressPartialEq;
 

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -4,16 +4,16 @@ use core::nullable::{match_nullable, FromNullableResult};
 use core::num::traits::{OverflowingAdd, OverflowingSub, OverflowingMul};
 use core::poseidon::PoseidonTrait;
 use core::starknet::SyscallResultTrait;
+use core::starknet::{
+    Store, StorageBaseAddress, storage_base_address_from_felt252, ContractAddress, EthAddress,
+    emit_event_syscall
+};
 use evm::backend::starknet_backend::fetch_original_storage;
 
 use evm::errors::{ensure, EVMError, WRITE_SYSCALL_FAILED, READ_SYSCALL_FAILED, BALANCE_OVERFLOW};
 use evm::model::account::{AccountTrait, AccountInternalTrait};
 use evm::model::{Event, Transfer, Account, Address, AddressTrait};
 use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
-use core::starknet::{
-    Store, StorageBaseAddress, storage_base_address_from_felt252, ContractAddress, EthAddress,
-    emit_event_syscall
-};
 use utils::helpers::{ArrayExtTrait, ResultExTrait};
 use utils::set::{Set, SetTrait};
 
@@ -296,6 +296,8 @@ mod tests {
         use contracts::kakarot_core::interface::{IExtendedKakarotCoreDispatcherTrait};
         use contracts::test_utils as contract_utils;
         use contracts::uninitialized_account::UninitializedAccount;
+        use core::starknet::EthAddress;
+        use core::starknet::testing::set_contract_address;
         use evm::backend::starknet_backend;
         use evm::model::account::{Account, AccountTrait, AccountInternalTrait};
         use evm::model::{Event, Transfer, Address};
@@ -304,8 +306,6 @@ mod tests {
         use openzeppelin::token::erc20::interface::{
             IERC20CamelDispatcher, IERC20CamelDispatcherTrait
         };
-        use core::starknet::EthAddress;
-        use core::starknet::testing::set_contract_address;
         use utils::helpers::compute_starknet_address;
         use utils::set::{Set, SetTrait};
 

--- a/crates/evm/src/test_utils.cairo
+++ b/crates/evm/src/test_utils.cairo
@@ -2,6 +2,10 @@ use contracts::account_contract::{IAccountDispatcher, IAccountDispatcherTrait};
 use contracts::test_utils::{deploy_contract_account};
 use contracts::uninitialized_account::UninitializedAccount;
 use core::nullable::{match_nullable, FromNullableResult};
+use core::starknet::{
+    StorageBaseAddress, storage_base_address_from_felt252, contract_address_try_from_felt252,
+    ContractAddress, EthAddress, deploy_syscall, get_contract_address, contract_address_const
+};
 use core::traits::TryInto;
 use evm::errors::{EVMError};
 
@@ -9,10 +13,6 @@ use evm::model::vm::{VM, VMTrait};
 use evm::model::{Message, Environment, Address, Account, AccountTrait};
 use evm::state::State;
 use evm::{stack::{Stack, StackTrait}, memory::{Memory, MemoryTrait}};
-use core::starknet::{
-    StorageBaseAddress, storage_base_address_from_felt252, contract_address_try_from_felt252,
-    ContractAddress, EthAddress, deploy_syscall, get_contract_address, contract_address_const
-};
 use utils::constants;
 
 #[derive(Destruct)]

--- a/crates/openzeppelin/src/token/erc20/erc20.cairo
+++ b/crates/openzeppelin/src/token/erc20/erc20.cairo
@@ -9,13 +9,13 @@
 pub mod ERC20 {
     use core::num::traits::Bounded;
     use core::num::traits::Zero;
+    use core::starknet::ContractAddress;
+    use core::starknet::get_caller_address;
     use core::starknet::storage::{
         Map, StorageMapWriteAccess, StorageMapReadAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
     use openzeppelin::token::erc20::interface::{IERC20, IERC20CamelOnly};
-    use core::starknet::ContractAddress;
-    use core::starknet::get_caller_address;
 
     #[storage]
     struct Storage {

--- a/crates/utils/src/utils.cairo
+++ b/crates/utils/src/utils.cairo
@@ -2,6 +2,38 @@ use core::array;
 use core::felt252_div;
 use core::num::traits::Zero;
 
+/// Pack an array of bytes into 31-byte words and a final word.
+/// The bytes are packed in big-endian order.
+///
+/// # Arguments
+/// * `input` - An array of bytes to pack.
+///
+/// # Returns
+/// An array of felt252 values containing the packed bytes. The last word might not be full.
+pub fn pack_bytes(input: Span<u8>) -> Array<felt252> {
+    let mut result: Array<felt252> = Default::default();
+    let mut current_word: u256 = 0;
+    let mut byte_count: usize = 0;
+
+    for byte in input {
+        current_word = (current_word * 256) + (*byte).into();
+        byte_count += 1;
+
+        if byte_count == 31 {
+            result.append(current_word.try_into().unwrap());
+            current_word = 0;
+            byte_count = 0;
+        }
+    };
+
+    // Append the last word if there are any remaining bytes
+    if byte_count != 0 {
+        result.append(current_word.try_into().unwrap());
+    }
+
+    result
+}
+
 /// Load packed bytes from an array of bytes packed in 31-byte words and a final word.
 ///
 /// # Arguments
@@ -15,76 +47,67 @@ use core::num::traits::Zero;
 ///
 /// # Performance considerations
 ///
-/// This function uses head-recursive helper functions (`unpack_full_value` and
-/// `unpack_partial_value`) for unpacking individual felt252 values. Head recursion
-/// is used here instead of loops because the Array type in Cairo is append-only. This approach
-/// allows us to append the bytes in the correct order (big-endian) without needing to
-/// reverse the array afterwards. This leads to more efficient memory usage and performance.
-pub fn load_packed_bytes(mut input: Span<felt252>, bytes_len: u32) -> Array<u8> {
+/// This function uses head-recursive helper functions (`unpack_chunk`) for unpacking individual
+/// felt252 values. Head recursion is used here instead of loops because the Array type in Cairo is
+/// append-only. This approach allows us to append the bytes in the correct order (big-endian)
+/// without needing to reverse the array afterwards. This leads to more efficient memory usage and
+/// performance.
+pub fn load_packed_bytes(input: Span<felt252>, bytes_len: u32) -> Array<u8> {
     if input.is_empty() {
         return Default::default();
     }
+    let (chunk_counts, remainder) = DivRem::div_rem(bytes_len, 31);
     let mut res: Array<u8> = Default::default();
-    let full_words = input.slice(0, input.len() - 1);
-    for value in full_words {
-        let mut value: u256 = (*value).into();
-        unpack_full_value(value, ref res);
+
+    let mut i = 0;
+    while i != chunk_counts {
+        let mut value: u256 = (*input[i]).into();
+        unpack_chunk(value, 31, ref res);
+        i += 1;
     };
 
-    let mut last_value: u256 = (*input.pop_back().unwrap()).into();
-    if last_value.is_zero() {
+    if remainder.is_zero() {
         return res;
     }
-    let mut remaining_bytes = bytes_len - (full_words.len() * 31);
-    unpack_partial_value(last_value, remaining_bytes, ref res);
+    unpack_chunk((*input[input.len() - 1]).into(), remainder, ref res);
     res
 }
 
-/// Unpacks a value into an array of bytes. The value is expected to be a 31-bytes word.
-/// Uses head recursion to append bytes in big-endian order.
-///
-/// # Arguments
-///
-/// * `value` - The u256 value to unpack.
-/// * `output` - A mutable reference to the output byte array.
-fn unpack_full_value(value: u256, ref output: Array<u8>) {
-    if value == 0 {
-        return;
-    }
-    let (q, r) = DivRem::div_rem(value, 256);
-    unpack_full_value(q, ref output);
-    output.append(r.try_into().unwrap());
-}
 
-/// Unpacks a partial felt252 value into an array of bytes.
-///
-/// Similar to `unpack_full_value`, but it unpacks only a specified
-/// number of bytes from the value.
-/// Uses head recursion to append bytes in big-endian order.
+/// Unpacks only a specified number of bytes from the value.  Uses head recursion to append bytes in
+/// big-endian order.
 ///
 /// # Arguments
 ///
 /// * `value` - The u256 value to unpack.
 /// * `remaining_bytes` - The number of bytes to unpack from the value.
-fn unpack_partial_value(value: u256, remaining_bytes: u32, ref output: Array<u8>) {
+/// * `output` - The array to append the unpacked bytes to.
+fn unpack_chunk(value: u256, remaining_bytes: u32, ref output: Array<u8>) {
     if remaining_bytes == 0 {
         return;
     }
-
     let (q, r) = DivRem::div_rem(value, 256);
-    unpack_partial_value(q, remaining_bytes - 1, ref output);
+    unpack_chunk(q, remaining_bytes - 1, ref output);
     output.append(r.try_into().unwrap());
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{load_packed_bytes};
+    use super::{load_packed_bytes, pack_bytes};
 
     #[test]
     fn test_should_load_empty_array() {
         let res = load_packed_bytes([].span(), 0);
 
         assert_eq!(res.span(), [].span());
+    }
+
+    #[test]
+    fn test_should_load_zeroes() {
+        let input = [0x00, 0x00];
+        let res = load_packed_bytes(input.span(), 35);
+
+        assert_eq!(res.span(), [0x00; 35].span());
     }
 
     #[test]
@@ -117,11 +140,12 @@ mod tests {
 
     #[test]
     fn test_should_load_mixed_byte_values_big_endian() {
-        let input = [0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f, 0x2021];
-        let res = load_packed_bytes(input.span(), 33);
+        let input = [0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e, 0x1f2021];
+        let res = load_packed_bytes(input.span(), 34);
         assert_eq!(
             res.span(),
             [
+                0x00,
                 0x01,
                 0x02,
                 0x03,
@@ -157,5 +181,132 @@ mod tests {
                 0x21
             ].span()
         );
+    }
+
+    #[test]
+    fn test_should_pack_empty_array() {
+        let res = pack_bytes([].span());
+
+        assert_eq!(res, array![]);
+    }
+
+    #[test]
+    fn test_should_pack_single_31bytes_felt() {
+        let input = [0xff; 31];
+        let res = pack_bytes(input.span());
+
+        assert_eq!(res, array![0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff]);
+    }
+
+    #[test]
+    fn test_should_pack_with_non_full_last_felt() {
+        let mut input = [0xff; 33];
+        let res = pack_bytes(input.span());
+
+        assert_eq!(
+            res, array![0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xffff]
+        );
+    }
+
+    #[test]
+    fn test_should_pack_multiple_words() {
+        let input = [0xff; 64];
+        let res = pack_bytes(input.span());
+
+        assert_eq!(
+            res,
+            array![
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+                0xffff
+            ]
+        );
+    }
+
+    #[test]
+    fn test_should_pack_mixed_byte_values_big_endian() {
+        let input = [
+            0x00,
+            0x01,
+            0x02,
+            0x03,
+            0x04,
+            0x05,
+            0x06,
+            0x07,
+            0x08,
+            0x09,
+            0x0a,
+            0x0b,
+            0x0c,
+            0x0d,
+            0x0e,
+            0x0f,
+            0x10,
+            0x11,
+            0x12,
+            0x13,
+            0x14,
+            0x15,
+            0x16,
+            0x17,
+            0x18,
+            0x19,
+            0x1a,
+            0x1b,
+            0x1c,
+            0x1d,
+            0x1e,
+            0x1f,
+            0x20,
+            0x21
+        ];
+        let res = pack_bytes(input.span());
+        assert_eq!(
+            res, array![0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e, 0x1f2021]
+        );
+    }
+
+    #[test]
+    fn test_pack_and_unpack_roundtrip() {
+        let original = [
+            0x00,
+            0x01,
+            0x02,
+            0x03,
+            0x04,
+            0x05,
+            0x06,
+            0x07,
+            0x08,
+            0x09,
+            0x0a,
+            0x0b,
+            0x0c,
+            0x0d,
+            0x0e,
+            0x0f,
+            0x10,
+            0x11,
+            0x12,
+            0x13,
+            0x14,
+            0x15,
+            0x16,
+            0x17,
+            0x18,
+            0x19,
+            0x1a,
+            0x1b,
+            0x1c,
+            0x1d,
+            0x1e,
+            0x1f,
+            0x20,
+            0x21
+        ].span();
+        let packed = pack_bytes(original);
+        let unpacked = load_packed_bytes(packed.span(), original.len().try_into().unwrap());
+        assert_eq!(original, unpacked.span());
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #827

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
 
- Stores the bytecode of a contract in 31-bytes chunks, sequentially from address 0 of the contract's storage.
- Packing / unpacking is transparent and handled in the `Store` trait.
- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/838)
<!-- Reviewable:end -->
