### PR TITLE
fix: storage commitment on selfdestruct accounts

### DIFF
--- a/crates/evm/src/backend/starknet_backend.cairo
+++ b/crates/evm/src/backend/starknet_backend.cairo
@@ -249,20 +249,20 @@ mod tests {
     use evm::model::Address;
     use evm::model::account::Account;
     use evm::state::{State, StateTrait};
-    use evm::test_utils::{evm_address};
     use evm::test_utils::{
         setup_test_environment, uninitialized_account, account_contract, register_account
     };
+    use evm::test_utils::{evm_address};
     use snforge_std::{test_address, start_mock_call, get_class_hash};
     use snforge_utils::snforge_utils::{assert_not_called, assert_called};
+    use super::commit_storage;
     use utils::helpers::U8SpanExTrait;
     use utils::helpers::compute_starknet_address;
-    use super::commit_storage;
 
     // Helper function to create a test account
     fn create_test_account(is_selfdestruct: bool, is_created: bool, id: felt252) -> Account {
         let evm_address = (evm_address().into() + id).try_into().unwrap();
-        let starknet_address = (0x5678 + id ).try_into().unwrap();
+        let starknet_address = (0x5678 + id).try_into().unwrap();
         Account {
             address: Address { evm: evm_address, starknet: starknet_address },
             nonce: 0,
@@ -275,9 +275,9 @@ mod tests {
     }
 
     mod test_commit_storage {
-        use super::{create_test_account, StateTrait, commit_storage};
         use snforge_std::start_mock_call;
         use snforge_utils::snforge_utils::{assert_called_with, assert_not_called};
+        use super::{create_test_account, StateTrait, commit_storage};
 
         #[test]
         fn test_commit_storage_normal_case() {
@@ -295,7 +295,9 @@ mod tests {
             commit_storage(ref state).expect('commit storage failed');
 
             //TODO(starknet-foundry): verify call args in assert_called
-            assert_called_with::<(u256, u256)>(account.address.starknet, selector!("write_storage"), (key, value));
+            assert_called_with::<
+                (u256, u256)
+            >(account.address.starknet, selector!("write_storage"), (key, value));
         }
 
         #[test]
@@ -333,7 +335,9 @@ mod tests {
             commit_storage(ref state).expect('commit storage failed');
 
             // Assert that write_storage was called
-            assert_called_with::<(u256, u256)>(account.address.starknet, selector!("write_storage"), (key, value));
+            assert_called_with::<
+                (u256, u256)
+            >(account.address.starknet, selector!("write_storage"), (key, value));
         }
 
         #[test]
@@ -367,9 +371,13 @@ mod tests {
             commit_storage(ref state).expect('commit storage failed');
 
             // Assert that write_storage was called for accounts 1 and 3, but not for account 2
-            assert_called_with::<(u256, u256)>(account0.address.starknet, selector!("write_storage"), (key, value));
+            assert_called_with::<
+                (u256, u256)
+            >(account0.address.starknet, selector!("write_storage"), (key, value));
             assert_not_called(account1.address.starknet, selector!("write_storage"));
-            assert_called_with::<(u256, u256)>(account2.address.starknet, selector!("write_storage"), (key, value));
+            assert_called_with::<
+                (u256, u256)
+            >(account2.address.starknet, selector!("write_storage"), (key, value));
         }
     }
 

--- a/crates/snforge_utils/src/contracts.cairo
+++ b/crates/snforge_utils/src/contracts.cairo
@@ -35,7 +35,7 @@ mod tests {
         IHelloDispatcher { contract_address: hellocontract }.hello();
 
         assert_called(hellocontract, selector!("hello"));
-        assert_called_with(hellocontract, selector!("hello"), [].span());
+        assert_called_with::<()>(hellocontract, selector!("hello"), ());
     }
 
     #[test]
@@ -46,6 +46,6 @@ mod tests {
         IHelloDispatcher { contract_address: hellocontract }.bar();
 
         assert_called(hellocontract, selector!("hello"));
-        assert_called_with(hellocontract, selector!("hello"), [].span());
+        assert_called_with::<()>(hellocontract, selector!("hello"), ());
     }
 }

--- a/crates/snforge_utils/src/lib.cairo
+++ b/crates/snforge_utils/src/lib.cairo
@@ -64,11 +64,13 @@ pub mod snforge_utils {
         }
     }
 
-    pub fn assert_called_with(
-        contract_address: ContractAddress, selector: felt252, calldata: Span<felt252>
+    pub fn assert_called_with<C, +Serde<C>, +Drop<C>, +Copy<C>>(
+        contract_address: ContractAddress, selector: felt252, calldata: C
     ) {
+        let mut serialized_calldata = array![];
+        Serde::serialize(@calldata, ref serialized_calldata);
         assert!(
-            is_called_with(contract_address, selector, calldata),
+            is_called_with(contract_address, selector, serialized_calldata.span()),
             "Expected call with specific data not found in trace"
         );
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple
pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves: #

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes an issue where, because account storage and account commitments are separate, we were skipping storage commits in case an account was SELFDESTRUCT instead of SELFDESTRUCT **and** created in the same tx.
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and
migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/953)
<!-- Reviewable:end -->
