### PR TITLE
fix: memory expansions

### DIFF
--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -60,9 +60,9 @@ impl CreateHelpersImpl of CreateHelpers {
             CreateType::Create2 => {
                 let calldata_words = ceil32(size) / 32;
                 gas::CREATE
-                + gas::KECCAK256WORD * calldata_words.into()
-                + memory_expansion.expansion_cost
-                + init_code_gas
+                    + gas::KECCAK256WORD * calldata_words.into()
+                    + memory_expansion.expansion_cost
+                    + init_code_gas
             },
         };
         self.charge_gas(charged_gas)?;

--- a/crates/evm/src/create_helpers.cairo
+++ b/crates/evm/src/create_helpers.cairo
@@ -52,16 +52,17 @@ impl CreateHelpersImpl of CreateHelpers {
         let offset = self.stack.pop_usize()?;
         let size = self.stack.pop_usize()?;
 
-        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), [(offset, size)].span());
+        self.memory.ensure_length(memory_expansion.new_size);
         let init_code_gas = gas::init_code_cost(size);
         let charged_gas = match create_type {
             CreateType::Create => gas::CREATE + memory_expansion.expansion_cost + init_code_gas,
             CreateType::Create2 => {
                 let calldata_words = ceil32(size) / 32;
                 gas::CREATE
-                    + gas::KECCAK256WORD * calldata_words.into()
-                    + memory_expansion.expansion_cost
-                    + init_code_gas
+                + gas::KECCAK256WORD * calldata_words.into()
+                + memory_expansion.expansion_cost
+                + init_code_gas
             },
         };
         self.charge_gas(charged_gas)?;

--- a/crates/evm/src/gas.cairo
+++ b/crates/evm/src/gas.cairo
@@ -168,7 +168,9 @@ fn calculate_memory_gas_cost(size_in_bytes: usize) -> u128 {
 fn memory_expansion(current_size: usize, operations: Span<(usize, usize)>) -> MemoryExpansion {
     let mut max_size = current_size;
 
-    for (offset, size) in operations {
+    for (
+        offset, size
+    ) in operations {
         if *size != 0 {
             let end = *offset + *size;
             if end > max_size {

--- a/crates/evm/src/instructions/logging_operations.cairo
+++ b/crates/evm/src/instructions/logging_operations.cairo
@@ -197,7 +197,11 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
         vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
-        vm.memory.store_with_expansion(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
+        vm
+            .memory
+            .store_with_expansion(
+                0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20
+            );
 
         vm.stack.push(0x00).expect('push failed');
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
@@ -234,7 +238,11 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
         vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
-        vm.memory.store_with_expansion(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
+        vm
+            .memory
+            .store_with_expansion(
+                0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20
+            );
 
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
         vm.stack.push(0x00).expect('push failed');
@@ -364,7 +372,11 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
         vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
-        vm.memory.store_with_expansion(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
+        vm
+            .memory
+            .store_with_expansion(
+                0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20
+            );
 
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
         vm.stack.push(0x00).expect('push failed');

--- a/crates/evm/src/instructions/logging_operations.cairo
+++ b/crates/evm/src/instructions/logging_operations.cairo
@@ -98,7 +98,7 @@ mod tests {
     use evm::memory::MemoryTrait;
     use evm::stack::StackTrait;
     use evm::state::StateTrait;
-    use evm::test_utils::{VMBuilderTrait};
+    use evm::test_utils::{VMBuilderTrait, MemoryTestUtilsTrait};
     use utils::helpers::u256_to_bytes_array;
 
     #[test]
@@ -106,7 +106,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(0x1F).expect('push failed');
         vm.stack.push(0x00).expect('push failed');
@@ -134,7 +134,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(0x0123456789ABCDEF).expect('push failed');
         vm.stack.push(0x20).expect('push failed');
@@ -164,7 +164,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
         vm.stack.push(0x0123456789ABCDEF).expect('push failed');
@@ -196,8 +196,8 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
-        vm.memory.store(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
 
         vm.stack.push(0x00).expect('push failed');
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
@@ -233,8 +233,8 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
-        vm.memory.store(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
 
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
         vm.stack.push(0x00).expect('push failed');
@@ -270,7 +270,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new().with_read_only().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(0x0123456789ABCDEF).expect('push failed');
         vm.stack.push(0x20).expect('push failed');
@@ -291,7 +291,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(0x0123456789ABCDEF).expect('push failed');
         vm.stack.push(0x00).expect('push failed');
@@ -319,7 +319,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(0x0123456789ABCDEF).expect('push failed');
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
@@ -341,7 +341,7 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
 
         vm.stack.push(0x0123456789ABCDEF).expect('push failed');
         vm.stack.push(0x20).expect('push failed');
@@ -363,8 +363,8 @@ mod tests {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.memory.store(Bounded::<u256>::MAX, 0);
-        vm.memory.store(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
+        vm.memory.store_with_expansion(Bounded::<u256>::MAX, 0);
+        vm.memory.store_with_expansion(0x0123456789ABCDEF000000000000000000000000000000000000000000000000, 0x20);
 
         vm.stack.push(Bounded::<u256>::MAX).expect('push failed');
         vm.stack.push(0x00).expect('push failed');

--- a/crates/evm/src/instructions/logging_operations.cairo
+++ b/crates/evm/src/instructions/logging_operations.cairo
@@ -69,7 +69,8 @@ mod internal {
         let size = self.stack.pop_usize()?;
         let topics: Array<u256> = self.stack.pop_n(topics_len.into())?;
 
-        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), [(offset, size)].span());
+        self.memory.ensure_length(memory_expansion.new_size);
         self
             .charge_gas(
                 gas::LOG

--- a/crates/evm/src/instructions/sha3.cairo
+++ b/crates/evm/src/instructions/sha3.cairo
@@ -25,7 +25,8 @@ impl Sha3Impl of Sha3Trait {
 
         let words_size: u128 = (ceil32(size) / 32).into();
         let word_gas_cost = gas::KECCAK256WORD * words_size;
-        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), [(offset, size)].span());
+        self.memory.ensure_length(memory_expansion.new_size);
         self.charge_gas(gas::KECCAK256 + word_gas_cost + memory_expansion.expansion_cost)?;
 
         let mut to_hash: Array<u64> = Default::default();

--- a/crates/evm/src/instructions/sha3.cairo
+++ b/crates/evm/src/instructions/sha3.cairo
@@ -208,11 +208,8 @@ mod tests {
 
         // Then
         let result = vm.stack.peek().unwrap();
-        assert(
-            result == 0xc41589e7559804ea4a2080dad19d876a024ccb05117835447d72ce08c1d020ec,
-            'wrong result'
-        );
-        assert_eq!(vm.memory.size(), 32, 'wrong memory size');
+        assert_eq!(result, 0xc41589e7559804ea4a2080dad19d876a024ccb05117835447d72ce08c1d020ec);
+        assert_eq!(vm.memory.size(), 32);
     }
 
     #[test]

--- a/crates/evm/src/instructions/sha3.cairo
+++ b/crates/evm/src/instructions/sha3.cairo
@@ -169,7 +169,11 @@ mod tests {
         vm.stack.push(0x00).expect('push failed');
         vm.stack.push(0x00).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -193,7 +197,11 @@ mod tests {
         vm.stack.push(0x05).expect('push failed');
         vm.stack.push(0x04).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -215,7 +223,11 @@ mod tests {
         vm.stack.push(24).expect('push failed');
         vm.stack.push(10).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -234,7 +246,11 @@ mod tests {
         vm.stack.push(0xFFFFF).expect('push failed');
         vm.stack.push(1000).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -256,7 +272,11 @@ mod tests {
         vm.stack.push(1000000).expect('push failed');
         vm.stack.push(2).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -278,8 +298,16 @@ mod tests {
         vm.stack.push(1000000).expect('push failed');
         vm.stack.push(2).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -301,7 +329,11 @@ mod tests {
         vm.stack.push(1).expect('push failed');
         vm.stack.push(2048).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -323,7 +355,11 @@ mod tests {
         vm.stack.push(0).expect('push failed');
         vm.stack.push(1024).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -345,7 +381,11 @@ mod tests {
         vm.stack.push(32).expect('push failed');
         vm.stack.push(2016).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -367,7 +407,11 @@ mod tests {
         vm.stack.push(32).expect('push failed');
         vm.stack.push(0).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -389,7 +433,11 @@ mod tests {
         vm.stack.push(31).expect('push failed');
         vm.stack.push(0).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -411,7 +459,11 @@ mod tests {
         vm.stack.push(33).expect('push failed');
         vm.stack.push(0).expect('push failed');
 
-        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0
+            );
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -437,7 +489,9 @@ mod tests {
         while mem_dst <= 0x0C80 {
             vm
                 .memory
-                .store_with_expansion(0xFAFAFAFA00000000000000000000000000000000000000000000000000000000, mem_dst);
+                .store_with_expansion(
+                    0xFAFAFAFA00000000000000000000000000000000000000000000000000000000, mem_dst
+                );
             mem_dst += 0x20;
         };
 
@@ -459,7 +513,11 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
         let mut to_hash: Array<u64> = Default::default();
 
-        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0
+            );
         let mut size = 32;
         let mut offset = 0;
 
@@ -483,7 +541,11 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
         let mut to_hash: Array<u64> = Default::default();
 
-        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm
+            .memory
+            .store_with_expansion(
+                0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0
+            );
         let mut size = 33;
         let mut offset = 0;
 

--- a/crates/evm/src/instructions/sha3.cairo
+++ b/crates/evm/src/instructions/sha3.cairo
@@ -159,7 +159,7 @@ mod tests {
     use evm::instructions::sha3::internal;
     use evm::memory::{InternalMemoryTrait, MemoryTrait};
     use evm::stack::StackTrait;
-    use evm::test_utils::VMBuilderTrait;
+    use evm::test_utils::{VMBuilderTrait, MemoryTestUtilsTrait};
 
     #[test]
     fn test_exec_sha3_size_0_offset_0() {
@@ -169,7 +169,7 @@ mod tests {
         vm.stack.push(0x00).expect('push failed');
         vm.stack.push(0x00).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -186,14 +186,14 @@ mod tests {
 
 
     #[test]
-    fn test_exec_sha3_size_5_offset_4() {
+    fn test_exec_sha3_should_not_expand_memory() {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
         vm.stack.push(0x05).expect('push failed');
         vm.stack.push(0x04).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -204,29 +204,26 @@ mod tests {
             result == 0xc41589e7559804ea4a2080dad19d876a024ccb05117835447d72ce08c1d020ec,
             'wrong result'
         );
-        assert(vm.memory.size() == 64, 'wrong memory size');
+        assert_eq!(vm.memory.size(), 32, 'wrong memory size');
     }
 
     #[test]
-    fn test_exec_sha3_size_10_offset_10() {
+    fn test_exec_sha3_should_expand_memory() {
         // Given
         let mut vm = VMBuilderTrait::new_with_presets().build();
 
-        vm.stack.push(10).expect('push failed');
+        vm.stack.push(24).expect('push failed');
         vm.stack.push(10).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
 
         // Then
         let result = vm.stack.peek().unwrap();
-        assert(
-            result == 0x6bd2dd6bd408cbee33429358bf24fdc64612fbf8b1b4db604518f40ffd34b607,
-            'wrong result'
-        );
-        assert(vm.memory.size() == 64, 'wrong memory size');
+        assert_eq!(result, 0x827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd);
+        assert_eq!(vm.memory.size(), 64);
     }
 
     #[test]
@@ -237,7 +234,7 @@ mod tests {
         vm.stack.push(0xFFFFF).expect('push failed');
         vm.stack.push(1000).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -259,7 +256,7 @@ mod tests {
         vm.stack.push(1000000).expect('push failed');
         vm.stack.push(2).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -281,8 +278,8 @@ mod tests {
         vm.stack.push(1000000).expect('push failed');
         vm.stack.push(2).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -304,7 +301,7 @@ mod tests {
         vm.stack.push(1).expect('push failed');
         vm.stack.push(2048).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -326,7 +323,7 @@ mod tests {
         vm.stack.push(0).expect('push failed');
         vm.stack.push(1024).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -348,7 +345,7 @@ mod tests {
         vm.stack.push(32).expect('push failed');
         vm.stack.push(2016).expect('push failed');
 
-        vm.memory.store(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
+        vm.memory.store_with_expansion(0xFFFFFFFF00000000000000000000000000000000000000000000000000000000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -370,7 +367,7 @@ mod tests {
         vm.stack.push(32).expect('push failed');
         vm.stack.push(0).expect('push failed');
 
-        vm.memory.store(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -392,7 +389,7 @@ mod tests {
         vm.stack.push(31).expect('push failed');
         vm.stack.push(0).expect('push failed');
 
-        vm.memory.store(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -414,7 +411,7 @@ mod tests {
         vm.stack.push(33).expect('push failed');
         vm.stack.push(0).expect('push failed');
 
-        vm.memory.store(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
 
         // When
         vm.exec_sha3().expect('exec_sha3 failed');
@@ -440,7 +437,7 @@ mod tests {
         while mem_dst <= 0x0C80 {
             vm
                 .memory
-                .store(0xFAFAFAFA00000000000000000000000000000000000000000000000000000000, mem_dst);
+                .store_with_expansion(0xFAFAFAFA00000000000000000000000000000000000000000000000000000000, mem_dst);
             mem_dst += 0x20;
         };
 
@@ -462,7 +459,7 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
         let mut to_hash: Array<u64> = Default::default();
 
-        vm.memory.store(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
         let mut size = 32;
         let mut offset = 0;
 
@@ -486,7 +483,7 @@ mod tests {
         let mut vm = VMBuilderTrait::new_with_presets().build();
         let mut to_hash: Array<u64> = Default::default();
 
-        vm.memory.store(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
+        vm.memory.store_with_expansion(0xFAFFFFFF000000E500000077000000DEAD0000000004200000FADE0000450000, 0);
         let mut size = 33;
         let mut offset = 0;
 

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -38,19 +38,11 @@ impl SystemOperations of SystemOperationsTrait {
         let ret_offset = self.stack.pop_usize()?;
         let ret_size = self.stack.pop_usize()?;
 
-        let args_max_offset = args_offset + args_size;
-        let ret_max_offset = ret_offset + ret_size;
-
-        let max_memory_size = if args_max_offset > ret_max_offset {
-            args_max_offset
-        } else {
-            ret_max_offset
-        };
-
         // GAS
-        //TODO(optimization): if we know how much the memory is going to be expanded,
-        // we can return the new size and save a computation later.
-        let memory_expansion = gas::memory_expansion(self.memory.size(), max_memory_size);
+        let memory_expansion = gas::memory_expansion(
+            self.memory.size(), [(args_offset, args_size), (ret_offset, ret_size)].span()
+        );
+        self.memory.ensure_length(memory_expansion.new_size);
 
         let access_gas_cost = if self.accessed_addresses.contains(to) {
             gas::WARM_ACCESS_COST
@@ -139,7 +131,10 @@ impl SystemOperations of SystemOperationsTrait {
         // GAS
         //TODO(optimization): if we know how much the memory is going to be expanded,
         // we can return the new size and save a computation later.
-        let memory_expansion = gas::memory_expansion(self.memory.size(), max_memory_size);
+        let memory_expansion = gas::memory_expansion(
+            self.memory.size(), [(args_offset, args_size), (ret_offset, ret_size)].span()
+        );
+        self.memory.ensure_length(memory_expansion.new_size);
 
         let access_gas_cost = if self.accessed_addresses.contains(code_address) {
             gas::WARM_ACCESS_COST
@@ -193,7 +188,8 @@ impl SystemOperations of SystemOperationsTrait {
     fn exec_return(ref self: VM) -> Result<(), EVMError> {
         let offset = self.stack.pop_usize()?;
         let size = self.stack.pop_usize()?;
-        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), [(offset, size)].span());
+        self.memory.ensure_length(memory_expansion.new_size);
         self.charge_gas(gas::ZERO + memory_expansion.expansion_cost)?;
 
         let mut return_data = Default::default();
@@ -216,19 +212,13 @@ impl SystemOperations of SystemOperationsTrait {
         let ret_offset = self.stack.pop_usize()?;
         let ret_size = self.stack.pop_usize()?;
 
-        let args_max_offset = args_offset + args_size;
-        let ret_max_offset = ret_offset + ret_size;
-
-        let max_memory_size = if args_max_offset > ret_max_offset {
-            args_max_offset
-        } else {
-            ret_max_offset
-        };
-
         // GAS
         //TODO(optimization): if we know how much the memory is going to be expanded,
         // we can return the new size and save a computation later.
-        let memory_expansion = gas::memory_expansion(self.memory.size(), max_memory_size);
+        let memory_expansion = gas::memory_expansion(
+            self.memory.size(), [(args_offset, args_size), (ret_offset, ret_size)].span()
+        );
+        self.memory.ensure_length(memory_expansion.new_size);
 
         let access_gas_cost = if self.accessed_addresses.contains(code_address) {
             gas::WARM_ACCESS_COST
@@ -277,19 +267,13 @@ impl SystemOperations of SystemOperationsTrait {
         let ret_offset = self.stack.pop_usize()?;
         let ret_size = self.stack.pop_usize()?;
 
-        let args_max_offset = args_offset + args_size;
-        let ret_max_offset = ret_offset + ret_size;
-
-        let max_memory_size = if args_max_offset > ret_max_offset {
-            args_max_offset
-        } else {
-            ret_max_offset
-        };
-
         // GAS
         //TODO(optimization): if we know how much the memory is going to be expanded,
         // we can return the new size and save a computation later.
-        let memory_expansion = gas::memory_expansion(self.memory.size(), max_memory_size);
+        let memory_expansion = gas::memory_expansion(
+            self.memory.size(), [(args_offset, args_size), (ret_offset, ret_size)].span()
+        );
+        self.memory.ensure_length(memory_expansion.new_size);
 
         let access_gas_cost = if self.accessed_addresses.contains(to) {
             gas::WARM_ACCESS_COST
@@ -326,7 +310,8 @@ impl SystemOperations of SystemOperationsTrait {
         let offset = self.stack.pop_usize()?;
         let size = self.stack.pop_usize()?;
 
-        let memory_expansion = gas::memory_expansion(self.memory.size(), offset + size);
+        let memory_expansion = gas::memory_expansion(self.memory.size(), [(offset, size)].span());
+        self.memory.ensure_length(memory_expansion.new_size);
         self.charge_gas(memory_expansion.expansion_cost)?;
 
         let mut return_data = Default::default();

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -263,9 +263,6 @@ impl SystemOperations of SystemOperationsTrait {
     fn exec_create2(ref self: VM) -> Result<(), EVMError> {
         ensure(!self.message().read_only, EVMError::WriteInStaticContext)?;
 
-        // TODO: add dynamic gas costs
-        self.charge_gas(gas::CREATE)?;
-
         let create_args = self.prepare_create(CreateType::Create2)?;
         self.generic_create(create_args)
     }

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -244,13 +244,6 @@ impl EVMImpl of EVMTrait {
     }
 
     fn execute_opcode(ref self: VM, opcode: u8) -> Result<(), EVMError> {
-        println!(
-            "Address {:?}, opcode {:?}, pc {:?}, gas left in call {:?}",
-            self.message().code_address.evm,
-            opcode,
-            self.pc(),
-            self.gas_left()
-        );
         // Call the appropriate function based on the opcode.
         if opcode == 0 {
             // STOP

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -244,7 +244,13 @@ impl EVMImpl of EVMTrait {
     }
 
     fn execute_opcode(ref self: VM, opcode: u8) -> Result<(), EVMError> {
-        println!("Address {:?}, opcode {:?}, pc {:?}, gas left in call {:?}", self.message().code_address.evm, opcode, self.pc(), self.gas_left());
+        println!(
+            "Address {:?}, opcode {:?}, pc {:?}, gas left in call {:?}",
+            self.message().code_address.evm,
+            opcode,
+            self.pc(),
+            self.gas_left()
+        );
         // Call the appropriate function based on the opcode.
         if opcode == 0 {
             // STOP

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -244,6 +244,7 @@ impl EVMImpl of EVMTrait {
     }
 
     fn execute_opcode(ref self: VM, opcode: u8) -> Result<(), EVMError> {
+        println!("Address {:?}, opcode {:?}, pc {:?}, gas left in call {:?}", self.message().code_address.evm, opcode, self.pc(), self.gas_left());
         // Call the appropriate function based on the opcode.
         if opcode == 0 {
             // STOP

--- a/crates/evm/src/precompiles/ec_recover.cairo
+++ b/crates/evm/src/precompiles/ec_recover.cairo
@@ -80,7 +80,9 @@ mod tests {
     use evm::precompiles::ec_recover::EcRecover;
     use evm::stack::StackTrait;
     use evm::test_utils::setup_test_storages;
-    use evm::test_utils::{VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address};
+    use evm::test_utils::{
+        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address
+    };
     use snforge_std::{start_mock_call, test_address};
     use utils::helpers::{U256Trait, ToBytes, FromBytes};
 

--- a/crates/evm/src/precompiles/ec_recover.cairo
+++ b/crates/evm/src/precompiles/ec_recover.cairo
@@ -80,7 +80,7 @@ mod tests {
     use evm::precompiles::ec_recover::EcRecover;
     use evm::stack::StackTrait;
     use evm::test_utils::setup_test_storages;
-    use evm::test_utils::{VMBuilderTrait, native_token, other_starknet_address};
+    use evm::test_utils::{VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address};
     use snforge_std::{start_mock_call, test_address};
     use utils::helpers::{U256Trait, ToBytes, FromBytes};
 
@@ -122,7 +122,7 @@ mod tests {
             .store(
                 0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3, 0x0
             ); // msg_hash
-        vm.memory.store(0x1C, 0x20); // v
+        vm.memory.store_with_expansion(0x1C, 0x20); // v
         vm
             .memory
             .store(0x9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608, 0x40); // r

--- a/crates/evm/src/precompiles/identity.cairo
+++ b/crates/evm/src/precompiles/identity.cairo
@@ -32,7 +32,8 @@ mod tests {
     use evm::precompiles::identity::Identity;
     use evm::stack::StackTrait;
     use evm::test_utils::{
-        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address, setup_test_storages
+        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address,
+        setup_test_storages
     };
     use snforge_std::{start_mock_call, test_address};
 

--- a/crates/evm/src/precompiles/identity.cairo
+++ b/crates/evm/src/precompiles/identity.cairo
@@ -32,7 +32,7 @@ mod tests {
     use evm::precompiles::identity::Identity;
     use evm::stack::StackTrait;
     use evm::test_utils::{
-        VMBuilderTrait, native_token, other_starknet_address, setup_test_storages
+        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address, setup_test_storages
     };
     use snforge_std::{start_mock_call, test_address};
 
@@ -64,7 +64,7 @@ mod tests {
         vm.stack.push(0x4).unwrap(); // address
         vm.stack.push(0xFFFFFFFF).unwrap(); // gas
 
-        vm.memory.store(0x2A, 0x1F);
+        vm.memory.store_with_expansion(0x2A, 0x1F);
 
         start_mock_call::<u256>(native_token(), selector!("balanceOf"), 0);
         vm.exec_staticcall().unwrap();

--- a/crates/evm/src/precompiles/sha256.cairo
+++ b/crates/evm/src/precompiles/sha256.cairo
@@ -62,7 +62,7 @@ mod tests {
     use evm::precompiles::sha256::Sha256;
     use evm::stack::StackTrait;
     use evm::test_utils::{
-        VMBuilderTrait, native_token, other_starknet_address, setup_test_storages
+        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address, setup_test_storages
     };
     use snforge_std::{start_mock_call};
     use utils::helpers::ToBytes;
@@ -165,7 +165,7 @@ mod tests {
         vm.stack.push(0x2).unwrap(); // address
         vm.stack.push(0xFFFFFFFF).unwrap(); // gas
 
-        vm.memory.store(0xFF, 0x0);
+        vm.memory.store_with_expansion(0xFF, 0x0);
 
         start_mock_call::<u256>(native_token(), selector!("balanceOf"), 0);
         vm.exec_staticcall().unwrap();

--- a/crates/evm/src/precompiles/sha256.cairo
+++ b/crates/evm/src/precompiles/sha256.cairo
@@ -62,7 +62,8 @@ mod tests {
     use evm::precompiles::sha256::Sha256;
     use evm::stack::StackTrait;
     use evm::test_utils::{
-        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address, setup_test_storages
+        VMBuilderTrait, MemoryTestUtilsTrait, native_token, other_starknet_address,
+        setup_test_storages
     };
     use snforge_std::{start_mock_call};
     use utils::helpers::ToBytes;

--- a/crates/evm/src/test_utils.cairo
+++ b/crates/evm/src/test_utils.cairo
@@ -49,6 +49,19 @@ fn register_account(evm_address: EthAddress, starknet_address: ContractAddress) 
 }
 
 
+#[generate_trait]
+impl MemoryUtilsImpl of MemoryTestUtilsTrait {
+    fn store_with_expansion(ref self: Memory, element: u256, offset: usize) {
+        self.ensure_length(offset + 32);
+        self.store(element, offset);
+    }
+
+    fn store_n_with_expansion(ref self: Memory, elements: Span<u8>, offset: usize) {
+        self.ensure_length(offset + elements.len());
+        self.store_n(elements, offset);
+    }
+}
+
 #[derive(Destruct)]
 struct VMBuilder {
     vm: VM

--- a/scripts/gas_debug_call.py
+++ b/scripts/gas_debug_call.py
@@ -5,7 +5,9 @@ def process_logs(logs):
     gas_consumption = {}
     previous_gas = {}
 
-    pattern = re.compile(r"Address (\d+), opcode (\w+), pc (\d+), gas left in call (\d+)")
+    pattern = re.compile(
+        r"Address (\d+), opcode (\w+), pc (\d+), gas left in call (\d+)"
+    )
 
     for line in logs.split("\n"):
         match = pattern.search(line)
@@ -23,7 +25,9 @@ def process_logs(logs):
                 gas_consumption[address] += gas_used
                 previous_gas[address] = gas_left
 
-            print(f"{hex(address)} - {pc} - {opcode} --> total gas used: {gas_consumption[address]}")
+            print(
+                f"{hex(address)} - {pc} - {opcode} --> total gas used: {gas_consumption[address]}"
+            )
 
 
 # Example usage

--- a/scripts/gas_debug_call.py
+++ b/scripts/gas_debug_call.py
@@ -2,42 +2,33 @@ import re
 
 
 def process_logs(logs):
-    current_address = None
-    previous_gas = None
-    accumulated_gas = 0
+    gas_consumption = {}
+    previous_gas = {}
 
-    pattern = re.compile(r"Address (\d+), gas left in call (\d+)")
+    pattern = re.compile(r"Address (\d+), opcode (\w+), pc (\d+), gas left in call (\d+)")
 
     for line in logs.split("\n"):
         match = pattern.search(line)
         if match:
-            address, gas_left = match.groups()
+            address, opcode, pc, gas_left = match.groups()
+            address = int(address)
+            pc = int(pc)
             gas_left = int(gas_left)
 
-            if address != current_address:
-                if current_address is not None:
-                    print(
-                        f"Total gas used for {hex(int(current_address))}: {accumulated_gas}"
-                    )
-                current_address = address
-                previous_gas = gas_left
-                accumulated_gas = 0
+            if address not in gas_consumption:
+                gas_consumption[address] = 0
+                previous_gas[address] = gas_left
             else:
-                gas_used = previous_gas - gas_left
-                accumulated_gas += gas_used
-                print(
-                    f"Gas used in step for {hex(int(current_address))}: {gas_used} (Total: {accumulated_gas})"
-                )
-                previous_gas = gas_left
+                gas_used = previous_gas[address] - gas_left
+                gas_consumption[address] += gas_used
+                previous_gas[address] = gas_left
 
-    if current_address is not None:
-        print(f"Total gas used for {hex(int(current_address))}: {accumulated_gas}")
+            print(f"{hex(address)} - {pc} - {opcode} --> total gas used: {gas_consumption[address]}")
 
 
 # Example usage
 logs = """
-Address 1169201309864722334562947866173026415724746034380, gas left in call 79978528
-Address 1169201309864722334562947866173026415724746034380, gas left in call 79978525
+Address 1169201309864722334562947866173026415724746034380, opcode 96, pc 1, gas left in call 79978644
 """
 
 process_logs(logs)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #910
Resolves: #911

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes a bug where memory expansion was not always applied properly, as the max memory offset written could be different from the max theoritical memory offset passed in calls.
- As memory is always resized prior to calls / operations, removed length checks & expansions in the memory trait
- Fixes a bug where memory expansion was computed based on the max offset, even if the associated size written was zero.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/913)
<!-- Reviewable:end -->
