### PR TITLE
fix: origin nonce used in deploy tx & available balance in tx

### DIFF
--- a/crates/evm/src/backend/starknet_backend.cairo
+++ b/crates/evm/src/backend/starknet_backend.cairo
@@ -71,7 +71,7 @@ pub fn get_bytecode(evm_address: EthAddress) -> Span<u8> {
 }
 
 /// Populate an Environment with Starknet syscalls.
-pub fn get_env(origin: EthAddress, gas_price: u128) -> Environment {
+pub fn get_env(origin: Address, gas_price: u128) -> Environment {
     let kakarot_state = KakarotCore::unsafe_new_contract_state();
     let kakarot_storage = kakarot_state.snapshot_deref();
     let block_info = get_block_info().unbox();

--- a/crates/evm/src/instructions/environmental_information.cairo
+++ b/crates/evm/src/instructions/environmental_information.cairo
@@ -46,7 +46,7 @@ pub impl EnvironmentInformationImpl of EnvironmentInformationTrait {
     /// # Specification: https://www.evm.codes/#32?fork=shanghai
     fn exec_origin(ref self: VM) -> Result<(), EVMError> {
         self.charge_gas(gas::BASE)?;
-        self.stack.push(self.env.origin.into())
+        self.stack.push(self.env.origin.evm.into())
     }
 
     /// 0x33 - CALLER
@@ -448,7 +448,7 @@ mod tests {
 
         // Then
         assert_eq!(vm.stack.len(), 1);
-        assert_eq!(vm.stack.peek().unwrap(), origin().into());
+        assert_eq!(vm.stack.peek().unwrap(), vm.env.origin.evm.into());
     }
 
 

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -104,7 +104,6 @@ pub impl MemoryOperation of MemoryOperationTrait {
     fn exec_sstore(ref self: VM) -> Result<(), EVMError> {
         let key = self.stack.pop()?;
         let new_value = self.stack.pop()?;
-        println!("key: {}, new_value: {}", key, new_value);
         ensure(self.gas_left() > gas::CALL_STIPEND, EVMError::OutOfGas)?; // EIP-1706
 
         let evm_address = self.message().target.evm;

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -104,6 +104,7 @@ pub impl MemoryOperation of MemoryOperationTrait {
     fn exec_sstore(ref self: VM) -> Result<(), EVMError> {
         let key = self.stack.pop()?;
         let new_value = self.stack.pop()?;
+        println!("key: {}, new_value: {}", key, new_value);
         ensure(self.gas_left() > gas::CALL_STIPEND, EVMError::OutOfGas)?; // EIP-1706
 
         let evm_address = self.message().target.evm;

--- a/crates/evm/src/interpreter.cairo
+++ b/crates/evm/src/interpreter.cairo
@@ -108,8 +108,9 @@ pub impl EVMImpl of EVMTrait {
 
         let (message, is_deploy_tx) = {
             let mut sender_account = env.state.get_account(origin.evm);
-            // Charge the intrinsic gas to the sender so that it's not available for the execution of the transaction
-            // but don't trigger any actual transfer, as only the actual consumde gas is charged at the end of the transaction
+            // Charge the intrinsic gas to the sender so that it's not available for the execution
+            // of the transaction but don't trigger any actual transfer, as only the actual consumde
+            // gas is charged at the end of the transaction
             sender_account.set_balance(sender_account.balance() - max_fee.into());
 
             let (message, is_deploy_tx) = self
@@ -123,7 +124,6 @@ pub impl EVMImpl of EVMTrait {
         };
 
         let mut summary = Self::process_message_call(message, env, is_deploy_tx);
-
 
         // Cancel the max_fee that was taken from the sender to prevent double charging
         let mut sender_account = summary.state.get_account(origin.evm);
@@ -406,7 +406,6 @@ pub impl EVMImpl of EVMTrait {
     }
 
     fn execute_opcode(ref self: VM, opcode: u8) -> Result<(), EVMError> {
-        println!("Address {:?}, opcode {:?}, pc {:?}, gas left in call {:?}", self.message().code_address.evm, opcode, self.pc(), self.gas_left());
         // Call the appropriate function based on the opcode.
         if opcode == 0x00 {
             // STOP

--- a/crates/evm/src/model.cairo
+++ b/crates/evm/src/model.cairo
@@ -17,7 +17,7 @@ use utils::traits::{EthAddressDefault, ContractAddressDefault, SpanDefault};
 
 #[derive(Destruct, Default)]
 pub struct Environment {
-    pub origin: EthAddress,
+    pub origin: Address,
     pub gas_price: u128,
     pub chain_id: u64,
     pub prevrandao: u256,

--- a/crates/evm/src/model/account.cairo
+++ b/crates/evm/src/model/account.cairo
@@ -163,6 +163,11 @@ pub impl AccountImpl of AccountTrait {
     }
 
     #[inline(always)]
+    fn set_balance(ref self: Account, value: u256) {
+        self.balance = value;
+    }
+
+    #[inline(always)]
     fn address(self: @Account) -> Address {
         *self.address
     }
@@ -265,14 +270,6 @@ pub impl AccountImpl of AccountTrait {
             i += 1;
         };
         jumpdests
-    }
-}
-
-#[generate_trait]
-pub(crate) impl AccountInternals of AccountInternalTrait {
-    #[inline(always)]
-    fn set_balance(ref self: Account, value: u256) {
-        self.balance = value;
     }
 }
 

--- a/crates/evm/src/state.cairo
+++ b/crates/evm/src/state.cairo
@@ -8,7 +8,7 @@ use core::starknet::{EthAddress};
 use evm::backend::starknet_backend::fetch_original_storage;
 
 use evm::errors::{ensure, EVMError, BALANCE_OVERFLOW};
-use evm::model::account::{AccountTrait, AccountInternalTrait};
+use evm::model::account::{AccountTrait};
 use evm::model::{Event, Transfer, Account};
 use utils::set::{Set, SetTrait};
 

--- a/crates/evm/src/test_utils.cairo
+++ b/crates/evm/src/test_utils.cairo
@@ -131,7 +131,7 @@ pub fn origin() -> EthAddress {
     'origin'.try_into().unwrap()
 }
 
-pub fn dual_origin() -> Address{
+pub fn dual_origin() -> Address {
     let origin_evm = origin();
     let origin_starknet = utils::helpers::compute_starknet_address(
         test_address(), origin_evm, uninitialized_account()

--- a/crates/evm/src/test_utils.cairo
+++ b/crates/evm/src/test_utils.cairo
@@ -131,6 +131,14 @@ pub fn origin() -> EthAddress {
     'origin'.try_into().unwrap()
 }
 
+pub fn dual_origin() -> Address{
+    let origin_evm = origin();
+    let origin_starknet = utils::helpers::compute_starknet_address(
+        test_address(), origin_evm, uninitialized_account()
+    );
+    Address { evm: origin_evm, starknet: origin_starknet }
+}
+
 pub fn caller() -> EthAddress {
     'caller'.try_into().unwrap()
 }
@@ -253,8 +261,9 @@ pub fn preset_message() -> Message {
 
 pub fn preset_environment() -> Environment {
     let block_info = starknet::get_block_info().unbox();
+
     Environment {
-        origin: origin(),
+        origin: dual_origin(),
         gas_price: gas_price(),
         chain_id: chain_id(),
         prevrandao: 0,


### PR DESCRIPTION
- Fixes an issue where the nonce used was incremented before computing the target address in deploy transactions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/957)
<!-- Reviewable:end -->
