### PR TITLE
dev: bump versions with test speedups

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.8.2
-starknet-foundry 0.30.0
+scarb 2.8.3
+starknet-foundry 0.31.0


### PR DESCRIPTION
Decreases testing time by a huge margin with latest improvements in the compilation model of scarb and starknet-foundry.

Before: 
```
scarb test  508.48s user 79.38s system 174% cpu 5:37.26 total total
```

After
```
scarb test  363.00s user 64.87s system 181% cpu 3:55.85 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/981)
<!-- Reviewable:end -->
