### PR TITLE
feat: update starknet address computation method

### DIFF
--- a/crates/contracts/src/account_contract.cairo
+++ b/crates/contracts/src/account_contract.cairo
@@ -9,10 +9,7 @@ use core::starknet::{ContractAddress, EthAddress, ClassHash};
 #[starknet::interface]
 pub trait IAccount<TContractState> {
     fn initialize(
-        ref self: TContractState,
-        kakarot_address: ContractAddress,
-        evm_address: EthAddress,
-        implementation_class: ClassHash
+        ref self: TContractState, evm_address: EthAddress, implementation_class: ClassHash
     );
     fn get_implementation(self: @TContractState) -> ClassHash;
     fn get_evm_address(self: @TContractState) -> EthAddress;
@@ -74,10 +71,8 @@ pub mod AccountContract {
 
     // Add ownable component
     component!(path: ownable_component, storage: ownable, event: OwnableEvent);
-
     #[abi(embed_v0)]
     impl OwnableImpl = ownable_component::Ownable<ContractState>;
-
     impl OwnableInternal = ownable_component::InternalImpl<ContractState>;
 
 
@@ -120,19 +115,16 @@ pub mod AccountContract {
     #[abi(embed_v0)]
     impl Account of super::IAccount<ContractState> {
         fn initialize(
-            ref self: ContractState,
-            kakarot_address: ContractAddress,
-            evm_address: EthAddress,
-            implementation_class: ClassHash
+            ref self: ContractState, evm_address: EthAddress, implementation_class: ClassHash
         ) {
             assert(!self.Account_is_initialized.read(), 'Account already initialized');
             self.Account_is_initialized.write(true);
-            self.ownable.initializer(kakarot_address);
+
             self.Account_evm_address.write(evm_address);
             self.Account_implementation.write(implementation_class);
 
+            let kakarot_address = self.ownable.owner();
             let kakarot = IKakarotCoreDispatcher { contract_address: kakarot_address };
-
             let native_token = kakarot.get_native_token();
             // To internally perform value transfer of the network's native
             // token (which conforms to the ERC20 standard), we need to give the

--- a/crates/contracts/src/test_utils.cairo
+++ b/crates/contracts/src/test_utils.cairo
@@ -129,14 +129,13 @@ pub(crate) fn deploy_contract_account(evm_address: EthAddress, bytecode: Span<u8
 }
 
 fn deploy_eoa(eoa_address: EthAddress) -> IAccountDispatcher {
-    let kakarot_address = get_contract_address();
-    let calldata: Span<felt252> = [kakarot_address.into(), eoa_address.into()].span();
+    let calldata: Span<felt252> = [1, eoa_address.into()].span();
 
     let (starknet_address, _) = deploy_syscall(
         UninitializedAccount::TEST_CLASS_HASH.try_into().unwrap(),
         eoa_address.into(),
         calldata,
-        true
+        deploy_from_zero: false
     )
         .expect('failed to deploy EOA');
 

--- a/crates/evm/src/backend/starknet_backend.cairo
+++ b/crates/evm/src/backend/starknet_backend.cairo
@@ -44,11 +44,13 @@ fn deploy(evm_address: EthAddress) -> Result<Address, EVMError> {
 
     let mut kakarot_state = KakarotCore::unsafe_new_contract_state();
     let uninitialized_account_class_hash = kakarot_state.uninitialized_account_class_hash();
-    let kakarot_address = get_contract_address();
-    let calldata: Span<felt252> = [kakarot_address.into(), evm_address.into()].span();
+    let calldata: Span<felt252> = [1, evm_address.into()].span();
 
     let (starknet_address, _) = deploy_syscall(
-        uninitialized_account_class_hash, evm_address.into(), calldata, true
+        uninitialized_account_class_hash,
+        contract_address_salt: evm_address.into(),
+        calldata: calldata,
+        deploy_from_zero: false
     )
         .unwrap_syscall();
 

--- a/crates/utils/src/helpers.cairo
+++ b/crates/utils/src/helpers.cairo
@@ -761,22 +761,22 @@ pub impl ResultExImpl<T, E, +Drop<T>, +Drop<E>> of ResultExTrait<T, E> {
 pub fn compute_starknet_address(
     kakarot_address: ContractAddress, evm_address: EthAddress, class_hash: ClassHash
 ) -> ContractAddress {
-    // Deployer is always 0
+    // Deployer is always Kakarot (current contract)
     // pedersen(a1, a2, a3) is defined as:
     // pedersen(pedersen(pedersen(a1, a2), a3), len([a1, a2, a3]))
     // https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/hash_state.py#L6
     // https://github.com/xJonathanLEI/starknet-rs/blob/master/starknet-core/src/crypto.rs#L49
     // Constructor Calldata For an Account, the constructor calldata is:
-    // [kakarot_address, evm_address]
+    // [1, evm_address]
     let constructor_calldata_hash = PedersenTrait::new(0)
-        .update_with(kakarot_address)
+        .update_with(1)
         .update_with(evm_address)
         .update(2)
         .finalize();
 
     let hash = PedersenTrait::new(0)
         .update_with(CONTRACT_ADDRESS_PREFIX)
-        .update_with(0)
+        .update_with(kakarot_address)
         .update_with(evm_address)
         .update_with(class_hash)
         .update_with(constructor_calldata_hash)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #860 
resolves  #863

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Address computation no longer takes kakarot_address as constructor argument, (now [1, evm_address]) and is DEPLOY_FROM_ZERO is now false, so that the deployer;s address (kakarot's) is used for computation of the address of the deployed contract
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/862)
<!-- Reviewable:end -->
