### PR TITLE
Implement eth_get_balance

### DIFF
--- a/crates/contracts/src/kakarot_core/eth_rpc.cairo
+++ b/crates/contracts/src/kakarot_core/eth_rpc.cairo
@@ -8,9 +8,9 @@ use evm::backend::starknet_backend;
 use evm::backend::validation::validate_eth_tx;
 use evm::model::{TransactionResult, Address};
 use evm::{EVMTrait};
+use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 use utils::constants::POW_2_53;
 use utils::eth_transaction::transaction::Transaction;
-use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 
 #[starknet::interface]
 pub trait IEthRPC<T> {
@@ -224,10 +224,10 @@ mod tests {
     use crate::kakarot_core::KakarotCore;
     use crate::kakarot_core::eth_rpc::IEthRPC;
     use crate::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
-    use snforge_std::{start_cheat_chain_id_global, stop_cheat_chain_id_global};
-    use utils::constants::POW_2_53;
     use crate::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
     use evm::test_utils::{sequencer_evm_address, evm_address};
+    use snforge_std::{start_cheat_chain_id_global, stop_cheat_chain_id_global};
+    use utils::constants::POW_2_53;
 
     fn set_up() -> KakarotCore::ContractState {
         // Define the kakarot state to access contract functions

--- a/crates/contracts/src/kakarot_core/eth_rpc.cairo
+++ b/crates/contracts/src/kakarot_core/eth_rpc.cairo
@@ -10,6 +10,7 @@ use evm::model::{TransactionResult, Address};
 use evm::{EVMTrait};
 use utils::constants::POW_2_53;
 use utils::eth_transaction::transaction::Transaction;
+use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
 
 #[starknet::interface]
 pub trait IEthRPC<T> {
@@ -123,7 +124,11 @@ pub impl EthRPC<
     TContractState, impl KakarotState: KakarotCoreState<TContractState>, +Drop<TContractState>
 > of IEthRPC<TContractState> {
     fn eth_get_balance(self: @TContractState, address: EthAddress) -> u256 {
-        panic!("unimplemented")
+        let kakarot_state = KakarotState::get_state();
+        let starknet_address = kakarot_state.get_starknet_address(address);
+        let native_token_address = kakarot_state.get_native_token();
+        let native_token = IERC20CamelDispatcher { contract_address: native_token_address };
+        native_token.balanceOf(starknet_address)
     }
 
     fn eth_get_transaction_count(self: @TContractState, address: EthAddress) -> u64 {
@@ -218,8 +223,11 @@ fn is_view(self: @KakarotCore::ContractState) -> bool {
 mod tests {
     use crate::kakarot_core::KakarotCore;
     use crate::kakarot_core::eth_rpc::IEthRPC;
+    use crate::kakarot_core::interface::IExtendedKakarotCoreDispatcherTrait;
     use snforge_std::{start_cheat_chain_id_global, stop_cheat_chain_id_global};
     use utils::constants::POW_2_53;
+    use crate::test_utils::{setup_contracts_for_testing, fund_account_with_native_token};
+    use evm::test_utils::{sequencer_evm_address, evm_address};
 
     fn set_up() -> KakarotCore::ContractState {
         // Define the kakarot state to access contract functions
@@ -232,6 +240,16 @@ mod tests {
         stop_cheat_chain_id_global();
     }
 
+    #[test]
+    fn test_eth_get_balance() {
+        let (native_token, kakarot_core) = setup_contracts_for_testing();
+        // Uninitialized accounts should return a zero balance
+        assert_eq!(kakarot_core.eth_get_balance(evm_address()), 0);
+        let sequencer_starknet_address = kakarot_core.get_starknet_address(sequencer_evm_address());
+        // Fund an initialized account and make sure the balance is correct
+        fund_account_with_native_token(sequencer_starknet_address, native_token, 0x1);
+        assert_eq!(kakarot_core.eth_get_balance(sequencer_evm_address()), 0x1);
+    }
 
     #[test]
     fn test_eth_chain_id_returns_input_when_less_than_pow_2_53() {

--- a/crates/contracts/src/kakarot_core/interface.cairo
+++ b/crates/contracts/src/kakarot_core/interface.cairo
@@ -74,6 +74,9 @@ pub trait IExtendedKakarotCore<TContractState> {
         ref self: TContractState, evm_address: EthAddress
     ) -> ContractAddress;
 
+    /// Returns the balance of the specified address.
+    fn eth_get_balance(self: @TContractState, address: EthAddress) -> u256;
+
     /// View entrypoint into the EVM
     /// Performs view calls into the blockchain
     /// It cannot modify the state of the chain

--- a/crates/contracts/src/kakarot_core/kakarot.cairo
+++ b/crates/contracts/src/kakarot_core/kakarot.cairo
@@ -211,7 +211,7 @@ pub mod KakarotCore {
         // @return starknet_address The Starknet Account Contract address
         fn get_starknet_address(self: @ContractState, evm_address: EthAddress) -> ContractAddress {
             let registered_starknet_address = self.address_registry(evm_address);
-            if (registered_starknet_address.is_zero()) {
+            if (!registered_starknet_address.is_zero()) {
                 return registered_starknet_address;
             }
 

--- a/crates/evm/src/backend/starknet_backend.cairo
+++ b/crates/evm/src/backend/starknet_backend.cairo
@@ -121,9 +121,7 @@ pub fn fetch_original_storage(account: @Account, key: u256) -> u256 {
 /// The balance of the given address.
 pub fn fetch_balance(self: @Address) -> u256 {
     let kakarot_state = KakarotCore::unsafe_new_contract_state();
-    let native_token_address = kakarot_state.get_native_token();
-    let native_token = IERC20CamelDispatcher { contract_address: native_token_address };
-    native_token.balanceOf(*self.starknet)
+    kakarot_state.eth_get_balance(*self.evm)
 }
 
 

--- a/crates/evm/src/backend/validation.cairo
+++ b/crates/evm/src/backend/validation.cairo
@@ -57,8 +57,8 @@ mod tests {
     use contracts::kakarot_core::KakarotCore;
     use core::num::traits::Bounded;
     use core::ops::SnapshotDeref;
-    use core::starknet::{EthAddress, ContractAddress};
     use core::starknet::storage::{StorageTrait, StoragePathEntry};
+    use core::starknet::{EthAddress, ContractAddress};
     use evm::gas;
     use snforge_std::cheatcodes::storage::{store_felt252};
     use snforge_std::{

--- a/crates/evm/src/backend/validation.cairo
+++ b/crates/evm/src/backend/validation.cairo
@@ -57,7 +57,6 @@ mod tests {
     use contracts::kakarot_core::KakarotCore;
     use core::num::traits::Bounded;
     use core::ops::SnapshotDeref;
-
     use core::starknet::{EthAddress, ContractAddress};
     use core::starknet::storage::StorageTrait;
     use evm::gas;


### PR DESCRIPTION
This PR implements `eth_get_balance` and use it instead of querying the balanceOf function of the `native_token` in the codebase. It also fixes a suspected bug in `get_starknet_address` from `KakarotCore`.

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `eth_get_balance` is not implemented and thus we need to query the `native_token` directly in several parts of the codebase.

Resolves: #941 

## What is the new behavior?

The `eth_get_balance` is now implemented and replicates its `eth_getBalance` counterpart in the EVM.

- The implementation of `eth_get_balance` leverages the `get_starknet_address` function from `KakarotCore` to get the corresponding starknet address from an evm address. Once we have the underlying starknet address, we query the `native_token` balance. The function has also been added to `ExtendedKakarotCore` interface.
- When reading about the description of the `get_starknet_address`, I suspected a bug and from my understanding we should return the registered starknet address only if it is found and thus non-zero, so I think the if condition should be inversed, this is why my PR introduces a bugfix.
- The occurences of direct `native_token` querying have been replaced by `eth_get_balance`, in particular for the `eth_validate_tx` test helper I had to mock additional calls so `account.get_evm_address` returns the expected `account_starknet_address`.
- A simple test has been added to ensure the correct behavior of `eth_get_balance` both for uninitialized and initialized accounts.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/990)
<!-- Reviewable:end -->
