### PR TITLE
fix: saturate gas taken from stack

### DIFF
--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -30,7 +30,7 @@ impl SystemOperations of SystemOperationsTrait {
     /// CALL
     /// # Specification: https://www.evm.codes/#f1?fork=shanghai
     fn exec_call(ref self: VM) -> Result<(), EVMError> {
-        let gas = self.stack.pop_u128()?;
+        let gas = self.stack.pop_saturating_u128()?;
         let to = self.stack.pop_eth_address()?;
         let value = self.stack.pop()?;
         let args_offset = self.stack.pop_usize()?;
@@ -117,7 +117,7 @@ impl SystemOperations of SystemOperationsTrait {
     /// CALLCODE
     /// # Specification: https://www.evm.codes/#f2?fork=shanghai
     fn exec_callcode(ref self: VM) -> Result<(), EVMError> {
-        let gas = self.stack.pop_u128()?;
+        let gas = self.stack.pop_saturating_u128()?;
         let code_address = self.stack.pop_eth_address()?;
         let value = self.stack.pop()?;
         let args_offset = self.stack.pop_usize()?;
@@ -209,7 +209,7 @@ impl SystemOperations of SystemOperationsTrait {
     /// DELEGATECALL
     /// # Specification: https://www.evm.codes/#f4?fork=shanghai
     fn exec_delegatecall(ref self: VM) -> Result<(), EVMError> {
-        let gas = self.stack.pop_u128()?;
+        let gas = self.stack.pop_saturating_u128()?;
         let code_address = self.stack.pop_eth_address()?;
         let args_offset = self.stack.pop_usize()?;
         let args_size = self.stack.pop_usize()?;
@@ -273,7 +273,7 @@ impl SystemOperations of SystemOperationsTrait {
     /// STATICCALL
     /// # Specification: https://www.evm.codes/#fa?fork=shanghai
     fn exec_staticcall(ref self: VM) -> Result<(), EVMError> {
-        let gas = self.stack.pop_u128()?;
+        let gas = self.stack.pop_saturating_u128()?;
         let to = self.stack.pop_eth_address()?;
         let args_offset = self.stack.pop_usize()?;
         let args_size = self.stack.pop_usize()?;

--- a/crates/evm/src/stack.cairo
+++ b/crates/evm/src/stack.cairo
@@ -1,7 +1,7 @@
 use core::fmt::{Debug, Formatter, Error, Display};
 use core::nullable::{NullableTrait};
-use core::starknet::{StorageBaseAddress, EthAddress};
 use core::num::traits::Bounded;
+use core::starknet::{StorageBaseAddress, EthAddress};
 //! Stack implementation.
 //! # Example
 //! ```
@@ -339,11 +339,11 @@ mod tests {
     }
 
     mod pop {
+        use core::num::traits::Bounded;
         use core::starknet::storage_base_address_const;
         use evm::errors::{EVMError, TYPE_CONVERSION_ERROR};
         use super::StackTrait;
         use utils::traits::StorageBaseAddressPartialEq;
-        use core::num::traits::Bounded;
 
         #[test]
         fn test_should_pop_an_element_from_the_stack() {

--- a/crates/evm/src/stack.cairo
+++ b/crates/evm/src/stack.cairo
@@ -376,7 +376,7 @@ mod tests {
             // Then
             assert_eq!(stack.len(), 0);
             assert_eq!(elements.len(), 3);
-            assert_eq!(elements.span(), [1, 2, 3].span())
+            assert_eq!(elements.span(), [3, 2, 1].span())
         }
 
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #914

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Saturates the gas taken from the stack to MAX_U128 so that, if the gas is passed with a very big value, the execution doesn't throw an error here. The actual gas passed to the call will depend on the min(gas_left, gas_param), and since gas_left is a u128, it's safe to saturate 
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/915)
<!-- Reviewable:end -->
