### PR TITLE
feat: differentiate reverts from run exceptions

### DIFF
--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -396,7 +396,7 @@ pub mod KakarotCore {
             // };
 
             TransactionResult {
-                success: summary.success,
+                success: summary.is_success(),
                 return_data: summary.return_data,
                 gas_used: total_gas_used,
                 state: summary.state,

--- a/crates/contracts/tests/test_kakarot_core.cairo
+++ b/crates/contracts/tests/test_kakarot_core.cairo
@@ -322,7 +322,7 @@ fn test_process_transaction() {
     let return_data = result.return_data;
 
     // Then
-    assert!(result.success);
+    assert!(result.is_success());
     assert_eq!(return_data, u256_to_bytes_array(0).span());
 }
 

--- a/crates/contracts/tests/test_kakarot_core.cairo
+++ b/crates/contracts/tests/test_kakarot_core.cairo
@@ -322,7 +322,7 @@ fn test_process_transaction() {
     let return_data = result.return_data;
 
     // Then
-    assert!(result.is_success());
+    assert!(result.success);
     assert_eq!(return_data, u256_to_bytes_array(0).span());
 }
 

--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -10,7 +10,7 @@ use evm::interpreter::EVMTrait;
 use evm::memory::MemoryTrait;
 use evm::model::account::{AccountTrait};
 use evm::model::vm::{VM, VMTrait};
-use evm::model::{Transfer, Address, Message};
+use evm::model::{Transfer, Address, Message, ExecutionResultTrait};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
 use utils::constants;
@@ -99,7 +99,7 @@ impl CallHelpersImpl of CallHelpers {
         let result = EVMTrait::process_message(message, ref self.env);
         self.merge_child(@result);
 
-        if result.success {
+        if result.is_success() {
             self.stack.push(1)?;
         } else {
             self.stack.push(0)?;

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -13,7 +13,9 @@ use evm::interpreter::EVMTrait;
 use evm::memory::MemoryTrait;
 use evm::model::account::{Account, AccountTrait};
 use evm::model::vm::{VM, VMTrait};
-use evm::model::{ExecutionResult, ExecutionResultTrait, ExecutionSummary, Environment};
+use evm::model::{
+    ExecutionResult, ExecutionResultTrait, ExecutionResultStatus, ExecutionSummary, Environment
+};
 use evm::model::{Message, Address, Transfer};
 use evm::stack::StackTrait;
 use evm::state::StateTrait;
@@ -137,12 +139,19 @@ impl CreateHelpersImpl of CreateHelpers {
         let result = EVMTrait::process_create_message(child_message, ref self.env);
         self.merge_child(@result);
 
-        if result.success {
-            self.return_data = [].span();
-            self.stack.push(target_address.evm.into())?;
-        } else {
-            self.return_data = result.return_data;
-            self.stack.push(0)?;
+        match result.status {
+            ExecutionResultStatus::Success => {
+                self.return_data = [].span();
+                self.stack.push(target_address.evm.into())?;
+            },
+            ExecutionResultStatus::Revert => {
+                self.return_data = result.return_data;
+                self.stack.push(0)?;
+            },
+            ExecutionResultStatus::Exception => {
+                self.return_data = [].span();
+                self.stack.push(0)?;
+            },
         }
         Result::Ok(())
     }

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -149,6 +149,7 @@ impl CreateHelpersImpl of CreateHelpers {
                 self.stack.push(0)?;
             },
             ExecutionResultStatus::Exception => {
+                // returndata is emptied in case of exception
                 self.return_data = [].span();
                 self.stack.push(0)?;
             },

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -47,12 +47,19 @@ struct Message {
 
 #[derive(Drop, Debug)]
 struct ExecutionResult {
-    success: bool,
+    status: ExecutionResultStatus,
     return_data: Span<u8>,
     gas_left: u128,
     accessed_addresses: SpanSet<EthAddress>,
     accessed_storage_keys: SpanSet<(EthAddress, u256)>,
     gas_refund: u128,
+}
+
+#[derive(Copy, Drop, PartialEq, Debug)]
+enum ExecutionResultStatus {
+    Success,
+    Revert,
+    Exception,
 }
 
 #[generate_trait]
@@ -63,7 +70,7 @@ impl ExecutionResultImpl of ExecutionResultTrait {
         accessed_storage_keys: SpanSet<(EthAddress, u256)>
     ) -> ExecutionResult {
         ExecutionResult {
-            success: false,
+            status: ExecutionResultStatus::Exception,
             return_data: error,
             gas_left: 0,
             accessed_addresses,
@@ -79,11 +86,23 @@ impl ExecutionResultImpl of ExecutionResultTrait {
         self.gas_left = self.gas_left.checked_sub(value).ok_or(EVMError::OutOfGas)?;
         Result::Ok(())
     }
+
+    fn is_success(self: @ExecutionResult) -> bool {
+        *self.status == ExecutionResultStatus::Success
+    }
+
+    fn is_exception(self: @ExecutionResult) -> bool {
+        *self.status == ExecutionResultStatus::Exception
+    }
+
+    fn is_revert(self: @ExecutionResult) -> bool {
+        *self.status == ExecutionResultStatus::Revert
+    }
 }
 
 #[derive(Destruct)]
 struct ExecutionSummary {
-    success: bool,
+    status: ExecutionResultStatus,
     return_data: Span<u8>,
     gas_left: u128,
     state: State,
@@ -94,12 +113,24 @@ struct ExecutionSummary {
 impl ExecutionSummaryImpl of ExecutionSummaryTrait {
     fn exceptional_failure(error: Span<u8>) -> ExecutionSummary {
         ExecutionSummary {
-            success: false,
+            status: ExecutionResultStatus::Exception,
             return_data: error,
             gas_left: 0,
             state: Default::default(),
             gas_refund: 0
         }
+    }
+
+    fn is_success(self: @ExecutionSummary) -> bool {
+        *self.status == ExecutionResultStatus::Success
+    }
+
+    fn is_exception(self: @ExecutionSummary) -> bool {
+        *self.status == ExecutionResultStatus::Exception
+    }
+
+    fn is_revert(self: @ExecutionSummary) -> bool {
+        *self.status == ExecutionResultStatus::Revert
     }
 }
 

--- a/crates/evm/src/model/vm.cairo
+++ b/crates/evm/src/model/vm.cairo
@@ -154,6 +154,7 @@ impl VMImpl of VMTrait {
                 self.return_data = *child.return_data;
             },
             ExecutionResultStatus::Revert => { self.gas_left += *child.gas_left; },
+            // If the call has halted exceptionnaly, the gas is not returned.
             ExecutionResultStatus::Exception => {}
         };
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #897

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduces a new enum (success, revert, exception) to differentiate between execution statuses
- Exceptions are supposed to clear the returndata buffer and not reimburse gas left - unlike reverts

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->
