### PR TITLE
fix: account state was discarded after processing created accounts initcode

### DIFF
--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -77,10 +77,10 @@ impl EVMImpl of EVMTrait {
         }
 
         let mut result = Self::process_message(message, ref env);
-        let target_account = env.state.get_account(target_evm_address);
         if result.success {
             // Write the return_data of the initcode
             // as the deployed contract's bytecode and charge gas
+            let target_account = env.state.get_account(target_evm_address);
             match result.finalize_creation(target_account) {
                 Result::Ok(account_created) => { env.state.set_account(account_created) },
                 Result::Err(err) => {

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -62,17 +62,22 @@ impl EVMImpl of EVMTrait {
         // snapshot of the environment state so that we can revert if the
         let state_snapshot = env.state.clone();
         let target_evm_address = message.target.evm;
-        let mut target_account = env.state.get_account(target_evm_address);
 
-        // Increment nonce of target
-        target_account.set_nonce(1);
-        // Set the target as created
-        target_account.set_created(true);
-        target_account.address = message.target;
-        env.state.set_account(target_account);
+        //@dev: Adding a scope block around `target_account` to ensure that the same instance is not
+        //being accessed after
+        // the state has been modified in `process_message`.
+        {
+            let mut target_account = env.state.get_account(target_evm_address);
+            // Increment nonce of target
+            target_account.set_nonce(1);
+            // Set the target as created
+            target_account.set_created(true);
+            target_account.address = message.target;
+            env.state.set_account(target_account);
+        }
 
         let mut result = Self::process_message(message, ref env);
-
+        let target_account = env.state.get_account(target_evm_address);
         if result.success {
             // Write the return_data of the initcode
             // as the deployed contract's bytecode and charge gas

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -64,8 +64,7 @@ impl EVMImpl of EVMTrait {
         let target_evm_address = message.target.evm;
 
         //@dev: Adding a scope block around `target_account` to ensure that the same instance is not
-        //being accessed after
-        // the state has been modified in `process_message`.
+        //being accessed after the state has been modified in `process_message`.
         {
             let mut target_account = env.state.get_account(target_evm_address);
             // Increment nonce of target


### PR DESCRIPTION


<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes a bug where any changes made to the target_account during its initcode were being discarded, as we reused an old instance of `target_account` and overriding any previous state changes.
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/867)
<!-- Reviewable:end -->
