### PR TITLE
fix: copy opcodes slices overflows

### DIFF
--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -133,11 +133,10 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         self.charge_gas(gas::VERYLOW + copy_gas_cost + memory_expansion.expansion_cost)?;
 
         let calldata: Span<u8> = self.message().data;
-
-        let copied: Span<u8> = if (offset + size > calldata.len()) {
-            calldata.slice(offset, calldata.len() - offset)
+        let copied = if offset < calldata.len() {
+            calldata.slice(offset, core::cmp::min(size, calldata.len() - offset))
         } else {
-            calldata.slice(offset, size)
+            [].span()
         };
 
         self.memory.store_padded_segment(dest_offset, size, copied);
@@ -169,12 +168,11 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
 
         let bytecode: Span<u8> = self.message().code;
 
-        let copied: Span<u8> = if offset > bytecode.len() {
-            [].span()
-        } else if (offset + size > bytecode.len()) {
-            bytecode.slice(offset, bytecode.len() - offset)
+        let bytecode_len = bytecode.len();
+        let copied = if offset < bytecode_len {
+            bytecode.slice(offset, core::cmp::min(size, bytecode_len - offset))
         } else {
-            bytecode.slice(offset, size)
+            [].span()
         };
 
         self.memory.store_padded_segment(dest_offset, size, copied);
@@ -232,7 +230,7 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
         let bytecode = self.env.state.get_account(evm_address).code;
         let bytecode_len = bytecode.len();
         let bytecode_slice = if offset < bytecode_len {
-            bytecode.slice(offset, bytecode_len - offset)
+            bytecode.slice(offset, core::cmp::min(size, bytecode_len - offset))
         } else {
             [].span()
         };

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -297,7 +297,9 @@ impl EnvironmentInformationImpl of EnvironmentInformationTrait {
 }
 
 #[inline(always)]
-fn copy_bytes_to_memory(ref self: VM, bytes: Span<u8>, dest_offset: usize, offset: usize, size: usize) {
+fn copy_bytes_to_memory(
+    ref self: VM, bytes: Span<u8>, dest_offset: usize, offset: usize, size: usize
+) {
     let bytes_slice = if offset < bytes.len() {
         bytes.slice(offset, core::cmp::min(size, bytes.len() - offset))
     } else {
@@ -336,17 +338,13 @@ mod tests {
     const EMPTY_KECCAK: u256 = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
 
     mod test_internals {
-        use super::super::copy_bytes_to_memory;
         use evm::memory::MemoryTrait;
         use evm::model::vm::VMTrait;
         use evm::test_utils::VMBuilderTrait;
+        use super::super::copy_bytes_to_memory;
 
         fn test_copy_bytes_to_memory_helper(
-            bytes: Span<u8>,
-            dest_offset: usize,
-            offset: usize,
-            size: usize,
-            expected: Span<u8>
+            bytes: Span<u8>, dest_offset: usize, offset: usize, size: usize, expected: Span<u8>
         ) {
             // Given
             let mut vm = VMBuilderTrait::new_with_presets().build();
@@ -995,9 +993,7 @@ mod tests {
         expected_result: Result<Span<u8>, EVMError>
     ) {
         // Given
-        let mut vm = VMBuilderTrait::new_with_presets()
-            .with_return_data(return_data)
-            .build();
+        let mut vm = VMBuilderTrait::new_with_presets().with_return_data(return_data).build();
 
         vm.stack.push(size.into()).expect('push failed');
         vm.stack.push(offset.into()).expect('push failed');
@@ -1011,7 +1007,9 @@ mod tests {
             Result::Ok(expected) => {
                 assert!(res.is_ok());
                 let mut result = ArrayTrait::new();
-                vm.memory.load_n(size.try_into().unwrap(), ref result, dest_offset.try_into().unwrap());
+                vm
+                    .memory
+                    .load_n(size.try_into().unwrap(), ref result, dest_offset.try_into().unwrap());
                 assert_eq!(result.span(), expected);
             },
             Result::Err(expected_error) => {
@@ -1036,13 +1034,17 @@ mod tests {
     #[test]
     fn test_returndatacopy_out_of_bounds() {
         let return_data = array![1, 2, 3, 4, 5].span();
-        test_returndatacopy_helper(return_data, 0, 3, 3, Result::Err(EVMError::ReturnDataOutOfBounds));
+        test_returndatacopy_helper(
+            return_data, 0, 3, 3, Result::Err(EVMError::ReturnDataOutOfBounds)
+        );
     }
 
     #[test]
     fn test_returndatacopy_overflowing_add() {
         let return_data = array![1, 2, 3, 4, 5].span();
-        test_returndatacopy_helper(return_data, 0, 0xFFFFFFFF, 1, Result::Err(EVMError::ReturnDataOutOfBounds));
+        test_returndatacopy_helper(
+            return_data, 0, 0xFFFFFFFF, 1, Result::Err(EVMError::ReturnDataOutOfBounds)
+        );
     }
 
     // *************************************************************************


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes a bug where COPY opcodes would overflow/underflow in some combinations of size / offset / source_len
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/903)
<!-- Reviewable:end -->
