### PR TITLE
fix CREATE2 gas

### DIFF
--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -263,9 +263,6 @@ impl SystemOperations of SystemOperationsTrait {
     fn exec_create2(ref self: VM) -> Result<(), EVMError> {
         ensure(!self.message().read_only, EVMError::WriteInStaticContext)?;
 
-        // TODO: add dynamic gas costs
-        self.charge_gas(gas::CREATE)?;
-
         let create_args = self.prepare_create(CreateType::Create2)?;
         self.generic_create(create_args)
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes a double-charging of gas for CREATE2 (covered in prepare_create)
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/912)
<!-- Reviewable:end -->
