### PR TITLE
fix: saturate jumpi index taken on stack

### DIFF
--- a/crates/contracts/src/kakarot_core/eth_rpc.cairo
+++ b/crates/contracts/src/kakarot_core/eth_rpc.cairo
@@ -134,7 +134,6 @@ pub impl EthRPC<
     fn eth_get_transaction_count(self: @TContractState, address: EthAddress) -> u64 {
         let kakarot_state = KakarotState::get_state();
         let starknet_address = kakarot_state.get_starknet_address(address);
-        println!("starknet_address: {:?}", starknet_address);
         let account = IAccountDispatcher { contract_address: starknet_address };
         let nonce = account.get_nonce();
         nonce

--- a/crates/evm/src/instructions/memory_operations.cairo
+++ b/crates/evm/src/instructions/memory_operations.cairo
@@ -188,7 +188,9 @@ pub impl MemoryOperation of MemoryOperationTrait {
     /// The new pc target has to be a JUMPDEST opcode.
     /// # Specification: https://www.evm.codes/#57?fork=shanghai
     fn exec_jumpi(ref self: VM) -> Result<(), EVMError> {
-        let index = self.stack.pop_usize()?;
+        let index = self
+            .stack
+            .pop_saturating_usize()?; // Saturate because if b is 0, we skip the jump but don't want to fail here.
         let b = self.stack.pop()?;
 
         self.charge_gas(gas::HIGH)?;


### PR DESCRIPTION
Saturates the jumpi index taken on the stack to avoid returning directly if it doesn't fit in a usize. 

If b is zero, it will just increment PC. 
Otherwise, it will be OOB of the bytecode which is capped to 24kb, thus at an invalid jumpdest index.

Closes #971

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-ssj/1002)
<!-- Reviewable:end -->
