### PR TITLE
feat: add code address in message

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -304,12 +304,12 @@ pub mod KakarotCore {
             };
 
             // Handle deploy/non-deploy transaction cases
-            let (to, is_deploy_tx, code, calldata) = match tx.destination() {
+            let (to, is_deploy_tx, code, code_address, calldata) = match tx.destination() {
                 Option::Some(to) => {
                     let target_starknet_address = self.compute_starknet_address(to);
                     let to = Address { evm: to, starknet: target_starknet_address };
                     let code = env.state.get_account(to.evm).code;
-                    (to, false, code, tx.calldata())
+                    (to, false, code, to, tx.calldata())
                 },
                 Option::None => {
                     // Deploy tx case.
@@ -319,7 +319,7 @@ pub mod KakarotCore {
                     let to = Address { evm: to_evm_address, starknet: to_starknet_address };
                     let code = tx.calldata();
                     let calldata = [].span();
-                    (to, true, code, calldata)
+                    (to, true, code, Zero::zero(), calldata)
                 },
             };
 
@@ -346,6 +346,7 @@ pub mod KakarotCore {
                 gas_limit: gas_left,
                 data: calldata,
                 code,
+                code_address: code_address,
                 value: tx.value(),
                 should_transfer_value: true,
                 depth: 0,

--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -73,7 +73,7 @@ impl CallHelpersImpl of CallHelpers {
         self.memory.load_n(args_size, ref calldata, args_offset);
 
         // We enter the standard flow
-        let code = self.env.state.get_account(code_address).code;
+        let code_account = self.env.state.get_account(code_address);
         let read_only = is_staticcall || self.message.read_only;
 
         let kakarot_core = KakarotCore::unsafe_new_contract_state();
@@ -87,7 +87,8 @@ impl CallHelpersImpl of CallHelpers {
             target: to,
             gas_limit: gas,
             data: calldata.span(),
-            code,
+            code: code_account.code,
+            code_address: code_account.address,
             value: value,
             should_transfer_value: should_transfer_value,
             depth: self.message().depth + 1,

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -4,6 +4,7 @@ use contracts::kakarot_core::interface::IKakarotCore;
 use core::cmp::min;
 use core::keccak::cairo_keccak;
 use core::num::traits::Bounded;
+use core::num::traits::Zero;
 use core::starknet::{EthAddress, get_tx_info};
 use evm::errors::{
     ensure, EVMError, CALL_GAS_GT_GAS_LIMIT, ACTIVE_MACHINE_STATE_IN_CALL_FINALIZATION
@@ -126,6 +127,7 @@ impl CreateHelpersImpl of CreateHelpers {
             gas_limit: create_message_gas,
             data: [].span(),
             code: create_args.bytecode,
+            code_address: Zero::zero(),
             value: create_args.value,
             should_transfer_value: true,
             depth: self.message().depth + 1,

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -765,7 +765,7 @@ mod tests {
     fn test_exec_call_code() {
         // Given
         // Set vm bytecode
-        // (call 0xffffff 0x100 0 0 0 0 1)
+        // (callcode 0xffffff 0x1234 0 0 0 0 1)
         let bytecode = [
             0x60,
             0x01,
@@ -780,8 +780,8 @@ mod tests {
             0x60,
             0x00,
             0x61,
-            0x01,
-            0x00,
+            0x12,
+            0x34,
             0x62,
             0xff,
             0xff,
@@ -801,7 +801,7 @@ mod tests {
         };
         vm.env.state.set_account(eoa_account);
 
-        // Deploy bytecode at 0x100
+        // Deploy bytecode at 0x1234
         // ret (+ 0x1 0x1)
         let deployed_bytecode = [
             0x60,
@@ -823,7 +823,7 @@ mod tests {
             0x00,
             0xf3
         ].span();
-        let eth_address: EthAddress = 0x100.try_into().unwrap();
+        let eth_address: EthAddress = 0x1234.try_into().unwrap();
         let starknet_address = compute_starknet_address(
             test_address(), eth_address, 0.try_into().unwrap()
         );
@@ -855,7 +855,7 @@ mod tests {
         // Given
 
         // Set vm bytecode
-        // (call 0xffffff 0x100 0 0 0 0 1)
+        // (delegatecall 0xffffff 0x1234 0 0 0 0 1)
         let bytecode = [
             0x60,
             0x01,
@@ -868,8 +868,8 @@ mod tests {
             0x60,
             0x00,
             0x61,
-            0x01,
-            0x00,
+            0x12,
+            0x34,
             0x62,
             0xff,
             0xff,
@@ -889,7 +889,7 @@ mod tests {
         };
         vm.env.state.set_account(eoa_account);
 
-        // Deploy bytecode at 0x100
+        // Deploy bytecode at 0x1234
         // ret (+ 0x1 0x1)
         let deployed_bytecode = [
             0x60,
@@ -911,7 +911,7 @@ mod tests {
             0x00,
             0xf3
         ].span();
-        let eth_address: EthAddress = 0x100.try_into().unwrap();
+        let eth_address: EthAddress = 0x1234.try_into().unwrap();
         let starknet_address = compute_starknet_address(
             test_address(), eth_address, 0.try_into().unwrap()
         );

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -146,7 +146,7 @@ impl EVMImpl of EVMTrait {
 
     fn execute_code(ref vm: VM) -> ExecutionResult {
         // Handle precompile logic
-        if vm.message.target.evm.is_precompile() {
+        if vm.message.code_address.evm.is_precompile() {
             let result = Precompiles::exec_precompile(ref vm);
 
             match result {

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -37,6 +37,7 @@ struct Message {
     gas_limit: u128,
     data: Span<u8>,
     code: Span<u8>,
+    code_address: Address,
     value: u256,
     should_transfer_value: bool,
     depth: usize,
@@ -130,6 +131,18 @@ struct Event {
 struct Address {
     evm: EthAddress,
     starknet: ContractAddress,
+}
+
+impl ZeroAddress of core::num::traits::Zero<Address> {
+    fn zero() -> Address {
+        Address { evm: Zero::zero(), starknet: Zero::zero(), }
+    }
+    fn is_zero(self: @Address) -> bool {
+        self.evm.is_zero() && self.starknet.is_zero()
+    }
+    fn is_non_zero(self: @Address) -> bool {
+        !self.is_zero()
+    }
 }
 
 #[generate_trait]

--- a/crates/evm/src/precompiles.cairo
+++ b/crates/evm/src/precompiles.cairo
@@ -28,7 +28,7 @@ trait Precompile {
 #[generate_trait]
 impl PrecompilesImpl of Precompiles {
     fn exec_precompile(ref vm: VM) -> Result<(), EVMError> {
-        let precompile_address = vm.message.target.evm;
+        let precompile_address = vm.message.code_address.evm;
         let input = vm.message().data;
 
         let (gas, result) = if precompile_address.address == 0x100 {

--- a/crates/evm/src/test_utils.cairo
+++ b/crates/evm/src/test_utils.cairo
@@ -227,6 +227,7 @@ fn preset_message() -> Message {
             test_address(), evm_address(), uninitialized_account()
         )
     };
+    let code_address = target;
     let read_only = false;
     let tx_gas_limit = tx_gas_limit();
 
@@ -238,6 +239,7 @@ fn preset_message() -> Message {
         gas_limit: tx_gas_limit,
         read_only,
         code,
+        code_address,
         should_transfer_value: true,
         depth: 0,
         accessed_addresses: Default::default(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #894

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds code_address in message struct
- Execution of precompiles is done by checking code_address, not target_address (as we can delegatecall to a precompile...)
- code_address is zero in case of deploy / create messages
- had to adapt tests for delegatecall / callcade that were calling 0x100 (RIP7212 reserved address) to another, non-conflicting address

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/901)
<!-- Reviewable:end -->
