### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ file.
 ## Issues and feature requests
 
 You've found a bug in the source code, a mistake in the documentation or maybe
-you'd like a new feature?Take a look at
+you'd like a new feature? Take a look at
 [GitHub Discussions](https://github.com/sayajin-labs/kakarot-ssj/discussions) to
 see if it's already being discussed. You can help us by
 [submitting an issue on GitHub](https://github.com/sayajin-labs/kakarot-ssj/issues).

--- a/docs/general/contract_storage.md
+++ b/docs/general/contract_storage.md
@@ -15,7 +15,7 @@ _Account state associated to an Ethereum address. Source:
 [EVM Illustrated](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 In traditional EVM clients, like Geth, the _world state_ is stored as a _trie_,
-and information about account are stored in the world state trie and can be
+and information about accounts are stored in the world state trie and can be
 retrieved through queries. Each account in the world state trie is associated
 with an account storage trie, which stores all of the information related to the
 account. When Geth updates the storage of a contract by executing the SSTORE


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Description correction:
A space has been added to the sentence and corrected `account` to `accounts`

Please review the changes and let me know if any additional changes are needed.