### PR TITLE
fix: sha256 output was not forcing conversion of u32 words to 4-bytes

### DIFF
--- a/crates/evm/src/precompiles/sha256.cairo
+++ b/crates/evm/src/precompiles/sha256.cairo
@@ -144,7 +144,7 @@ mod tests {
         let expected_result = 0x3b745a1c00d035c334f358d007a430e4cf0ae63aa0556fb05529706de546464d;
 
         assert_eq!(result, expected_result);
-        assert_eq!(gas, 72);
+        assert_eq!(gas, 84); // BASE + 2 WORDS
     }
 
 

--- a/crates/evm/src/precompiles/sha256.cairo
+++ b/crates/evm/src/precompiles/sha256.cairo
@@ -44,7 +44,7 @@ impl Sha256 of Precompile {
         let mut result_bytes = array![];
         for word in result_words_32
             .span() {
-                let word_bytes = (*word).to_be_bytes();
+                let word_bytes = (*word).to_be_bytes_padded();
                 result_bytes.append_span(word_bytes);
             };
 
@@ -91,6 +91,57 @@ mod tests {
 
         let result: u256 = result.from_be_bytes().unwrap();
         let expected_result = 0xc0b057f584795eff8b06d5e420e71d747587d20de836f501921fd1b5741f1283;
+
+        assert_eq!(result, expected_result);
+        assert_eq!(gas, 72);
+    }
+
+    #[test]
+    fn test_sha256_more_than_32_bytes() {
+        let calldata = [
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xf3,
+            0x45,
+            0x78,
+            0x90,
+            0x7f,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00
+        ];
+
+        let (gas, result) = Sha256::exec(calldata.span()).unwrap();
+
+        let result: u256 = result.from_be_bytes().unwrap();
+        let expected_result = 0x3b745a1c00d035c334f358d007a430e4cf0ae63aa0556fb05529706de546464d;
 
         assert_eq!(result, expected_result);
         assert_eq!(gas, 72);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes the sha256 output that wasnt converting each u32 chunk to word padded to 4-bytes
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/877)
<!-- Reviewable:end -->
