### PR TITLE
fix: returndata buffer emptied on stop

### DIFF
--- a/crates/evm/src/backend/validation.cairo
+++ b/crates/evm/src/backend/validation.cairo
@@ -1,4 +1,3 @@
-use contracts::IKakarotCore;
 use contracts::account_contract::{IAccountDispatcher, IAccountDispatcherTrait};
 use contracts::kakarot_core::KakarotCore;
 use core::ops::SnapshotDeref;
@@ -78,7 +77,7 @@ mod tests {
     use utils::constants::BLOCK_GAS_LIMIT;
     use utils::eth_transaction::common::TxKind;
     use utils::eth_transaction::eip1559::TxEip1559;
-    use utils::eth_transaction::transaction::{Transaction, TransactionTrait};
+    use utils::eth_transaction::transaction::Transaction;
 
     fn set_up() -> KakarotCore::ContractState {
         // Define the addresses used in the tests, whose calls will be mocked

--- a/crates/evm/src/call_helpers.cairo
+++ b/crates/evm/src/call_helpers.cairo
@@ -107,9 +107,11 @@ pub impl CallHelpersImpl of CallHelpers {
                 self.stack.push(0)?;
             },
             ExecutionResultStatus::Exception => {
-                // If the call has halted exceptionnaly, the return_data is emptied.
+                // If the call has halted exceptionnaly,
+                // the return_data is emptied, and nothing is stored in memory
                 self.return_data = [].span();
                 self.stack.push(0)?;
+                return Result::Ok(());
             },
         }
 

--- a/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
+++ b/crates/evm/src/instructions/stop_and_arithmetic_operations.cairo
@@ -15,10 +15,10 @@ pub impl StopAndArithmeticOperations of StopAndArithmeticOperationsTrait {
     /// Halts the execution of the current program.
     /// # Specification: https://www.evm.codes/#00?fork=shanghai
     fn exec_stop(ref self: VM) {
-        // return_data stored the return_data for the last executed sub context
-        // see CALLs opcodes. When we run the STOP opcode, we stop the current
+        // return_data store the return_data for the last executed sub context
+        // see CALLs opcodes. When it runs the STOP opcode, it stops the current
         // execution context with *no* return data (unlike RETURN and REVERT).
-        // hence we just clear the return_data and stop.
+        // hence it just clear the return_data and stop.
         self.return_data = [].span();
         self.stop();
     }

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -541,7 +541,7 @@ mod tests {
     }
 
     #[test]
-    fn test_exec_staticcall() {
+    fn test_should_fail_exec_staticcall() {
         // Given
 
         // Set vm bytecode

--- a/crates/evm/src/instructions/system_operations.cairo
+++ b/crates/evm/src/instructions/system_operations.cairo
@@ -493,13 +493,11 @@ mod tests {
         vm.env.state.set_account(caller_account);
 
         // Deploy bytecode at 0xabfa740ccd
-        // (+ 0x1 0x1)
+        // SSTORE 0x42 at 0x42
         let eth_address: EthAddress = 0xabfa740ccd_u256.into();
         let starknet_address = compute_starknet_address(
             test_address(), eth_address, 0.try_into().unwrap()
         );
-        // Deploy bytecode at 0x1234
-        // SSTORE 0x42 at 0x42
         let deployed_bytecode = [
             0x60,
             0x01,
@@ -547,7 +545,7 @@ mod tests {
         // Given
 
         // Set vm bytecode
-        // (call 0xffffff 0xabfa740ccd 0 0 0 0 1)
+        // (staticcall 0xffffff 0xabfa740ccd 0 0 0 0 1)
         let bytecode = [
             0x60,
             0x01,
@@ -586,12 +584,12 @@ mod tests {
         };
         vm.env.state.set_account(caller_account);
 
+        // Deploy bytecode at 0xabfa740ccd
+        // SSTORE 0x42 at 0x42
         let eth_address: EthAddress = 0xabfa740ccd_u256.into();
         let starknet_address = compute_starknet_address(
             test_address(), eth_address, 0.try_into().unwrap()
         );
-        // Deploy bytecode at 0x1234
-        // SSTORE 0x42 at 0x42
         let deployed_bytecode = [
             0x60,
             0x01,

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -304,8 +304,13 @@ pub impl EVMImpl of EVMTrait {
         let pc = vm.pc();
         let bytecode = vm.message().code;
 
-        // Check if PC is not out of bounds.
-        if pc >= bytecode.len() || vm.is_running() == false {
+        // If PC is out of bounds, stop the VM
+        // Also empties the returndata - akin to executing the STOP opcode.
+        if pc >= bytecode.len() {
+            vm.exec_stop();
+        }
+
+        if !vm.is_running() {
             // REVERT opcode case
             if vm.is_error() {
                 return ExecutionResult {
@@ -372,7 +377,7 @@ pub impl EVMImpl of EVMTrait {
         // Call the appropriate function based on the opcode.
         if opcode == 0x00 {
             // STOP
-            return self.exec_stop();
+            return Result::Ok(self.exec_stop());
         }
         if opcode == 0x01 {
             // ADD

--- a/crates/utils/src/eth_transaction.cairo
+++ b/crates/utils/src/eth_transaction.cairo
@@ -5,7 +5,7 @@ pub mod legacy;
 pub mod transaction;
 pub mod tx_type;
 use core::cmp::min;
-use core::num::traits::{CheckedAdd, Zero};
+use core::num::traits::CheckedAdd;
 use core::option::OptionTrait;
 use core::starknet::{EthAddress, secp256_trait::Signature,};
 use utils::errors::{EthTransactionError, RLPErrorImpl};


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes an issue where the returndata buffer was not correctly emptied on stop.
- Fixes an issue where the returndata was copied in memory for exceptional halts.
- Adapted the CALL opcodes tests accordingly - no longer checking returndata, but rather checking the context in which an SSTORE was executed...

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/948)
<!-- Reviewable:end -->
