### PR TITLE
fix: out-of-bounds read on push instructions

### DIFF
--- a/crates/evm/src/instructions/push_operations.cairo
+++ b/crates/evm/src/instructions/push_operations.cairo
@@ -15,7 +15,11 @@ fn exec_push_i(ref self: VM, i: u8) -> Result<(), EVMError> {
 
     self.set_pc(self.pc() + i);
 
-    self.stack.push(load_word(i, data))
+    if data.len() == 0 {
+        self.stack.push(0)
+    } else {
+        self.stack.push(load_word(i, data))
+    }
 }
 
 #[generate_trait]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes an issue where, if we did a `push_i` instruction, we might try to get a slice of bytecode that is out of bounds.
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/947)
<!-- Reviewable:end -->
