### PR TITLE
fix: ec_recover when point at infinity

### DIFF
--- a/crates/evm/src/precompiles/ec_recover.cairo
+++ b/crates/evm/src/precompiles/ec_recover.cairo
@@ -6,8 +6,8 @@ use core::traits::Into;
 use evm::errors::EVMError;
 use evm::precompiles::Precompile;
 use utils::helpers::{ToBytes, FromBytes};
-use utils::traits::BoolIntoNumeric;
 use utils::traits::EthAddressIntoU256;
+use utils::traits::{NumericIntoBool, BoolIntoNumeric};
 
 const EC_RECOVER_PRECOMPILE_GAS_COST: u64 = 3000;
 
@@ -30,11 +30,10 @@ pub impl EcRecover of Precompile {
         let y_parity = match v {
             Option::Some(v) => {
                 let y_parity = v - 27;
-                if (y_parity == 0 || y_parity == 1) {
-                    y_parity == 1
-                } else {
+                if (y_parity != 0 && y_parity != 1) {
                     return Result::Ok((gas, [].span()));
                 }
+                y_parity.into()
             },
             Option::None => { return Result::Ok((gas, [].span())); }
         };

--- a/crates/utils/src/traits.cairo
+++ b/crates/utils/src/traits.cairo
@@ -45,6 +45,13 @@ pub impl BoolIntoNumeric<T, +Zero<T>, +One<T>> of Into<bool, T> {
     }
 }
 
+pub impl NumericIntoBool<T, +Drop<T>, +Zero<T>, +One<T>, +PartialEq<T>> of Into<T, bool> {
+    #[inline(always)]
+    fn into(self: T) -> bool {
+        self != Zero::<T>::zero()
+    }
+}
+
 pub impl EthAddressIntoU256 of Into<EthAddress, u256> {
     fn into(self: EthAddress) -> u256 {
         let intermediate: felt252 = self.into();


### PR DESCRIPTION
Fixes the y_parity value in ec_recover and handling of point at infinity

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/958)
<!-- Reviewable:end -->
