### PR TITLE
fix: warm up 0x0a precompile

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -30,6 +30,7 @@ pub mod KakarotCore {
         Transfer, Message, Environment, TransactionResult, TransactionResultTrait, ExecutionSummary,
         ExecutionSummaryTrait, Address, AddressTrait
     };
+    use evm::precompiles::eth_precompile_addresses;
     use evm::state::{State, StateTrait};
     use super::{INVOKE_ETH_CALL_FORBIDDEN};
     use utils::address::compute_contract_address;
@@ -327,7 +328,7 @@ pub mod KakarotCore {
             accessed_addresses.add(env.coinbase);
             accessed_addresses.add(to.evm);
             accessed_addresses.add(origin.evm);
-            accessed_addresses.extend(constants::precompile_addresses().spanset());
+            accessed_addresses.extend(eth_precompile_addresses().spanset());
 
             let mut accessed_storage_keys: Set<(EthAddress, u256)> = Default::default();
 

--- a/crates/evm/src/lib.cairo
+++ b/crates/evm/src/lib.cairo
@@ -24,7 +24,7 @@ mod memory;
 mod model;
 
 // instructions module
-mod precompiles;
+pub mod precompiles;
 
 // Stack module
 mod stack;

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -7,15 +7,15 @@ use core::num::traits::{CheckedAdd, CheckedSub, CheckedMul};
 use core::starknet::{EthAddress, get_contract_address, ContractAddress};
 use evm::errors::{EVMError, CONTRACT_SYSCALL_FAILED};
 use evm::model::account::{Account, AccountTrait};
+use evm::precompiles::{
+    FIRST_ROLLUP_PRECOMPILE_ADDRESS, FIRST_ETHEREUM_PRECOMPILE_ADDRESS,
+    LAST_ETHEREUM_PRECOMPILE_ADDRESS
+};
 use evm::state::State;
 use utils::fmt::{TSpanSetDebug};
 use utils::helpers::{ResultExTrait};
 use utils::set::{Set, SpanSet};
 use utils::traits::{EthAddressDefault, ContractAddressDefault, SpanDefault};
-
-const FIRST_ROLLUP_PRECOMPILE_ADDRESS: u256 = 0x100;
-const LAST_ETHEREUM_PRECOMPILE_ADDRESS: u256 = 0x0a;
-const ZERO: felt252 = 0x0;
 
 #[derive(Destruct, Default)]
 struct Environment {
@@ -143,9 +143,10 @@ impl AddressImpl of AddressTrait {
     /// Check whether an address for a call-family opcode is a precompile.
     fn is_precompile(self: EthAddress) -> bool {
         let self: felt252 = self.into();
-        return self != ZERO
-            && (self.into() <= LAST_ETHEREUM_PRECOMPILE_ADDRESS
-                || self.into() == FIRST_ROLLUP_PRECOMPILE_ADDRESS);
+        return self != 0x00
+            && (FIRST_ETHEREUM_PRECOMPILE_ADDRESS <= self.into()
+                && self.into() <= LAST_ETHEREUM_PRECOMPILE_ADDRESS)
+                || self.into() == FIRST_ROLLUP_PRECOMPILE_ADDRESS;
     }
 }
 

--- a/crates/evm/src/precompiles.cairo
+++ b/crates/evm/src/precompiles.cairo
@@ -7,7 +7,6 @@ mod modexp;
 mod p256verify;
 mod sha256;
 use core::starknet::EthAddress;
-
 use core::traits::Into;
 use evm::errors::EVMError;
 use evm::model::vm::VM;
@@ -18,6 +17,24 @@ use evm::precompiles::identity::Identity;
 use evm::precompiles::modexp::ModExp;
 use evm::precompiles::p256verify::P256Verify;
 use evm::precompiles::sha256::Sha256;
+
+use utils::set::{Set};
+
+
+pub const FIRST_ETHEREUM_PRECOMPILE_ADDRESS: u256 = 0x01;
+pub const LAST_ETHEREUM_PRECOMPILE_ADDRESS: u256 = 0x0a;
+pub const FIRST_ROLLUP_PRECOMPILE_ADDRESS: u256 = 0x100;
+
+pub fn eth_precompile_addresses() -> Set<EthAddress> {
+    let mut precompile_addresses: Array<EthAddress> = array![];
+    //TODO(2.8) use range operator
+    let mut i = FIRST_ETHEREUM_PRECOMPILE_ADDRESS;
+    while i <= LAST_ETHEREUM_PRECOMPILE_ADDRESS {
+        precompile_addresses.append(i.try_into().unwrap());
+        i = i + 1;
+    };
+    Set { inner: precompile_addresses }
+}
 
 
 trait Precompile {
@@ -90,5 +107,20 @@ impl PrecompilesImpl of Precompiles {
         vm.return_data = result;
         vm.stop();
         return Result::Ok(());
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::eth_precompile_addresses;
+
+    #[test]
+    fn test_eth_precompile_addresses() {
+        let addresses = eth_precompile_addresses();
+        assert_eq!(
+            addresses.inner.span(),
+            [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a].span()
+        );
     }
 }

--- a/crates/evm/src/precompiles.cairo
+++ b/crates/evm/src/precompiles.cairo
@@ -120,7 +120,18 @@ mod tests {
         let addresses = eth_precompile_addresses();
         assert_eq!(
             addresses.inner.span(),
-            [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a].span()
+            [
+                0x01.try_into().unwrap(),
+                0x02.try_into().unwrap(),
+                0x03.try_into().unwrap(),
+                0x04.try_into().unwrap(),
+                0x05.try_into().unwrap(),
+                0x06.try_into().unwrap(),
+                0x07.try_into().unwrap(),
+                0x08.try_into().unwrap(),
+                0x09.try_into().unwrap(),
+                0x0a.try_into().unwrap()
+            ].span()
         );
     }
 }

--- a/crates/utils/src/constants.cairo
+++ b/crates/utils/src/constants.cairo
@@ -1,6 +1,7 @@
 use core::starknet::EthAddress;
-use utils::set::{Set};
+use evm::precompiles::{FIRST_ETHEREUM_PRECOMPILE_ADDRESS, LAST_ETHEREUM_PRECOMPILE_ADDRESS};
 use utils::traits::{U8IntoEthAddress};
+
 // FELT PRIME
 // 2^251 + 17 * 2^192 + 1
 const FELT252_PRIME: u256 = 0x800000000000011000000000000000000000000000000000000000000000001;
@@ -36,21 +37,6 @@ const EMPTY_KECCAK: u256 = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bf
 
 const BURN_ADDRESS: felt252 = 0xdead;
 
-//PRECOMPILES
-pub fn precompile_addresses() -> Set<EthAddress> {
-    let inner: Array<EthAddress> = array![
-        0x01_u8.into(),
-        0x02_u8.into(),
-        0x03_u8.into(),
-        0x04_u8.into(),
-        0x05_u8.into(),
-        0x06_u8.into(),
-        0x07_u8.into(),
-        0x08_u8.into(),
-        0x09_u8.into()
-    ];
-    Set { inner }
-}
 
 // Numeric constants
 pub const POW_256_0: u128 = 0x1;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes warm up of precompiles by ensuring the full range of eth precompiles is always warmed up.
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/895)
<!-- Reviewable:end -->
