### PR TITLE
fix: mcopy offset overflow

### DIFF
--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -279,7 +279,7 @@ pub impl MemoryOperation of MemoryOperationTrait {
     /// # Specification: https://www.evm.codes/#5e?fork=cancun
     fn exec_mcopy(ref self: VM) -> Result<(), EVMError> {
         let dest_offset = self.stack.pop_saturating_usize()?;
-        let source_offset = self.stack.pop_usize()?;
+        let source_offset = self.stack.pop_saturating_usize()?;
         let size = self.stack.pop_usize()?;
 
         let words_size = bytes_32_words_size(size).into();


### PR DESCRIPTION
Fixes an issue where the mcopy offset could overflow. Instead, saturate the offset at max_usize, knowing that if size is non-zero, it would result in an OOG.