### PR TITLE
fix: returndata merged with child on call frame error

### DIFF
--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -99,7 +99,6 @@ impl CallHelpersImpl of CallHelpers {
         let result = EVMTrait::process_message(message, ref self.env);
         self.merge_child(@result);
 
-        self.return_data = result.return_data;
         if result.success {
             self.stack.push(1)?;
         } else {

--- a/crates/evm/src/model/vm.cairo
+++ b/crates/evm/src/model/vm.cairo
@@ -150,6 +150,7 @@ impl VMImpl of VMTrait {
             self.accessed_addresses.extend(*child.accessed_addresses);
             self.accessed_storage_keys.extend(*child.accessed_storage_keys);
             self.gas_refund += *child.gas_refund;
+            self.return_data = *child.return_data;
         }
         //TODO(gas) handle error case
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #896

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- We used to always merge the returndata of a child call frame with its parent frame. Now, we only do it when the child has had an execution success
- Needs to differentiate further between normal reverts (REVERT) and exceptional reverts with #897. Only in cases of exceptional reverts should this field NOT be merged with the parent's frame.
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
